### PR TITLE
Fixed headers' formating for CORS Middleware Access-Control-Expose-Headers header value to HTTP/1.1 & HTTP/2 spec-compliant format

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,7 +15,6 @@
 
 * Allow TestServer to open a websocket on any URL (TestServer::ws_at()) #433
 
-
 ### Fixed
 
 * Fixed failure 0.1.2 compatibility
@@ -25,6 +24,8 @@
 * Gz streaming, use `flate2::write::GzDecoder` #228
 
 * HttpRequest::url_for is not working with scopes #429
+
+* Fixed headers' formating for CORS Middleware `Access-Control-Expose-Headers` header value to HTTP/1.1 & HTTP/2 spec-compliant format #436
 
 
 ## [0.7.2] - 2018-07-26


### PR DESCRIPTION
Also, I added a test for spec-conformance.

## Description

Given the following `.expose_headers` setting:
```rust
.expose_headers(vec![
    http::header::CONTENT_TYPE,
    http::header::ACCEPT,
    http::header::USER_AGENT,
    http::header::FORWARDED,
    http::header::HeaderName::from_static("X-Forwarded-For"),
])
```

I was getting the following headers: 
```
HTTP/1.1 200 OK
access-control-allow-origin: *
access-control-expose-headers: ontent-typeforwardedx-forwarded-foracceptuser-agent
```

Which is completely out of HTTP spec and plain wrong.

## Result after fix: 

```
HTTP/1.1 200 OK
access-control-allow-origin: *
access-control-expose-headers: forwarded, user-agent, content-type, accept, x-forwarded-for
```

Tests are passing