### PR TITLE
CORS: Do not validate Origin header on non-OPTION requests

### DIFF
--- a/src/middleware/cors.rs
+++ b/src/middleware/cors.rs
@@ -424,7 +424,10 @@ impl<S> Middleware<S> for Cors {
                     .finish(),
             ))
         } else {
-            self.validate_origin(req)?;
+            // Only check requests with a origin header.
+            if req.headers().contains_key(header::ORIGIN) {
+                self.validate_origin(req)?;
+            }
 
             Ok(Started::Done)
         }


### PR DESCRIPTION
Currently, the CORS middleware terminates requests without an `Origin` header, which is quite cumbersome for non-web requests.
This PR only runs the check (on non-OPTION) requests if an Origin header is present.

This should be compatible with https://www.w3.org/TR/cors/, which says under 6.1 that requests without an Origin header are out of scope for CORS.

Fixes #271