### PR TITLE
feature: allow TestServer to open a websocket on any URL

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
 
 * Support HTTP/2 with rustls #36
 
+* Allow TestServer to open a websocket on any URL # 433
+
 ### Fixed
 
 * Do not override HOST header for client request #428
@@ -22,7 +24,7 @@
 * Add implementation of `FromRequest<S>` for `Option<T>` and `Result<T, Error>`
 
 * Allow to handle application prefix, i.e. allow to handle `/app` path
-  for application with `/app` prefix. 
+  for application with `/app` prefix.
   Check [`App::prefix()`](https://actix.rs/actix-web/actix_web/struct.App.html#method.prefix)
   api doc.
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -207,15 +207,23 @@ impl TestServer {
         self.rt.block_on(fut)
     }
 
-    /// Connect to websocket server
-    pub fn ws(
+    /// Connect to websocket server at a given path
+    pub fn ws_at(
         &mut self,
+        path: &str,
     ) -> Result<(ws::ClientReader, ws::ClientWriter), ws::ClientError> {
-        let url = self.url("/");
+        let url = self.url(path);
         self.rt
             .block_on(ws::Client::with_connector(url, self.conn.clone()).connect())
     }
 
+    /// Connect to a websocket server
+    pub fn ws(
+        &mut self,
+    ) -> Result<(ws::ClientReader, ws::ClientWriter), ws::ClientError> {
+        self.ws_at("/")
+    }
+    
     /// Create `GET` request
     pub fn get(&self) -> ClientRequestBuilder {
         ClientRequest::get(self.url("/").as_str())


### PR DESCRIPTION
* added `TestServer::ws_at(uri_str)`
* modified `TestServer::ws()` to call `self.ws_at("/")` to preserve
behavior

Closes #432