### PR TITLE
Use zlib instead of deflate for content encoding

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,9 @@
 
 * Added `HttpServer::max_connections()` and `HttpServer::max_sslrate()`, accept backpressure #250
 
+* Fix: Use zlib instead of raw deflate for decoding and encoding payloads with
+  `Content-Encoding: deflate`.
+
 
 ## [0.7.3] - 2018-08-01
 

--- a/src/client/writer.rs
+++ b/src/client/writer.rs
@@ -8,7 +8,7 @@ use std::io::{self, Write};
 use brotli2::write::BrotliEncoder;
 use bytes::{BufMut, BytesMut};
 #[cfg(feature = "flate2")]
-use flate2::write::{DeflateEncoder, GzEncoder};
+use flate2::write::{GzEncoder, ZlibEncoder};
 #[cfg(feature = "flate2")]
 use flate2::Compression;
 use futures::{Async, Poll};
@@ -232,7 +232,7 @@ fn content_encoder(buf: BytesMut, req: &mut ClientRequest) -> Output {
                     let mut enc = match encoding {
                         #[cfg(feature = "flate2")]
                         ContentEncoding::Deflate => ContentEncoder::Deflate(
-                            DeflateEncoder::new(transfer, Compression::default()),
+                            ZlibEncoder::new(transfer, Compression::default()),
                         ),
                         #[cfg(feature = "flate2")]
                         ContentEncoding::Gzip => ContentEncoder::Gzip(GzEncoder::new(
@@ -302,7 +302,7 @@ fn content_encoder(buf: BytesMut, req: &mut ClientRequest) -> Output {
     req.replace_body(body);
     let enc = match encoding {
         #[cfg(feature = "flate2")]
-        ContentEncoding::Deflate => ContentEncoder::Deflate(DeflateEncoder::new(
+        ContentEncoding::Deflate => ContentEncoder::Deflate(ZlibEncoder::new(
             transfer,
             Compression::default(),
         )),

--- a/src/server/input.rs
+++ b/src/server/input.rs
@@ -5,7 +5,7 @@ use brotli2::write::BrotliDecoder;
 use bytes::{Bytes, BytesMut};
 use error::PayloadError;
 #[cfg(feature = "flate2")]
-use flate2::write::{DeflateDecoder, GzDecoder};
+use flate2::write::{GzDecoder, ZlibDecoder};
 use header::ContentEncoding;
 use http::header::{HeaderMap, CONTENT_ENCODING};
 use payload::{PayloadSender, PayloadStatus, PayloadWriter};
@@ -139,7 +139,7 @@ impl PayloadWriter for EncodedPayload {
 
 pub(crate) enum Decoder {
     #[cfg(feature = "flate2")]
-    Deflate(Box<DeflateDecoder<Writer>>),
+    Deflate(Box<ZlibDecoder<Writer>>),
     #[cfg(feature = "flate2")]
     Gzip(Box<GzDecoder<Writer>>),
     #[cfg(feature = "brotli")]
@@ -186,7 +186,7 @@ impl PayloadStream {
             }
             #[cfg(feature = "flate2")]
             ContentEncoding::Deflate => {
-                Decoder::Deflate(Box::new(DeflateDecoder::new(Writer::new())))
+                Decoder::Deflate(Box::new(ZlibDecoder::new(Writer::new())))
             }
             #[cfg(feature = "flate2")]
             ContentEncoding::Gzip => {

--- a/src/server/output.rs
+++ b/src/server/output.rs
@@ -7,7 +7,7 @@ use std::{cmp, fmt, io, mem};
 use brotli2::write::BrotliEncoder;
 use bytes::BytesMut;
 #[cfg(feature = "flate2")]
-use flate2::write::{DeflateEncoder, GzEncoder};
+use flate2::write::{GzEncoder, ZlibEncoder};
 #[cfg(feature = "flate2")]
 use flate2::Compression;
 use http::header::{ACCEPT_ENCODING, CONTENT_LENGTH};
@@ -210,7 +210,7 @@ impl Output {
                         let mut enc = match encoding {
                             #[cfg(feature = "flate2")]
                             ContentEncoding::Deflate => ContentEncoder::Deflate(
-                                DeflateEncoder::new(transfer, Compression::fast()),
+                                ZlibEncoder::new(transfer, Compression::fast()),
                             ),
                             #[cfg(feature = "flate2")]
                             ContentEncoding::Gzip => ContentEncoder::Gzip(
@@ -273,7 +273,7 @@ impl Output {
 
         let enc = match encoding {
             #[cfg(feature = "flate2")]
-            ContentEncoding::Deflate => ContentEncoder::Deflate(DeflateEncoder::new(
+            ContentEncoding::Deflate => ContentEncoder::Deflate(ZlibEncoder::new(
                 transfer,
                 Compression::fast(),
             )),
@@ -354,7 +354,7 @@ impl Output {
 
 pub(crate) enum ContentEncoder {
     #[cfg(feature = "flate2")]
-    Deflate(DeflateEncoder<TransferEncoding>),
+    Deflate(ZlibEncoder<TransferEncoding>),
     #[cfg(feature = "flate2")]
     Gzip(GzEncoder<TransferEncoding>),
     #[cfg(feature = "brotli")]

--- a/tests/test_server.rs
+++ b/tests/test_server.rs
@@ -20,7 +20,7 @@ use std::{net, thread, time};
 use brotli2::write::{BrotliDecoder, BrotliEncoder};
 use bytes::{Bytes, BytesMut};
 use flate2::read::GzDecoder;
-use flate2::write::{DeflateDecoder, DeflateEncoder, GzEncoder};
+use flate2::write::{GzEncoder, ZlibDecoder, ZlibEncoder};
 use flate2::Compression;
 use futures::stream::once;
 use futures::{Future, Stream};
@@ -528,7 +528,7 @@ fn test_body_chunked_explicit() {
 
 #[test]
 fn test_body_identity() {
-    let mut e = DeflateEncoder::new(Vec::new(), Compression::default());
+    let mut e = ZlibEncoder::new(Vec::new(), Compression::default());
     e.write_all(STR.as_ref()).unwrap();
     let enc = e.finish().unwrap();
     let enc2 = enc.clone();
@@ -578,7 +578,7 @@ fn test_body_deflate() {
     let bytes = srv.execute(response.body()).unwrap();
 
     // decode deflate
-    let mut e = DeflateDecoder::new(Vec::new());
+    let mut e = ZlibDecoder::new(Vec::new());
     e.write_all(bytes.as_ref()).unwrap();
     let dec = e.finish().unwrap();
     assert_eq!(Bytes::from(dec), Bytes::from_static(STR.as_ref()));
@@ -727,7 +727,7 @@ fn test_reading_deflate_encoding() {
         })
     });
 
-    let mut e = DeflateEncoder::new(Vec::new(), Compression::default());
+    let mut e = ZlibEncoder::new(Vec::new(), Compression::default());
     e.write_all(STR.as_ref()).unwrap();
     let enc = e.finish().unwrap();
 
@@ -760,7 +760,7 @@ fn test_reading_deflate_encoding_large() {
         })
     });
 
-    let mut e = DeflateEncoder::new(Vec::new(), Compression::default());
+    let mut e = ZlibEncoder::new(Vec::new(), Compression::default());
     e.write_all(data.as_ref()).unwrap();
     let enc = e.finish().unwrap();
 
@@ -797,7 +797,7 @@ fn test_reading_deflate_encoding_large_random() {
         })
     });
 
-    let mut e = DeflateEncoder::new(Vec::new(), Compression::default());
+    let mut e = ZlibEncoder::new(Vec::new(), Compression::default());
     e.write_all(data.as_ref()).unwrap();
     let enc = e.finish().unwrap();
 


### PR DESCRIPTION
This PR switches deflate with zlib for compliance with the HTTP spec for `Content-Encoding: deflate`. See #441 for an explanation of the issue.

Note this PR changes both input and output.

Closes #441