### PR TITLE
Allow returning failure::Error from handlers

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -10,6 +10,7 @@ use std::error::Error as StdError;
 use cookie;
 use httparse;
 use futures::Canceled;
+use failure;
 use failure::{Fail, Backtrace};
 use http2::Error as Http2Error;
 use http::{header, StatusCode, Error as HttpError};
@@ -92,6 +93,16 @@ impl<T: ResponseError> From<T> for Error {
             None
         };
         Error { cause: Box::new(err), backtrace: backtrace }
+    }
+}
+
+impl<T> ResponseError for failure::Compat<T>
+    where T: fmt::Display + fmt::Debug + Sync + Send + 'static
+{ }
+
+impl From<failure::Error> for Error {
+    fn from(err: failure::Error) -> Error {
+        Error { cause: Box::new(err.compat()), backtrace: None }
     }
 }
 


### PR DESCRIPTION
This was a little bit roundabout, because I couldn't directly implement `ResponseError for failure::Error` -- because `failure::Error` does not implement `failure::Fail` (or `std::Error`, for that matter). Here's the explanation: https://github.com/withoutboats/failure/issues/151

So instead, this implements `From<failure::Error>` for `Error` and `ResponseError` for `failure::Compat<T>`. The `From` implementation calls `error.compat()` to get the `failure::Compat` value which *does* implement `Fail`.

My main question is: is the `from` implementation ideal? I'm not sure if I should have done something with `backtrace`.