### PR TITLE
move reuse_address before bind

### DIFF
--- a/src/server/srv.rs
+++ b/src/server/srv.rs
@@ -697,7 +697,7 @@ fn create_tcp_listener(addr: net::SocketAddr, backlog: i32) -> io::Result<net::T
         net::SocketAddr::V4(_) => TcpBuilder::new_v4()?,
         net::SocketAddr::V6(_) => TcpBuilder::new_v6()?,
     };
-    builder.bind(addr)?;
     builder.reuse_address(true)?;
+    builder.bind(addr)?;
     Ok(builder.listen(backlog)?)
 }


### PR DESCRIPTION
reuse_address doesn't do anything if the socket is already bound.