### PR TITLE
Fix some ResourceHandler docs

### DIFF
--- a/src/resource.rs
+++ b/src/resource.rs
@@ -128,6 +128,14 @@ impl<S: 'static> ResourceHandler<S> {
 
     /// Register a new route and add method check to route.
     ///
+    /// ```rust
+    /// # extern crate actix_web;
+    /// use actix_web::*;
+    /// fn index(req: HttpRequest) -> HttpResponse { unimplemented!() }
+    ///
+    /// App::new().resource("/", |r| r.method(http::Method::GET).f(index));
+    /// ```
+    ///
     /// This is shortcut for:
     ///
     /// ```rust
@@ -143,6 +151,14 @@ impl<S: 'static> ResourceHandler<S> {
 
     /// Register a new route and add handler object.
     ///
+    /// ```rust
+    /// # extern crate actix_web;
+    /// use actix_web::*;
+    /// fn handler(req: HttpRequest) -> HttpResponse { unimplemented!() }
+    ///
+    /// App::new().resource("/", |r| r.h(handler));
+    /// ```
+    ///
     /// This is shortcut for:
     ///
     /// ```rust
@@ -157,6 +173,14 @@ impl<S: 'static> ResourceHandler<S> {
     }
 
     /// Register a new route and add handler function.
+    ///
+    /// ```rust
+    /// # extern crate actix_web;
+    /// use actix_web::*;
+    /// fn index(req: HttpRequest) -> HttpResponse { unimplemented!() }
+    ///
+    /// App::new().resource("/", |r| r.f(index));
+    /// ```
     ///
     /// This is shortcut for:
     ///
@@ -177,6 +201,14 @@ impl<S: 'static> ResourceHandler<S> {
 
     /// Register a new route and add handler.
     ///
+    /// ```rust
+    /// # extern crate actix_web;
+    /// use actix_web::*;
+    /// fn index(req: HttpRequest) -> HttpResponse { unimplemented!() }
+    ///
+    /// App::new().resource("/", |r| r.with(index));
+    /// ```
+    ///
     /// This is shortcut for:
     ///
     /// ```rust
@@ -196,6 +228,19 @@ impl<S: 'static> ResourceHandler<S> {
     }
 
     /// Register a new route and add async handler.
+    ///
+    /// ```rust
+    /// # extern crate actix_web;
+    /// # extern crate futures;
+    /// use actix_web::*;
+    /// use futures::future::Future;
+    ///
+    /// fn index(req: HttpRequest) -> Box<Future<Item=HttpResponse, Error=Error>> {
+    ///     unimplemented!()
+    /// }
+    ///
+    /// App::new().resource("/", |r| r.with_async(index));
+    /// ```
     ///
     /// This is shortcut for:
     ///

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -130,8 +130,11 @@ impl<S: 'static> ResourceHandler<S> {
     ///
     /// This is shortcut for:
     ///
-    /// ```rust,ignore
-    /// Application::resource("/", |r| r.route().filter(pred::Get()).f(index)
+    /// ```rust
+    /// # extern crate actix_web;
+    /// # use actix_web::*;
+    /// # fn index(req: HttpRequest) -> HttpResponse { unimplemented!() }
+    /// App::new().resource("/", |r| r.route().filter(pred::Get()).f(index));
     /// ```
     pub fn method(&mut self, method: Method) -> &mut Route<S> {
         self.routes.push(Route::default());
@@ -142,8 +145,11 @@ impl<S: 'static> ResourceHandler<S> {
     ///
     /// This is shortcut for:
     ///
-    /// ```rust,ignore
-    /// Application::resource("/", |r| r.route().h(handler)
+    /// ```rust
+    /// # extern crate actix_web;
+    /// # use actix_web::*;
+    /// # fn handler(req: HttpRequest) -> HttpResponse { unimplemented!() }
+    /// App::new().resource("/", |r| r.route().h(handler));
     /// ```
     pub fn h<H: Handler<S>>(&mut self, handler: H) {
         self.routes.push(Route::default());
@@ -154,8 +160,11 @@ impl<S: 'static> ResourceHandler<S> {
     ///
     /// This is shortcut for:
     ///
-    /// ```rust,ignore
-    /// Application::resource("/", |r| r.route().f(index)
+    /// ```rust
+    /// # extern crate actix_web;
+    /// # use actix_web::*;
+    /// # fn index(req: HttpRequest) -> HttpResponse { unimplemented!() }
+    /// App::new().resource("/", |r| r.route().f(index));
     /// ```
     pub fn f<F, R>(&mut self, handler: F)
     where
@@ -170,8 +179,11 @@ impl<S: 'static> ResourceHandler<S> {
     ///
     /// This is shortcut for:
     ///
-    /// ```rust,ignore
-    /// Application::resource("/", |r| r.route().with(index)
+    /// ```rust
+    /// # extern crate actix_web;
+    /// # use actix_web::*;
+    /// # fn index(req: HttpRequest) -> HttpResponse { unimplemented!() }
+    /// App::new().resource("/", |r| r.route().with(index));
     /// ```
     pub fn with<T, F, R>(&mut self, handler: F)
     where
@@ -187,8 +199,15 @@ impl<S: 'static> ResourceHandler<S> {
     ///
     /// This is shortcut for:
     ///
-    /// ```rust,ignore
-    /// Application::resource("/", |r| r.route().with_async(index)
+    /// ```rust
+    /// # extern crate actix_web;
+    /// # extern crate futures;
+    /// # use actix_web::*;
+    /// # use futures::future::Future;
+    /// # fn index(req: HttpRequest) -> Box<Future<Item=HttpResponse, Error=Error>> {
+    /// #     unimplemented!()
+    /// # }
+    /// App::new().resource("/", |r| r.route().with_async(index));
     /// ```
     pub fn with_async<T, F, R, I, E>(&mut self, handler: F)
     where


### PR DESCRIPTION
Re-enables code blocks as doc tests to prevent them failing in the future, and also adds some new code examples with the corresponding methods being used (in addition to the "this is a shortcut to" snippets).