### PR TITLE
impl FromRequest for ()

### DIFF
--- a/src/extractor.rs
+++ b/src/extractor.rs
@@ -693,7 +693,7 @@ macro_rules! tuple_from_req ({$fut_type:ident, $(($n:tt, $T:ident)),+} => {
 impl<S> FromRequest<S> for () {
     type Config = ();
     type Result = Self;
-    fn from_request(_req: &HttpRequest<S>, _cfg: &Self::Config) {}
+    fn from_request(_req: &HttpRequest<S>, _cfg: &Self::Config) -> Self::Result {}
 }
 
 tuple_from_req!(TupleFromRequest1, (0, A));
@@ -1013,6 +1013,6 @@ mod tests {
         assert_eq!((res.1).0, "name");
         assert_eq!((res.1).1, "user1");
 
-        <()>::extract(&req);
+        let () = <()>::extract(&req);
     }
 }

--- a/src/extractor.rs
+++ b/src/extractor.rs
@@ -690,6 +690,12 @@ macro_rules! tuple_from_req ({$fut_type:ident, $(($n:tt, $T:ident)),+} => {
     }
 });
 
+impl<S> FromRequest<S> for () {
+    type Config = ();
+    type Result = Self;
+    fn from_request(_req: &HttpRequest<S>, _cfg: &Self::Config) {}
+}
+
 tuple_from_req!(TupleFromRequest1, (0, A));
 tuple_from_req!(TupleFromRequest2, (0, A), (1, B));
 tuple_from_req!(TupleFromRequest3, (0, A), (1, B), (2, C));
@@ -1006,5 +1012,7 @@ mod tests {
         assert_eq!((res.0).1, "user1");
         assert_eq!((res.1).0, "name");
         assert_eq!((res.1).1, "user1");
+
+        <()>::extract(&req);
     }
 }


### PR DESCRIPTION
This allows writing `app.route("/foo", Method::GET, |()| foo)` when you don't care about the request, which is a bit more concise than `app.route("/foo", Method::GET, |_: HttpRequest| foo)`.

I didn't use the macro because it would've been a larger diff (need to change all the repeats from `+` to `*`) and the futures machinery from the macro isn't necessary for `()`.