### PR TITLE
Add HttpResponse methods to retrieve, add, and delete cookies

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+* Add methods to `HttpResponse` to retrieve, add, and delete cookies
+
 * Add `.set_content_type()` and `.set_content_disposition()` methods
   to `fs::NamedFile` to allow overriding the values inferred by default
 
@@ -21,6 +23,9 @@
 ### Changed
 
 * Min rustc version is 1.26
+
+* `HttpResponse::into_builder()` now moves cookies into the builder
+  instead of dropping them
 
 * Use tokio instead of tokio-core
 

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -276,7 +276,7 @@ impl Responder for NamedFile {
         if self.status_code != StatusCode::OK {
             let mut resp = HttpResponse::build(self.status_code);
             resp.set(header::ContentType(self.content_type.clone()))
-                .header("Content-Disposition", format!("{}", &self.content_disposition));
+                .header(header::CONTENT_DISPOSITION, self.content_disposition.to_string());
 
             if let Some(current_encoding) = self.encoding {
                 resp.content_encoding(current_encoding);
@@ -327,7 +327,7 @@ impl Responder for NamedFile {
 
         let mut resp = HttpResponse::build(self.status_code);
         resp.set(header::ContentType(self.content_type.clone()))
-            .header("Content-Disposition", format!("{}", &self.content_disposition));
+            .header(header::CONTENT_DISPOSITION, self.content_disposition.to_string());
 
         if let Some(current_encoding) = self.encoding {
             resp.content_encoding(current_encoding);

--- a/src/header/common/content_disposition.rs
+++ b/src/header/common/content_disposition.rs
@@ -193,8 +193,9 @@ impl fmt::Display for ContentDisposition {
                         }
                     }
                     if use_simple_format {
+                        use std::str;
                         try!(write!(f, "; filename=\"{}\"",
-                                    match String::from_utf8(bytes.clone()) {
+                                    match str::from_utf8(bytes) {
                                         Ok(s) => s,
                                         Err(_) => return Err(fmt::Error),
                                     }));


### PR DESCRIPTION
* Add methods to `HttpResponse` to retrieve, add, and delete cookies. Resolves #246.
* Preserve cookies in `HttpResponse::into_builder()`
* Minor cleanups to content disposition