### PR TITLE
Impl From<usize> and From<Option<usize>> for KeepAlive

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -6,6 +6,7 @@ use std::{env, fs};
 
 #[cfg(unix)]
 fn main() {
+    println!("cargo:rerun-if-env-changed=USE_SKEPTIC");
     let f = env::var("OUT_DIR").unwrap() + "/skeptic-tests.rs";
     if env::var("USE_SKEPTIC").is_ok() {
         let _ = fs::remove_file(f);

--- a/guide/src/qs_3_5.md
+++ b/guide/src/qs_3_5.md
@@ -134,9 +134,9 @@ for full example.
 Actix can wait for requests on a keep-alive connection. *Keep alive*
 connection behavior is defined by server settings.
 
- * `KeepAlive::Timeout(75)` - enable 75 sec *keep alive* timer according
+ * `75` or `Some(75)` or `KeepAlive::Timeout(75)` - enable 75 sec *keep alive* timer according
     request and response settings.
- * `KeepAlive::Disabled` - disable *keep alive*.
+ * `None` or `KeepAlive::Disabled` - disable *keep alive*.
  * `KeepAlive::Tcp(75)` - Use `SO_KEEPALIVE` socket option.
 
 ```rust
@@ -148,7 +148,17 @@ fn main() {
     HttpServer::new(||
         Application::new()
             .resource("/", |r| r.h(httpcodes::HttpOk)))
+        .keep_alive(75); // <- Set keep-alive to 75 seconds
+
+    HttpServer::new(||
+        Application::new()
+            .resource("/", |r| r.h(httpcodes::HttpOk)))
         .keep_alive(server::KeepAlive::Tcp(75)); // <- Use `SO_KEEPALIVE` socket option.
+
+    HttpServer::new(||
+        Application::new()
+            .resource("/", |r| r.h(httpcodes::HttpOk)))
+        .keep_alive(None); // <- Disable keep-alive
 }
 ```
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -44,6 +44,22 @@ pub enum KeepAlive {
     Disabled,
 }
 
+impl From<usize> for KeepAlive {
+    fn from(keepalive: usize) -> Self {
+        KeepAlive::Timeout(keepalive)
+    }
+}
+
+impl From<Option<usize>> for KeepAlive {
+    fn from(keepalive: Option<usize>) -> Self {
+        if let Some(keepalive) = keepalive {
+            KeepAlive::Timeout(keepalive)
+        } else {
+            KeepAlive::Disabled
+        }
+    }
+}
+
 /// Pause accepting incoming connections
 ///
 /// If socket contains some pending connection, they might be dropped.

--- a/src/server/srv.rs
+++ b/src/server/srv.rs
@@ -124,8 +124,8 @@ impl<H> HttpServer<H> where H: IntoHttpHandler + 'static
     /// Set server keep-alive setting.
     ///
     /// By default keep alive is set to a `Os`.
-    pub fn keep_alive(mut self, val: KeepAlive) -> Self {
-        self.keep_alive = val;
+    pub fn keep_alive<T: Into<KeepAlive>>(mut self, val: T) -> Self {
+        self.keep_alive = val.into();
         self
     }
 


### PR DESCRIPTION
The second commit ensures skeptic tests get generated when invoking `USE_SKEPTIC=1 cargo test` after `cargo test`.