### PR TITLE
Remove unsafe code from SharedHttpInnerMessage

### DIFF
--- a/src/server/helpers.rs
+++ b/src/server/helpers.rs
@@ -76,8 +76,7 @@ impl SharedHttpInnerMessage {
 
     #[inline]
     pub fn get_mut(&mut self) -> &mut HttpInnerMessage {
-        let r: &HttpInnerMessage = self.0.as_ref().unwrap().as_ref();
-        unsafe { &mut *(r as *const _ as *mut _) }
+        Rc::get_mut(self.0.as_mut().unwrap()).expect("cannot get mutable reference while object is immutably borrowed")
     }
 
     #[inline]


### PR DESCRIPTION
This attempts to fix #332 but I think this won't work well enough because
I'm pretty sure the Rc has multiple users right now.  I don't understand
this code well enough to judge if there are cases where references from
`get_mut` and `get` are floating around.