### PR TITLE
Propagate scope default resource

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,8 @@
 
 * `HttpRequest::url_for_static()` for a named route with no variables segments
 
+* Propagation of the application's default resource to scopes that haven't set a default resource.
+
 
 ### Changed
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,5 +1,7 @@
+use std::cell::RefCell;
 use std::marker::PhantomData;
 use std::ops::Deref;
+use std::rc::Rc;
 
 use futures::future::{err, ok, Future};
 use futures::{Async, Poll};
@@ -8,6 +10,7 @@ use error::Error;
 use http::StatusCode;
 use httprequest::HttpRequest;
 use httpresponse::HttpResponse;
+use resource::ResourceHandler;
 
 /// Trait defines object that could be registered as route handler
 #[allow(unused_variables)]
@@ -403,6 +406,14 @@ where
 // /// Trait defines object that could be registered as resource route
 pub(crate) trait RouteHandler<S>: 'static {
     fn handle(&mut self, req: HttpRequest<S>) -> AsyncResult<HttpResponse>;
+
+    fn has_default_resource(&self) -> bool {
+        false
+    }
+
+    fn default_resource(&mut self, default: Rc<RefCell<ResourceHandler<S>>>) {
+        unimplemented!()
+    }
 }
 
 /// Route handler wrapper for Handler

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -405,6 +405,14 @@ impl<S: 'static> RouteHandler<S> for Scope<S> {
             unimplemented!()
         }
     }
+
+    fn has_default_resource(&self) -> bool {
+        self.default.is_some()
+    }
+
+    fn default_resource(&mut self, default: ScopeResource<S>) {
+        self.default = Some(default);
+    }
 }
 
 struct Wrapper<S: 'static> {


### PR DESCRIPTION
Propagate the application's default resources to any underlying scopes that haven't set their own default resources.

Closes: #254 