### PR TITLE
fix session mut borrow lifetime

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 0.4.1 (2018-03-xx)
+
+* Fix Session mutable borrow lifetime
+
+
 ## 0.4.0 (2018-02-28)
 
 * Actix 0.5 compatibility

--- a/src/middleware/session.rs
+++ b/src/middleware/session.rs
@@ -86,7 +86,7 @@ impl<'a> Session<'a> {
     }
 
     /// Set a `value` from the session.
-    pub fn set<T: Serialize>(&'a mut self, key: &str, value: T) -> Result<()> {
+    pub fn set<T: Serialize>(&mut self, key: &str, value: T) -> Result<()> {
         self.0.set(key, serde_json::to_string(&value)?);
         Ok(())
     }


### PR DESCRIPTION
This fixes a lifetime issue where it is impossible to call `session.set(...)` more than once. e.g. calling
```rust
session.set("user_id", 1)?;
session.set("token", "1234")?;
```
throws an error 
```
error[E0499]: cannot borrow `session` as mutable more than once at a time
```
 I believe the problem is that the extra `'a` in the signature ties the lifetime of the borrow to the lifetime of the `Session` object itself.