### PR TITLE
Fix server startup log message

### DIFF
--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -217,7 +217,7 @@ impl Server {
             // start accept thread
             for sock in &self.sockets {
                 for s in sock.iter() {
-                    info!("Starting server on http://{:?}", s.1.local_addr().ok());
+                    info!("Starting server on http://{}", s.1.local_addr().unwrap());
                 }
             }
             let rx = self


### PR DESCRIPTION
**Actix web 0.7.4** broke the server startup log message.

The message I had:
Starting server on http://Some(V4(0.0.0.0:8080))

I fixed this with an **unwrap** and the display placeholder, because the address should be correct at this stage.