### PR TITLE
Public, signed and private cookies

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,8 @@
 
 * Fix logger request duration calculation #152
 
+* Add `signed` and `private` `CookieSessionBackend`s
+
 
 ## 0.4.10 (2018-03-20)
 

--- a/examples/basics/src/main.rs
+++ b/examples/basics/src/main.rs
@@ -105,7 +105,7 @@ fn main() {
             .middleware(middleware::Logger::default())
             // cookie session middleware
             .middleware(middleware::SessionStorage::new(
-                middleware::CookieSessionBackend::new(&[0; 32]).secure(false)
+                middleware::CookieSessionBackend::signed(&[0; 32]).secure(false)
             ))
             // register favicon
             .resource("/favicon.ico", |r| r.f(favicon))

--- a/guide/src/qs_10.md
+++ b/guide/src/qs_10.md
@@ -163,14 +163,17 @@ used with different backend types to store session data in different backends.
 > can be added.
 
 [**CookieSessionBackend**](../actix_web/middleware/struct.CookieSessionBackend.html)
-uses signed cookies as session storage. `CookieSessionBackend` creates sessions which
+uses cookies as session storage. `CookieSessionBackend` creates sessions which
 are limited to storing fewer than 4000 bytes of data, as the payload must fit into a
 single cookie. An internal server error is generated if a session contains more than 4000 bytes.
 
-You need to pass a random value to the constructor of `CookieSessionBackend`.
-This is a private key for cookie session. When this value is changed, all session data is lost.
+A cookie may have a security policy of *signed* or *private*. Each has a respective `CookieSessionBackend` constructor.
 
-> **Note**: anything you write into the session is visible by the user, but it is not modifiable.
+A *signed* cookie may be viewed but not modified by the client. A *private* cookie may neither be viewed nor modified by the client.
+
+The constructors take a key as an argument. This is the private key for cookie session - when this value is changed, all session data is lost.
+
+
 
 In general, you create a
 `SessionStorage` middleware and initialize it with specific backend implementation,
@@ -203,7 +206,7 @@ fn main() {
     server::new(
         || App::new()
             .middleware(SessionStorage::new(          // <- create session middleware
-                CookieSessionBackend::new(&[0; 32]) // <- create cookie session backend
+                CookieSessionBackend::signed(&[0; 32]) // <- create signed cookie session backend
                     .secure(false)
             )))
         .bind("127.0.0.1:59880").unwrap()

--- a/src/middleware/session.rs
+++ b/src/middleware/session.rs
@@ -381,15 +381,6 @@ pub struct CookieSessionBackend(Rc<CookieSessionInner>);
 
 impl CookieSessionBackend {
 
-    /// Construct new signed `CookieSessionBackend` instance.
-    ///
-    /// Panics if key length is less than 32 bytes.
-    #[deprecated(since="0.5.0", note="use `signed` or `private` instead")]
-    pub fn new(key: &[u8]) -> CookieSessionBackend {
-        CookieSessionBackend(
-            Rc::new(CookieSessionInner::new(key, CookieSecurity::Signed)))
-    }
-
     /// Construct new *signed* `CookieSessionBackend` instance.
     ///
     /// Panics if key length is less than 32 bytes.


### PR DESCRIPTION
This is one way to allow the use of public, signed and private cookies with `CookieSessionBackend`.

closes #159 