### PR TITLE
Include mention of http client in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Actix web is a simple, pragmatic and extremely fast web framework for Rust.
   [CORS](https://actix.rs/actix-web/actix_web/middleware/cors/index.html),
   [CSRF](https://actix.rs/actix-web/actix_web/middleware/csrf/index.html))
 * Built on top of [Actix actor framework](https://github.com/actix/actix)
+* Includes an asynchronous [HTTP client](https://github.com/actix/actix-web/blob/master/src/client/mod.rs)
 
 ## Documentation & community resources
 


### PR DESCRIPTION
The http client was mentioned in one of the release notes but is not discoverable from the readme. For now, just link to the mod.rs which contains a brief usage example in comments. 