### PR TITLE
Support returning addresses plus scheme from the server

### DIFF
--- a/src/server/srv.rs
+++ b/src/server/srv.rs
@@ -211,6 +211,16 @@ where
         self.sockets.iter().map(|s| s.addr).collect()
     }
 
+    /// Get addresses of bound sockets and the scheme for it.
+    ///
+    /// This is useful when the server is bound from different sources
+    /// with some sockets listening on http and some listening on https
+    /// and the user should be presented with an enumeration of which
+    /// socket requires which protocol.
+    pub fn addrs_with_scheme(&self) -> Vec<(net::SocketAddr, &str)> {
+        self.sockets.iter().map(|s| (s.addr, s.tp.scheme())).collect()
+    }
+
     /// Use listener for accepting incoming connection requests
     ///
     /// HttpServer does not change any configuration for TcpListener,

--- a/src/server/worker.rs
+++ b/src/server/worker.rs
@@ -239,4 +239,14 @@ impl StreamHandlerType {
             }
         }
     }
+
+    pub(crate) fn scheme(&self) -> &'static str {
+        match *self {
+            StreamHandlerType::Normal => "http",
+            #[cfg(feature = "tls")]
+            StreamHandlerType::Tls(ref acceptor) => "https",
+            #[cfg(feature = "alpn")]
+            StreamHandlerType::Alpn(ref acceptor) => "https",
+        }
+    }
 }


### PR DESCRIPTION
This is necessary if sockets are bound from different environment data and one wants to print things like `navigate to http://127.0.0.1:3000 vs https://127.0.0.1:3443` etc.

This assumes that #224 was merged. It's included in this.