### PR TITLE
Add FromRequest<S> implementation for Option<T> and Result<T> where T: FromRequest<S>

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## [0.7.1] - 2018-07-21
 
+### Added
+
+  * Add implementation of `FromRequest<S>` for `Option<T>` and `Result<T, Error>`
+
 ### Fixed
 
 * Fixed default_resource 'not yet implemented' panic #410

--- a/src/application.rs
+++ b/src/application.rs
@@ -610,7 +610,6 @@ impl<S: 'static> Iterator for App<S> {
 mod tests {
     use super::*;
     use body::{Binary, Body};
-    use fs;
     use http::StatusCode;
     use httprequest::HttpRequest;
     use httpresponse::HttpResponse;

--- a/src/extractor.rs
+++ b/src/extractor.rs
@@ -16,7 +16,10 @@ use error::{Error, ErrorBadRequest, ErrorNotFound, UrlencodedError};
 use handler::{AsyncResult, FromRequest};
 use httpmessage::{HttpMessage, MessageBody, UrlEncoded};
 use httprequest::HttpRequest;
+use Result;
+use futures::future;
 
+#[derive(PartialEq, Eq, PartialOrd, Ord)]
 /// Extract typed information from the request's path.
 ///
 /// ## Example
@@ -128,6 +131,7 @@ impl<T: fmt::Display> fmt::Display for Path<T> {
     }
 }
 
+#[derive(PartialEq, Eq, PartialOrd, Ord)]
 /// Extract typed information from from the request's query.
 ///
 /// ## Example
@@ -215,6 +219,7 @@ impl<T: fmt::Display> fmt::Display for Query<T> {
     }
 }
 
+#[derive(PartialEq, Eq, PartialOrd, Ord)]
 /// Extract typed information from the request's body.
 ///
 /// To extract typed information from request's body, the type `T` must


### PR DESCRIPTION
This pull request adds an implementation of  `FromRequest<S>` for `Option<T>` and `Result<T>` where `T: FromRequest<S>`.

In case the `FromRequest<T>` extractor fails for any reason the `FromRequest<Option<T>>` returns `None`, the `FromRequest<Result<T>>` return the Error itself. They do not fail the request, so it is available and can be handled within the handler.

They can be useful for example when extracting `Authorization` / `Cookie` / `Session` / `Header` / `X` information that may or may not be present for the request.

