### PR TITLE
Wait for spawned thread

### DIFF
--- a/guide/src/qs_2.md
+++ b/guide/src/qs_2.md
@@ -79,13 +79,14 @@ fn index(req: HttpRequest) -> &'static str {
 }
 
 fn main() {
-# thread::spawn(|| {
+# let child = thread::spawn(|| {
     HttpServer::new(
         || Application::new()
             .resource("/", |r| r.f(index)))
         .bind("127.0.0.1:8088").expect("Can not bind to 127.0.0.1:8088")
         .run();
-# });
+  });
+# child.join().expect("failed to join server thread");
 }
 ```
 

--- a/guide/src/qs_2.md
+++ b/guide/src/qs_2.md
@@ -71,7 +71,7 @@ Here is full source of main.rs file:
 
 ```rust
 # use std::thread;
-# extern crate actix_web;
+extern crate actix_web;
 use actix_web::*;
 
 fn index(req: HttpRequest) -> &'static str {
@@ -79,14 +79,16 @@ fn index(req: HttpRequest) -> &'static str {
 }
 
 fn main() {
-# let child = thread::spawn(|| {
+#  // In the doctest suite we can't run blocking code - deliberately leak a thread
+#  // If copying this example in show-all mode make sure you skip the thread spawn
+#  // call.
+#  thread::spawn(|| {
     HttpServer::new(
         || Application::new()
             .resource("/", |r| r.f(index)))
         .bind("127.0.0.1:8088").expect("Can not bind to 127.0.0.1:8088")
         .run();
-  });
-# child.join().expect("failed to join server thread");
+#  });
 }
 ```
 


### PR DESCRIPTION
A spawned thread doesn't block the main thread exiting unless explicitly joined.
The demo as written in the guide simply exits immediately at the moment.