### PR TITLE
Fix route in App::resource example

### DIFF
--- a/src/application.rs
+++ b/src/application.rs
@@ -314,7 +314,7 @@ where
     ///
     /// fn main() {
     ///     let app = App::new()
-    ///         .resource("/test", |r| {
+    ///         .resource("/users/{userid}/{friend}", |r| {
     ///              r.get().f(|_| HttpResponse::Ok());
     ///              r.head().f(|_| HttpResponse::MethodNotAllowed());
     ///         });


### PR DESCRIPTION
Hello, I guess the route should be updated.
Also, it is said [here](https://docs.rs/actix-web/0.5.2/actix_web/struct.HttpRequest.html#method.match_info) `:param` syntax should be used.
Is `HttpRequest::match_info` documentation outdated or I am missing on that?