### PR TITLE
Changes the router to use atoms internally

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ license = "MIT/Apache-2.0"
 exclude = [".gitignore", ".travis.yml", ".cargo/config", "appveyor.yml"]
 build = "build.rs"
 
+[package.metadata.docs.rs]
+features = ["tls", "alpn", "session", "brotli", "flate2-c"]
+
 [badges]
 travis-ci = { repository = "actix/actix-web", branch = "master" }
 appveyor = { repository = "fafhrd91/actix-web-hdy9d" }
@@ -45,9 +48,6 @@ flate2-c = ["flate2/miniz-sys"]
 
 # rust backend for flate2 crate
 flate2-rust = ["flate2/rust_backend"]
-
-[package.metadata.docs.rs]
-features = ["tls", "alpn", "session", "brotli", "flate2-c"]
 
 [dependencies]
 # actix = "0.6.1"
@@ -103,6 +103,7 @@ tokio-tls = { version="0.1", optional = true }
 # openssl
 openssl = { version="0.10", optional = true }
 tokio-openssl = { version="0.2", optional = true }
+string_cache = "0.7.3"
 
 [dev-dependencies]
 env_logger = "0.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,6 +114,7 @@ extern crate net2;
 extern crate parking_lot;
 extern crate rand;
 extern crate slab;
+extern crate string_cache;
 extern crate tokio;
 extern crate tokio_io;
 extern crate tokio_reactor;


### PR DESCRIPTION
This uses atoms instead of leaked strings. It trades some unsafety, leaked params and a memcpy for a atom increment per param. I'm pretty sure in the grand scheme of things this should not show up but I did not run benchmarks.