### PR TITLE
Implemented .cause() for InternalError's Fail trait.

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -238,7 +238,9 @@ where
         if self.fut.alive() {
             match self.fut.poll() {
                 Ok(Async::NotReady) | Ok(Async::Ready(())) => (),
-                Err(_) => return Err(ErrorInternalServerError("error")),
+                Err(_) => {
+                    return Err(ErrorInternalServerError(::error::FailMsg("error")))
+                }
             }
         }
 

--- a/src/middleware/errhandlers.rs
+++ b/src/middleware/errhandlers.rs
@@ -120,7 +120,9 @@ mod tests {
 
     impl<S> Middleware<S> for MiddlewareOne {
         fn start(&self, _: &HttpRequest<S>) -> Result<Started, Error> {
-            Err(ErrorInternalServerError("middleware error"))
+            Err(ErrorInternalServerError(::error::FailMsg(
+                "middleware error",
+            )))
         }
     }
 

--- a/src/ws/context.rs
+++ b/src/ws/context.rs
@@ -308,7 +308,7 @@ where
 
     fn poll(&mut self) -> Poll<Option<SmallVec<[ContextFrame; 4]>>, Error> {
         if self.fut.alive() && self.fut.poll().is_err() {
-            return Err(ErrorInternalServerError("error"));
+            return Err(ErrorInternalServerError(::error::FailMsg("error")));
         }
 
         // frames

--- a/tests/test_middleware.rs
+++ b/tests/test_middleware.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
 
-use actix_web::error::{Error, ErrorInternalServerError};
+use actix_web::error::{Error, ErrorInternalServerError, FailMsg};
 use actix_web::*;
 use futures::{future, Future};
 use tokio_timer::Delay;
@@ -332,7 +332,7 @@ fn test_scope_middleware_async_handler() {
 }
 
 fn index_test_middleware_async_error(_: &HttpRequest) -> FutureResponse<HttpResponse> {
-    future::result(Err(error::ErrorBadRequest("TEST"))).responder()
+    future::result(Err(error::ErrorBadRequest(FailMsg("TEST")))).responder()
 }
 
 #[test]
@@ -794,7 +794,7 @@ struct MiddlewareWithErr;
 
 impl<S> middleware::Middleware<S> for MiddlewareWithErr {
     fn start(&self, _: &HttpRequest<S>) -> Result<middleware::Started, Error> {
-        Err(ErrorInternalServerError("middleware error"))
+        Err(ErrorInternalServerError(FailMsg("middleware error")))
     }
 }
 
@@ -803,7 +803,7 @@ struct MiddlewareAsyncWithErr;
 impl<S> middleware::Middleware<S> for MiddlewareAsyncWithErr {
     fn start(&self, _: &HttpRequest<S>) -> Result<middleware::Started, Error> {
         Ok(middleware::Started::Future(Box::new(future::err(
-            ErrorInternalServerError("middleware error"),
+            ErrorInternalServerError(FailMsg("middleware error")),
         ))))
     }
 }


### PR DESCRIPTION
This PR fixes issue #443 at the cost of requiring `T: Fail` for all `InternalError`s. I understand that this is a breaking change for `actix-web` public APIs, but I don't see any other way to preserve error-cause chain information for internal errors without using unsafe code.

Please let me know if there is some more elegant approach I can use.