### PR TITLE
Let CSRF's `allowed_origin()` be specified as a type supporting `Into<String>`

### DIFF
--- a/src/middleware/csrf.rs
+++ b/src/middleware/csrf.rs
@@ -150,8 +150,8 @@ impl CsrfFilter {
 
     /// Add an origin that is allowed to make requests. Will be verified
     /// against the `Origin` request header.
-    pub fn allowed_origin(mut self, origin: &str) -> CsrfFilter {
-        self.origins.insert(origin.to_owned());
+    pub fn allowed_origin<T: Into<String>>(mut self, origin: T) -> CsrfFilter {
+        self.origins.insert(origin.into());
         self
     }
 


### PR DESCRIPTION
A very minor addition: I'm using this middleware on specific resources,
and given a non-static string, I often have to `clone()` already to get
a string into a closure. Take this code for example:

``` rust
let server = actix_web::server::new(move || {
    let csrf_origin_graphql = csrf_origin.clone();

    ...

    .resource("/graphql", move |r| {
	r.middleware(
	    csrf::CsrfFilter::new().allowed_origin(csrf_origin_graphql.as_str()),
	);

	r.method(Method::POST).a(graphql::handlers::graphql_post);
    })
```

Letting `allowed_origin()` take an `Into<String>` instead of `&str` would
prevent a second `clone()` in the code above, and also make the code a little
nicer to read (you eliminate the `.as_str()`). This is a pattern that
seems to be common throughout actix-web already anyway, so it should also be
fine to have here.