### PR TITLE
Fix TestServer::post

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -217,7 +217,7 @@ impl TestServer {
 
     /// Create `POST` request
     pub fn post(&self) -> ClientRequestBuilder {
-        ClientRequest::get(self.url("/").as_str())
+        ClientRequest::post(self.url("/").as_str())
     }
 
     /// Create `HEAD` request


### PR DESCRIPTION
Hello,

There is a typo in `TestServer::post`. 
It actually sends a `GET` request.

This PR fixes the problem. I have tested it on my test suite.
