### PR TITLE
Websocket close reason

### DIFF
--- a/src/ws/context.rs
+++ b/src/ws/context.rs
@@ -15,7 +15,7 @@ use error::{Error, ErrorInternalServerError};
 use httprequest::HttpRequest;
 
 use ws::frame::Frame;
-use ws::proto::{CloseCode, OpCode};
+use ws::proto::{CloseReason, OpCode};
 
 /// Execution context for `WebSockets` actors
 pub struct WebsocketContext<A, S = ()>
@@ -177,8 +177,8 @@ where
 
     /// Send close frame
     #[inline]
-    pub fn close(&mut self, code: CloseCode, reason: &str) {
-        self.write(Frame::close(code, reason, false));
+    pub fn close(&mut self, reason: Option<CloseReason>) {
+        self.write(Frame::close(reason, false));
     }
 
     /// Returns drain future

--- a/src/ws/frame.rs
+++ b/src/ws/frame.rs
@@ -11,7 +11,7 @@ use payload::PayloadHelper;
 
 use ws::ProtocolError;
 use ws::mask::apply_mask;
-use ws::proto::{CloseCode, OpCode};
+use ws::proto::{CloseCode, CloseReason, OpCode};
 
 /// A struct representing a `WebSocket` frame.
 #[derive(Debug)]
@@ -29,24 +29,22 @@ impl Frame {
 
     /// Create a new Close control frame.
     #[inline]
-    pub fn close(code: CloseCode, reason: &str, genmask: bool) -> Binary {
-        let raw: [u8; 2] = unsafe {
-            let u: u16 = code.into();
-            mem::transmute(u.to_be())
-        };
+    pub fn close(reason: Option<CloseReason>, genmask: bool) -> Binary {
+	    let payload:Vec<u8> = match reason {
+		    None => Vec::new(),
+		    Some(reason) => {
+			    let mut code_bytes = [0; 2];
+			    NetworkEndian::write_u16(&mut code_bytes, reason.code.into());
 
-        let payload = if let CloseCode::Empty = code {
-            Vec::new()
-        } else {
-            Vec::from_iter(
-                raw[..]
-                    .iter()
-                    .chain(reason.as_bytes().iter())
-                    .cloned(),
-            )
-        };
+			    let mut payload = Vec::from(&code_bytes[..]);
+			    if let Some(description) = reason.description{
+				    payload.extend(description.as_bytes());
+			    }
+			    payload
+		    }
+	    };
 
-        Frame::message(payload, OpCode::Close, true, genmask)
+	    Frame::message(payload, OpCode::Close, true, genmask)
     }
 
     #[cfg_attr(feature = "cargo-clippy", allow(type_complexity))]
@@ -279,6 +277,22 @@ impl Frame {
             opcode,
             payload: data.into(),
         })))
+    }
+
+    /// Parse the payload of a close frame.
+    pub fn parse_close_payload(payload: &Binary) -> Option<CloseReason> {
+        if payload.len() >= 2 {
+            let raw_code = NetworkEndian::read_uint(payload.as_ref(), 2) as u16;
+            let code = CloseCode::from(raw_code);
+            let description = if payload.len() > 2 {
+                Some(String::from_utf8_lossy(&payload.as_ref()[2..]).into())
+            } else {
+                None
+            };
+            Some(CloseReason { code, description })
+        } else {
+            None
+        }
     }
 
     /// Generate binary representation
@@ -516,12 +530,19 @@ mod tests {
         assert_eq!(frame, v.into());
     }
 
-    #[test]
-    fn test_close_frame() {
-        let frame = Frame::close(CloseCode::Normal, "data", false);
+	#[test]
+	fn test_close_frame() {
+		let reason = (CloseCode::Normal, "data");
+		let frame = Frame::close(Some(reason.into()), false);
 
-        let mut v = vec![136u8, 6u8, 3u8, 232u8];
-        v.extend(b"data");
-        assert_eq!(frame, v.into());
-    }
+		let mut v = vec![136u8, 6u8, 3u8, 232u8];
+		v.extend(b"data");
+		assert_eq!(frame, v.into());
+	}
+
+	#[test]
+	fn test_empty_close_frame() {
+		let frame = Frame::close(None, false);
+		assert_eq!(frame, vec![0x88, 0x00].into());
+	}
 }

--- a/src/ws/frame.rs
+++ b/src/ws/frame.rs
@@ -29,21 +29,21 @@ impl Frame {
     /// Create a new Close control frame.
     #[inline]
     pub fn close(reason: Option<CloseReason>, genmask: bool) -> Binary {
-	    let payload = match reason {
-		    None => Vec::new(),
-		    Some(reason) => {
-			    let mut code_bytes = [0; 2];
-			    NetworkEndian::write_u16(&mut code_bytes, reason.code.into());
+        let payload = match reason {
+            None => Vec::new(),
+            Some(reason) => {
+                let mut code_bytes = [0; 2];
+                NetworkEndian::write_u16(&mut code_bytes, reason.code.into());
 
-			    let mut payload = Vec::from(&code_bytes[..]);
-			    if let Some(description) = reason.description{
-				    payload.extend(description.as_bytes());
-			    }
-			    payload
-		    }
-	    };
+                let mut payload = Vec::from(&code_bytes[..]);
+                if let Some(description) = reason.description{
+                    payload.extend(description.as_bytes());
+                }
+                payload
+            }
+        };
 
-	    Frame::message(payload, OpCode::Close, true, genmask)
+        Frame::message(payload, OpCode::Close, true, genmask)
     }
 
     #[cfg_attr(feature = "cargo-clippy", allow(type_complexity))]
@@ -529,19 +529,19 @@ mod tests {
         assert_eq!(frame, v.into());
     }
 
-	#[test]
-	fn test_close_frame() {
-		let reason = (CloseCode::Normal, "data");
-		let frame = Frame::close(Some(reason.into()), false);
+    #[test]
+    fn test_close_frame() {
+        let reason = (CloseCode::Normal, "data");
+        let frame = Frame::close(Some(reason.into()), false);
 
-		let mut v = vec![136u8, 6u8, 3u8, 232u8];
-		v.extend(b"data");
-		assert_eq!(frame, v.into());
-	}
+        let mut v = vec![136u8, 6u8, 3u8, 232u8];
+        v.extend(b"data");
+        assert_eq!(frame, v.into());
+    }
 
-	#[test]
-	fn test_empty_close_frame() {
-		let frame = Frame::close(None, false);
-		assert_eq!(frame, vec![0x88, 0x00].into());
-	}
+    #[test]
+    fn test_empty_close_frame() {
+        let frame = Frame::close(None, false);
+        assert_eq!(frame, vec![0x88, 0x00].into());
+    }
 }

--- a/src/ws/frame.rs
+++ b/src/ws/frame.rs
@@ -2,7 +2,6 @@ use byteorder::{BigEndian, ByteOrder, NetworkEndian};
 use bytes::{BufMut, Bytes, BytesMut};
 use futures::{Async, Poll, Stream};
 use rand;
-use std::iter::FromIterator;
 use std::{fmt, mem, ptr};
 
 use body::Binary;
@@ -30,7 +29,7 @@ impl Frame {
     /// Create a new Close control frame.
     #[inline]
     pub fn close(reason: Option<CloseReason>, genmask: bool) -> Binary {
-	    let payload:Vec<u8> = match reason {
+	    let payload = match reason {
 		    None => Vec::new(),
 		    Some(reason) => {
 			    let mut code_bytes = [0; 2];

--- a/src/ws/mod.rs
+++ b/src/ws/mod.rs
@@ -43,7 +43,6 @@
 //! #      .finish();
 //! # }
 //! ```
-use byteorder::{ByteOrder, NetworkEndian};
 use bytes::Bytes;
 use futures::{Async, Poll, Stream};
 use http::{header, Method, StatusCode};

--- a/src/ws/proto.rs
+++ b/src/ws/proto.rs
@@ -181,26 +181,26 @@ impl From<u16> for CloseCode {
 
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub struct CloseReason {
-	pub code: CloseCode,
-	pub description: Option<String>,
+    pub code: CloseCode,
+    pub description: Option<String>,
 }
 
 impl From<CloseCode> for CloseReason {
-	fn from(code: CloseCode) -> Self {
-		CloseReason {
-			code,
-			description: None,
-		}
-	}
+    fn from(code: CloseCode) -> Self {
+        CloseReason {
+            code,
+            description: None,
+        }
+    }
 }
 
 impl <T: Into<String>> From<(CloseCode, T)> for CloseReason {
-	fn from(info: (CloseCode, T)) -> Self {
-		CloseReason{
-			code: info.0,
-			description: Some(info.1.into())
-		}
-	}
+    fn from(info: (CloseCode, T)) -> Self {
+        CloseReason{
+            code: info.0,
+            description: Some(info.1.into())
+        }
+    }
 }
 
 static WS_GUID: &'static str = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";

--- a/src/ws/proto.rs
+++ b/src/ws/proto.rs
@@ -179,7 +179,7 @@ impl From<u16> for CloseCode {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub struct CloseReason {
 	pub code: CloseCode,
 	pub description: Option<String>,

--- a/tests/test_ws.rs
+++ b/tests/test_ws.rs
@@ -27,7 +27,7 @@ impl StreamHandler<ws::Message, ws::ProtocolError> for Ws {
             ws::Message::Ping(msg) => ctx.pong(&msg),
             ws::Message::Text(text) => ctx.text(text),
             ws::Message::Binary(bin) => ctx.binary(bin),
-            ws::Message::Close(reason) => ctx.close(reason, ""),
+            ws::Message::Close(reason) => ctx.close(reason),
             _ => (),
         }
     }
@@ -55,9 +55,9 @@ fn test_simple() {
     let (item, reader) = srv.execute(reader.into_future()).unwrap();
     assert_eq!(item, Some(ws::Message::Pong("ping".to_owned())));
 
-    writer.close(ws::CloseCode::Normal, "");
+    writer.close(Some(ws::CloseCode::Normal.into()));
     let (item, _) = srv.execute(reader.into_future()).unwrap();
-    assert_eq!(item, Some(ws::Message::Close(ws::CloseCode::Normal)));
+    assert_eq!(item, Some(ws::Message::Close(Some(ws::CloseCode::Normal.into()))));
 }
 
 #[test]
@@ -65,9 +65,9 @@ fn test_empty_close_code() {
     let mut srv = test::TestServer::new(|app| app.handler(|req| ws::start(req, Ws)));
     let (reader, mut writer) = srv.ws().unwrap();
 
-    writer.close(ws::CloseCode::Empty, "");
+    writer.close(None);
     let (item, _) = srv.execute(reader.into_future()).unwrap();
-    assert_eq!(item, Some(ws::Message::Close(ws::CloseCode::Status)));
+    assert_eq!(item, Some(ws::Message::Close(None)));
 }
 
 #[test]
@@ -147,7 +147,7 @@ impl StreamHandler<ws::Message, ws::ProtocolError> for Ws2 {
             ws::Message::Ping(msg) => ctx.pong(&msg),
             ws::Message::Text(text) => ctx.text(text),
             ws::Message::Binary(bin) => ctx.binary(bin),
-            ws::Message::Close(reason) => ctx.close(reason, ""),
+            ws::Message::Close(reason) => ctx.close(reason),
             _ => (),
         }
     }

--- a/tests/test_ws.rs
+++ b/tests/test_ws.rs
@@ -71,6 +71,17 @@ fn test_empty_close_code() {
 }
 
 #[test]
+fn test_close_description() {
+    let mut srv = test::TestServer::new(|app| app.handler(|req| ws::start(req, Ws)));
+    let (reader, mut writer) = srv.ws().unwrap();
+
+    let close_reason:ws::CloseReason = (ws::CloseCode::Normal, "close description").into();
+    writer.close(Some(close_reason.clone()));
+    let (item, _) = srv.execute(reader.into_future()).unwrap();
+    assert_eq!(item, Some(ws::Message::Close(Some(close_reason))));
+}
+
+#[test]
 fn test_large_text() {
     let data = rand::thread_rng()
         .gen_ascii_chars()


### PR DESCRIPTION
Closes #193 

Fixes:
- Fix a panic in the websocket client if it receives a close frame without a close code (similar to #191)

Breaking Changes:
- Remove `CloseCode::Empty` and `CloseCode::Status`, which are replaced with `Option::None`
- Add `CloseReason` which includes both the `CloseCode` and description. Since the description is not sent unless a `CloseCode` is given, this allows the description to not be specified when no `CloseCode` is given
- When you receive a Close frame, the description is now parsed

I wanted to make the interface for `close()` methods look like
```rust
pub fn close<T: Into<CloseReason>>(&mut self, reason: Option<T>)
```
then you could use it like this...
```rust
ws.close(None); //close with no status
ws.close(Some(CloseCode::Normal)); //close with only status code
ws.close(Some((CloseCode::Normal, "some description"))); //close with both
```

but I couldn't find a nice way to allow `None` without declaring `T`. If you know of a good alternative, I can modify this PR.