### PR TITLE
Initial config for static files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+* Add `fs::StaticFileConfig` to provide means of customizing static file services. It allows to map
+`mime` to `Content-Disposition`, specify whether to use `ETag` and `Last-Modified` and allowed methods.
+
 * Add `.has_prefixed_resource()` method to `router::ResourceInfo` for route matching with prefix awareness
 
 * Add `HttpMessage::readlines()` for reading line by line.


### PR DESCRIPTION
Closes #401
Closes #351

Initial draft for generic configuration of static files.

Currently allows to:
- Specify mapping for content disposition
- Disable/Enable Etag/LastModified
- Mapping of allowed methods for file service