### PR TITLE
let Path::from_request() fail with ErrorNotFound

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 * Fix connector's default `keep-alive` and `lifetime` settings #212
 
+* Send `ErrorNotFound` instead of `ErrorBadRequest` when path extractor fails #214
+
 ## 0.6.0 (2018-05-08)
 
 * Add route scopes #202

--- a/src/extractor.rs
+++ b/src/extractor.rs
@@ -11,7 +11,7 @@ use serde::de::{self, DeserializeOwned};
 use serde_urlencoded;
 
 use de::PathDeserializer;
-use error::{Error, ErrorBadRequest};
+use error::{Error, ErrorNotFound, ErrorBadRequest};
 use handler::{AsyncResult, FromRequest};
 use httpmessage::{HttpMessage, MessageBody, UrlEncoded};
 use httprequest::HttpRequest;
@@ -108,7 +108,7 @@ where
     fn from_request(req: &HttpRequest<S>, _: &Self::Config) -> Self::Result {
         let req = req.clone();
         de::Deserialize::deserialize(PathDeserializer::new(&req))
-            .map_err(|e| e.into())
+            .map_err(ErrorNotFound)
             .map(|inner| Path { inner })
     }
 }


### PR DESCRIPTION
Suggestion: When the Path extractor fails it should result in a 404 error rather than 400 (which seems to be what's happening, currently).

I am not sure if this is at all the appropriate way to implement it.