### PR TITLE
remove the timestamp from the default logger middleware

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 * Fixed default_resource 'not yet implemented' panic #410
+* removed the timestamp from the default logger middleware
 
 
 ## [0.7.0] - 2018-07-21

--- a/src/middleware/logger.rs
+++ b/src/middleware/logger.rs
@@ -25,7 +25,7 @@ use middleware::{Finished, Middleware, Started};
 /// default format:
 ///
 /// ```ignore
-///  %a %t "%r" %s %b "%{Referer}i" "%{User-Agent}i" %T
+///  %a "%r" %s %b "%{Referer}i" "%{User-Agent}i" %T
 /// ```
 /// ```rust
 /// # extern crate actix_web;
@@ -94,7 +94,7 @@ impl Default for Logger {
     /// Create `Logger` middleware with format:
     ///
     /// ```ignore
-    /// %a %t "%r" %s %b "%{Referer}i" "%{User-Agent}i" %T
+    /// %a "%r" %s %b "%{Referer}i" "%{User-Agent}i" %T
     /// ```
     fn default() -> Logger {
         Logger {
@@ -143,7 +143,7 @@ struct Format(Vec<FormatText>);
 impl Default for Format {
     /// Return the default formatting style for the `Logger`:
     fn default() -> Format {
-        Format::new(r#"%a %t "%r" %s %b "%{Referer}i" "%{User-Agent}i" %T"#)
+        Format::new(r#"%a "%r" %s %b "%{Referer}i" "%{User-Agent}i" %T"#)
     }
 }
 


### PR DESCRIPTION
env_logger and other logging systems will (or should) already add their
own timestamp.

before:
    `INFO 2018-07-21T12:57:49Z: actix_web::middleware::logger: 127.0.0.1:42112 [21/Jul/2018:14:57:49 +0200] "GET / HTTP/1.1" 200 858 "-" "curl/7.61.0" 0.000686`
    
after:
    `INFO 2018-07-21T13:03:20Z: actix_web::middleware::logger: 127.0.0.1:42154 "GET / HTTP/1.1" 200 858 "-" "curl/7.61.0" 0.000367`

