### PR TITLE
Update cookie dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ lazy_static = "1.0"
 lazycell = "1.0.0"
 parking_lot = "0.6"
 url = { version="1.7", features=["query_encoding"] }
-cookie = { version="0.10", features=["percent-encode"] }
+cookie = { version="0.11", features=["percent-encode"] }
 brotli2 = { version="^0.3.2", optional = true }
 flate2 = { version="1.0", optional = true, default-features = false }
 


### PR DESCRIPTION
Updating `cookie` for security fix:
```
$ cargo audit 
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
    Scanning 191 crates for vulnerabilities (10 advisories in database)
error: Vulnerable crates found!

ID:	 RUSTSEC-2018-0001
Crate:	 untrusted
Version: 0.5.1
Date:	 2018-06-21
URL:	 https://github.com/briansmith/untrusted/pull/20
Title:	 An integer underflow could lead to panic
Solution: upgrade to: >= 0.6.2

error: 1 vulnerability found!
```

EDIT: Dependency chain is: `cookie` -> `ring` -> `untrusted`