### PR TITLE
Add WsWriter trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,6 +175,7 @@ pub use httprequest::HttpRequest;
 pub use httpresponse::HttpResponse;
 pub use json::Json;
 pub use scope::Scope;
+pub use ws::WsWriter;
 
 #[cfg(feature = "openssl")]
 pub(crate) const HAS_OPENSSL: bool = true;

--- a/src/ws/context.rs
+++ b/src/ws/context.rs
@@ -13,6 +13,7 @@ use context::{ActorHttpContext, Drain, Frame as ContextFrame};
 use error::{Error, ErrorInternalServerError};
 use httprequest::HttpRequest;
 
+use ws::WsWriter;
 use ws::frame::Frame;
 use ws::proto::{CloseReason, OpCode};
 
@@ -140,46 +141,6 @@ where
         &mut self.request
     }
 
-    /// Send text frame
-    #[inline]
-    pub fn text<T: Into<Binary>>(&mut self, text: T) {
-        self.write(Frame::message(text.into(), OpCode::Text, true, false));
-    }
-
-    /// Send binary frame
-    #[inline]
-    pub fn binary<B: Into<Binary>>(&mut self, data: B) {
-        self.write(Frame::message(data, OpCode::Binary, true, false));
-    }
-
-    /// Send ping frame
-    #[inline]
-    pub fn ping(&mut self, message: &str) {
-        self.write(Frame::message(
-            Vec::from(message),
-            OpCode::Ping,
-            true,
-            false,
-        ));
-    }
-
-    /// Send pong frame
-    #[inline]
-    pub fn pong(&mut self, message: &str) {
-        self.write(Frame::message(
-            Vec::from(message),
-            OpCode::Pong,
-            true,
-            false,
-        ));
-    }
-
-    /// Send close frame
-    #[inline]
-    pub fn close(&mut self, reason: Option<CloseReason>) {
-        self.write(Frame::close(reason, false));
-    }
-
     /// Returns drain future
     pub fn drain(&mut self) -> Drain<A> {
         let (tx, rx) = oneshot::channel();
@@ -210,6 +171,52 @@ where
     /// SpawnHandle is the handle returned by `AsyncContext::spawn()` method.
     pub fn handle(&self) -> SpawnHandle {
         self.inner.curr_handle()
+    }
+}
+
+impl<A, S> WsWriter for WebsocketContext<A, S>
+where
+    A: Actor<Context = Self>,
+    S: 'static,
+{
+    /// Send text frame
+    #[inline]
+    fn text<T: Into<Binary>>(&mut self, text: T) {
+        self.write(Frame::message(text.into(), OpCode::Text, true, false));
+    }
+
+    /// Send binary frame
+    #[inline]
+    fn binary<B: Into<Binary>>(&mut self, data: B) {
+        self.write(Frame::message(data, OpCode::Binary, true, false));
+    }
+
+    /// Send ping frame
+    #[inline]
+    fn ping(&mut self, message: &str) {
+        self.write(Frame::message(
+            Vec::from(message),
+            OpCode::Ping,
+            true,
+            false,
+        ));
+    }
+
+    /// Send pong frame
+    #[inline]
+    fn pong(&mut self, message: &str) {
+        self.write(Frame::message(
+            Vec::from(message),
+            OpCode::Pong,
+            true,
+            false,
+        ));
+    }
+
+    /// Send close frame
+    #[inline]
+    fn close(&mut self, reason: Option<CloseReason>) {
+        self.write(Frame::close(reason, false));
     }
 }
 

--- a/src/ws/mod.rs
+++ b/src/ws/mod.rs
@@ -340,6 +340,20 @@ where
     }
 }
 
+/// Common writing methods for a websocket.
+pub trait WsWriter {
+    /// Send a text
+    fn text<T: Into<Binary>>(&mut self, text: T);
+    /// Send a binary
+    fn binary<B: Into<Binary>>(&mut self, data: B);
+    /// Send a ping message
+    fn ping(&mut self, message: &str);
+    /// Send a pong message
+    fn pong(&mut self, message: &str);
+    /// Close the connection
+    fn close(&mut self, reason: Option<CloseReason>);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
`WsWriter` trait is a common interface for writing to a websocket and
it's implemented for both: `WebScoketContext` and `ClientWriter`.

`WsWriter` useful for creating generic implementations of `StreamHandler` which could handle incoming (server) and outgoing (client) sides. If you know how to create universal `Actor` for websockets compatible with two directions in another way then tell me, please.