### PR TITLE
add default value for header User-Agent in requests

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@
 
 * Use `&mut self` instead of `&self` for Middleware trait
 
+* Added header `User-Agent: Actix-web/<current_version>` to default headers when building a request
 
 ### Removed
 

--- a/src/client/request.rs
+++ b/src/client/request.rs
@@ -615,7 +615,10 @@ impl ClientRequestBuilder {
                 true
             };
             if !contains {
-                self.header(header::USER_AGENT, "Actix-web");
+                self.header(
+                    header::USER_AGENT,
+                    concat!("Actix-web/", env!("CARGO_PKG_VERSION")),
+                );
             }
         }
 

--- a/src/client/request.rs
+++ b/src/client/request.rs
@@ -506,7 +506,7 @@ impl ClientRequestBuilder {
     }
 
     /// Do not add default request headers.
-    /// By default `Accept-Encoding` header is set.
+    /// By default `Accept-Encoding` and `User-Agent` headers are set.
     pub fn no_default_headers(&mut self) -> &mut Self {
         self.default_headers = false;
         self
@@ -607,6 +607,15 @@ impl ClientRequestBuilder {
                 self.header(header::ACCEPT_ENCODING, "br, gzip, deflate");
             } else {
                 self.header(header::ACCEPT_ENCODING, "gzip, deflate");
+            }
+
+            let contains = if let Some(parts) = parts(&mut self.request, &self.err) {
+                parts.headers.contains_key(header::USER_AGENT)
+            } else {
+                true
+            };
+            if !contains {
+                self.header(header::USER_AGENT, "Actix-web");
             }
         }
 

--- a/tests/test_client.rs
+++ b/tests/test_client.rs
@@ -432,3 +432,21 @@ fn test_client_cookie_handling() {
     let c2 = response.cookie("cookie2").expect("Missing cookie2");
     assert_eq!(c2, &cookie2);
 }
+
+#[test]
+fn test_default_headers() {
+    let srv = test::TestServer::new(|app| app.handler(|_| HttpResponse::Ok().body(STR)));
+
+    let request = srv.get().finish().unwrap();
+    let repr = format!("{:?}", request);
+    assert!(repr.contains("\"accept-encoding\": \"gzip, deflate\""));
+    assert!(repr.contains("\"user-agent\": \"Actix-web\""));
+
+    let request_override = srv.get()
+        .header("User-Agent", "test")
+        .finish()
+        .unwrap();
+    let repr_override = format!("{:?}", request_override);
+    assert!(repr_override.contains("\"user-agent\": \"test\""));
+    assert!(!repr_override.contains("\"user-agent\": \"Actix-web\""));
+}

--- a/tests/test_client.rs
+++ b/tests/test_client.rs
@@ -440,7 +440,11 @@ fn test_default_headers() {
     let request = srv.get().finish().unwrap();
     let repr = format!("{:?}", request);
     assert!(repr.contains("\"accept-encoding\": \"gzip, deflate\""));
-    assert!(repr.contains("\"user-agent\": \"Actix-web\""));
+    assert!(repr.contains(concat!(
+        "\"user-agent\": \"Actix-web/",
+        env!("CARGO_PKG_VERSION"),
+        "\""
+    )));
 
     let request_override = srv.get()
         .header("User-Agent", "test")
@@ -448,5 +452,9 @@ fn test_default_headers() {
         .unwrap();
     let repr_override = format!("{:?}", request_override);
     assert!(repr_override.contains("\"user-agent\": \"test\""));
-    assert!(!repr_override.contains("\"user-agent\": \"Actix-web\""));
+    assert!(!repr_override.contains(concat!(
+        "\"user-agent\": \"Actix-web/",
+        env!("CARGO_PKG_VERSION"),
+        "\""
+    )));
 }


### PR DESCRIPTION
According to https://tools.ietf.org/html/rfc7231#section-5.5.3:
> A user agent SHOULD send a User-Agent field in each request unless specifically configured not to do so.

This adds a default `User-Agent` header to requests, with value `Actix-Web`. It can be overridden by the user, and won't be added if the `ClientRequestBuilder` `default_headers` is false