### PR TITLE
remove duplication of `App::with_state` in `App::new`

### DIFF
--- a/src/application.rs
+++ b/src/application.rs
@@ -192,20 +192,7 @@ impl App<()> {
     /// Create application with empty state. Application can
     /// be configured with a builder-like pattern.
     pub fn new() -> App<()> {
-        App {
-            parts: Some(ApplicationParts {
-                state: (),
-                prefix: "/".to_owned(),
-                settings: ServerSettings::default(),
-                default: ResourceHandler::default_not_found(),
-                resources: Vec::new(),
-                handlers: Vec::new(),
-                external: HashMap::new(),
-                encoding: ContentEncoding::Auto,
-                filters: Vec::new(),
-                middlewares: Vec::new(),
-            }),
-        }
+        App::with_state(())
     }
 }
 
@@ -737,7 +724,7 @@ impl<S: 'static> Iterator for App<S> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use body::{Body, Binary};
+    use body::{Binary, Body};
     use http::StatusCode;
     use httprequest::HttpRequest;
     use httpresponse::HttpResponse;
@@ -811,7 +798,9 @@ mod tests {
 
     #[test]
     fn test_handler() {
-        let mut app = App::new().handler("/test", |_| HttpResponse::Ok()).finish();
+        let mut app = App::new()
+            .handler("/test", |_| HttpResponse::Ok())
+            .finish();
 
         let req = TestRequest::with_uri("/test").finish();
         let resp = app.run(req);
@@ -836,7 +825,9 @@ mod tests {
 
     #[test]
     fn test_handler2() {
-        let mut app = App::new().handler("test", |_| HttpResponse::Ok()).finish();
+        let mut app = App::new()
+            .handler("test", |_| HttpResponse::Ok())
+            .finish();
 
         let req = TestRequest::with_uri("/test").finish();
         let resp = app.run(req);
@@ -890,21 +881,29 @@ mod tests {
     #[test]
     fn test_route() {
         let mut app = App::new()
-            .route("/test", Method::GET, |_: HttpRequest| HttpResponse::Ok())
+            .route("/test", Method::GET, |_: HttpRequest| {
+                HttpResponse::Ok()
+            })
             .route("/test", Method::POST, |_: HttpRequest| {
                 HttpResponse::Created()
             })
             .finish();
 
-        let req = TestRequest::with_uri("/test").method(Method::GET).finish();
+        let req = TestRequest::with_uri("/test")
+            .method(Method::GET)
+            .finish();
         let resp = app.run(req);
         assert_eq!(resp.as_msg().status(), StatusCode::OK);
 
-        let req = TestRequest::with_uri("/test").method(Method::POST).finish();
+        let req = TestRequest::with_uri("/test")
+            .method(Method::POST)
+            .finish();
         let resp = app.run(req);
         assert_eq!(resp.as_msg().status(), StatusCode::CREATED);
 
-        let req = TestRequest::with_uri("/test").method(Method::HEAD).finish();
+        let req = TestRequest::with_uri("/test")
+            .method(Method::HEAD)
+            .finish();
         let resp = app.run(req);
         assert_eq!(resp.as_msg().status(), StatusCode::NOT_FOUND);
     }
@@ -973,6 +972,9 @@ mod tests {
         let req = TestRequest::with_uri("/some").finish();
         let resp = app.run(req);
         assert_eq!(resp.as_msg().status(), StatusCode::OK);
-        assert_eq!(resp.as_msg().body(), &Body::Binary(Binary::Slice(b"some")));
+        assert_eq!(
+            resp.as_msg().body(),
+            &Body::Binary(Binary::Slice(b"some"))
+        );
     }
 }


### PR DESCRIPTION
I don't think that this is a testable change, as the output of `App::new()` is entirely identical.

I tried moving `App::new()` into the other `impl` block, but for some reason the type checker didn't like the `Default::default` impl.

As this is such a trivial internal change, I haven't added a changelog entry (unless you think it is necessary, then I'll willingly add one).

Also, there are a couple of spelling mistakes in [CHANGES.md](https://github.com/actix/actix-web/blob/c8528e8920f35ada090a90c7c000db5ede237fcb/CHANGES.md):
line 83: `traling` should be `trailing`.
line 444: `Gracefull` should be `Graceful`.
