### PR TITLE
Use StaticFile default handler when file is inaccessible

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,6 +49,10 @@
 
 * `HttpRequest::cookies()` returns `Ref<Vec<Cookie<'static>>>`
 
+* `StaticFiles::new()` returns `Result<StaticFiles<S>, Error>` instead of `StaticFiles<S>`
+
+* `StaticFiles` uses the default handler if the file does not exist
+
 
 ### Removed
 

--- a/src/application.rs
+++ b/src/application.rs
@@ -587,7 +587,7 @@ where
     ///     let app = App::new()
     ///         .middleware(middleware::Logger::default())
     ///         .configure(config)  // <- register resources
-    ///         .handler("/static", fs::StaticFiles::new("."));
+    ///         .handler("/static", fs::StaticFiles::new(".").unwrap());
     /// }
     /// ```
     pub fn configure<F>(self, cfg: F) -> App<S>

--- a/src/error.rs
+++ b/src/error.rs
@@ -629,6 +629,9 @@ impl From<UrlParseError> for UrlGenerationError {
 /// Errors which can occur when serving static files.
 #[derive(Fail, Debug, PartialEq)]
 pub enum StaticFileError {
+    /// Path is not a directory
+    #[fail(display = "Path is not a directory")]
+    IsNotDirectory,
     /// Cannot render directory
     #[fail(display = "Cannot render directory")]
     IsDirectory,

--- a/src/error.rs
+++ b/src/error.rs
@@ -626,6 +626,21 @@ impl From<UrlParseError> for UrlGenerationError {
     }
 }
 
+/// Errors which can occur when serving static files.
+#[derive(Fail, Debug, PartialEq)]
+pub enum StaticFileError {
+    /// Cannot render directory
+    #[fail(display = "Cannot render directory")]
+    IsDirectory,
+}
+
+/// Return `NotFound` for `StaticFileError`
+impl ResponseError for StaticFileError {
+    fn error_response(&self) -> HttpResponse {
+        HttpResponse::new(StatusCode::NOT_FOUND)
+    }
+}
+
 /// Helper type that can wrap any error and generate custom response.
 ///
 /// In following example any `io::Error` will be converted into "BAD REQUEST"

--- a/src/error.rs
+++ b/src/error.rs
@@ -630,10 +630,10 @@ impl From<UrlParseError> for UrlGenerationError {
 #[derive(Fail, Debug, PartialEq)]
 pub enum StaticFileError {
     /// Path is not a directory
-    #[fail(display = "Path is not a directory")]
+    #[fail(display = "Path is not a directory. Unable to serve static files")]
     IsNotDirectory,
     /// Cannot render directory
-    #[fail(display = "Cannot render directory")]
+    #[fail(display = "Unable to render directory without index file")]
     IsDirectory,
 }
 

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -673,7 +673,10 @@ impl<S: 'static> Handler<S> for StaticFiles<S> {
             };
 
             // full filepath
-            let path = self.directory.join(&relpath).canonicalize()?;
+            let path = match self.directory.join(&relpath).canonicalize() {
+                Ok(path) => path,
+                _ => return Ok(self.default.handle(req))
+            };
 
             if path.is_dir() {
                 if let Some(ref redir_index) = self.index {
@@ -696,8 +699,11 @@ impl<S: 'static> Handler<S> for StaticFiles<S> {
                     Ok(self.default.handle(req))
                 }
             } else {
-                NamedFile::open(path)?
-                    .set_cpu_pool(self.cpu_pool.clone())
+                let file = match NamedFile::open(path) {
+                    Ok(file) => file,
+                    _ => return Ok(self.default.handle(req))
+                };
+                file.set_cpu_pool(self.cpu_pool.clone())
                     .respond_to(&req)?
                     .respond_to(&req)
             }
@@ -806,6 +812,7 @@ mod tests {
 
     use super::*;
     use application::App;
+    use body::{Binary, Body};
     use http::{header, Method, StatusCode};
     use test::{self, TestRequest};
 
@@ -1208,6 +1215,19 @@ mod tests {
         );
         assert!(resp.body().is_binary());
         assert!(format!("{:?}", resp.body()).contains("README.md"));
+    }
+
+    #[test]
+    fn test_default_handler_file_missing() {
+        let st = StaticFiles::new(".")
+            .default_handler(|_req| "default content");
+        let req = TestRequest::with_uri("/missing")
+            .param("tail", "missing").finish();
+
+        let resp = st.handle(req).respond_to(&HttpRequest::default()).unwrap();
+        let resp = resp.as_msg();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(resp.body(), &Body::Binary(Binary::Slice(b"default content")));
     }
 
     #[test]


### PR DESCRIPTION
I also ran into #286 and I thought I'd have a go at fixing it. It seems that [canonicalize](https://doc.rust-lang.org/std/fs/fn.canonicalize.html) returns an error if the file doesn't exist. And `NamedFile::open` will return an error if you don't have permission to read the file. In both cases, the error was being propagated from `StaticFiles.handle()` rather than using the default handler.

I'm still very new to rust, let alone this framework, so I don't know if this is a _good_ way to solve this problem. So if you have any suggestions I'm all ears. I also don't know how to test the `NamedFile::open` error path in a platform-independent way so suggestions there are also welcome.