### PR TITLE
Started pinning Actix commit in Cargo.toml between releases.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ tokio-openssl = { version="0.2", optional = true }
 [dependencies.actix]
 #version = "^0.4.6"
 git = "https://github.com/actix/actix.git"
+rev = "136fd07"
 
 [dev-dependencies]
 env_logger = "0.5"


### PR DESCRIPTION
Currently, `actix-web` pins the Actix version it uses in released versions, this works great and ensures that `actix-web` can make use of the `System` of an existing `actix`-backed application (since the `actix` dependency of `actix-web` and the direct `actix` dependency of the application need to be the same version).

Between releases, the `actix-web` create is kept compatible with the `master` branch of `actix`.

In the rare case that a user of `actix` and `actix-web` in this configuration depends on a more recent commit of `actix` that is yet unreleased, it is impossible to guarantee that `actix-web`'s `actix` dependency and the direct `actix` dependency are the same (and therefore can use the same `System`). This is because the `actix-web` dependency looks directly at the `master` branch rather than a specific pinned commit (which could be matched by the direct dependency to `actix` to ensure the same version is used) and could change.

This PR changes the `Cargo.toml` file to pin the `actix` commit.