### PR TITLE
Remove reimplementation of `LazyCell`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ time = "0.1"
 encoding = "0.2"
 language-tags = "0.2"
 lazy_static = "1.0"
+lazycell = "1.0.0"
 parking_lot = "0.6"
 url = { version="1.7", features=["query_encoding"] }
 cookie = { version="0.10", features=["percent-encode"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,6 +107,7 @@ extern crate htmlescape;
 extern crate http as modhttp;
 extern crate httparse;
 extern crate language_tags;
+extern crate lazycell;
 extern crate mime;
 extern crate mime_guess;
 extern crate mio;


### PR DESCRIPTION
Fixes #366

- `LazyCell` has no overhead over the current `UnsafeCell` and allows removing some extra uses of unsafe.
- The `mem::uninitialized()` call is unnecessary: experimentation in the playpen shows that the compiler generates byte-for-byte identical code if it is (safely) zero-initialized instead, since it can trivially determine that the entire array is overwritten.