### PR TITLE
Reserve enough space for ServerError task to write status line

### DIFF
--- a/src/server/error.rs
+++ b/src/server/error.rs
@@ -16,6 +16,9 @@ impl HttpHandlerTask for ServerError {
     fn poll_io(&mut self, io: &mut Writer) -> Poll<bool, Error> {
         {
             let bytes = io.buffer();
+            //Buffer should have sufficient capacity for status line
+            //and extra space
+            bytes.reserve(helpers::STATUS_LINE_BUF_SIZE + 1);
             helpers::write_status_line(self.0, self.1.as_u16(), bytes);
         }
         io.set_date();

--- a/src/server/helpers.rs
+++ b/src/server/helpers.rs
@@ -8,8 +8,10 @@ const DEC_DIGITS_LUT: &[u8] = b"0001020304050607080910111213141516171819\
       6061626364656667686970717273747576777879\
       8081828384858687888990919293949596979899";
 
+pub(crate) const STATUS_LINE_BUF_SIZE: usize = 13;
+
 pub(crate) fn write_status_line(version: Version, mut n: u16, bytes: &mut BytesMut) {
-    let mut buf: [u8; 13] = [
+    let mut buf: [u8; STATUS_LINE_BUF_SIZE] = [
         b'H', b'T', b'T', b'P', b'/', b'1', b'.', b'1', b' ', b' ', b' ', b' ', b' ',
     ];
     match version {


### PR DESCRIPTION
The same function is used in H1 writer https://github.com/actix/actix-web/blob/master/src/server/h1writer.rs#L167

But there we reserve buffer with enough space.

But I'm not sure about error task here and whether it is possible to predict required space.
So I put reserve in `ServerError` just for status line, in case it wouldn't be sufficient.

@fafhrd91 Do you think it is a problem that buffer is not sufficient for `ServerError` to write status line in first place?

Closes #452