### PR TITLE
Update qs_14.md

### DIFF
--- a/guide/src/qs_14.md
+++ b/guide/src/qs_14.md
@@ -36,7 +36,7 @@ We can send `CreateUser` message to `DbExecutor` actor, and as result we get
 
 ```rust,ignore
 impl Handler<CreateUser> for DbExecutor {
-    type Result = Result<User, Error>
+    type Result = Result<User, Error>;
 
     fn handle(&mut self, msg: CreateUser, _: &mut Self::Context) -> Self::Result
     {


### PR DESCRIPTION
fix missing semicolon

```
error: expected one of `!`, `+`, `::`, or `;`, found `fn`
  --> src/main.rs:29:5
   |
27 |     type Result = Result<User, Error>
   |                                      - expected one of `!`, `+`, `::`, or `;` here
28 | 
29 |     fn handle(&mut self, msg: CreateUser, _: &mut Self::Context) -> Self::Result
   |     ^^ unexpected token
```