### PR TITLE
Fix Issue #490

### DIFF
--- a/src/server/error.rs
+++ b/src/server/error.rs
@@ -21,7 +21,12 @@ impl HttpHandlerTask for ServerError {
             bytes.reserve(helpers::STATUS_LINE_BUF_SIZE + 1);
             helpers::write_status_line(self.0, self.1.as_u16(), bytes);
         }
+        // Convert Status Code to Reason.
+        let reason = self.1.canonical_reason().unwrap_or("<unknown status code>");
+        io.buffer().extend_from_slice(reason.as_bytes());
+        // No response body.
         io.buffer().extend_from_slice(b"\r\ncontent-length: 0\r\n");
+        // date header
         io.set_date();
         Ok(Async::Ready(true))
     }

--- a/src/server/error.rs
+++ b/src/server/error.rs
@@ -22,7 +22,7 @@ impl HttpHandlerTask for ServerError {
             helpers::write_status_line(self.0, self.1.as_u16(), bytes);
         }
         // Convert Status Code to Reason.
-        let reason = self.1.canonical_reason().unwrap_or("<unknown status code>");
+        let reason = self.1.canonical_reason().unwrap_or("");
         io.buffer().extend_from_slice(reason.as_bytes());
         // No response body.
         io.buffer().extend_from_slice(b"\r\ncontent-length: 0\r\n");

--- a/tests/test_server.rs
+++ b/tests/test_server.rs
@@ -933,6 +933,29 @@ fn test_application() {
 }
 
 #[test]
+fn test_issue_490() {
+    let mut srv = test::TestServer::with_factory(|| {
+        App::new()
+            .prefix("/app")
+            .resource("", |r| r.f(|_| HttpResponse::Ok()))
+            .resource("/", |r| r.f(|_| HttpResponse::Ok()))
+    });
+    let addr = srv.addr();
+
+    let mut buf = [0; 24];
+    let request = TcpStream::connect(&addr)
+        .and_then(|sock| {
+            tokio::io::write_all(sock, "HEAD / HTTP/1.1\r\nHost: localhost\r\n\r\n")
+                .and_then(|(sock, _)| tokio::io::read_exact(sock, &mut buf))
+                .and_then(|(_, buf)| Ok(buf))
+        })
+        .map_err(|e| panic!("{:?}", e));
+    let response = srv.execute(request).unwrap();
+    let rep = String::from_utf8_lossy(&response[..]);
+    assert!(rep.contains("HTTP/1.1 404 Not Found"));
+}
+
+#[test]
 fn test_server_cookies() {
     use actix_web::http;
 

--- a/tests/test_server.rs
+++ b/tests/test_server.rs
@@ -933,7 +933,7 @@ fn test_application() {
 }
 
 #[test]
-fn test_issue_490() {
+fn test_default_404_handler_response() {
     let mut srv = test::TestServer::with_factory(|| {
         App::new()
             .prefix("/app")


### PR DESCRIPTION
Includes a testcase to check for the reason text in an HTTP 404 response.

The router has a default handler for 404 responses that correctly sends the "Not Found" reason in the response, because it uses the normal HTTP Response writing code.

If no handler is found (i.e. no routes), then the HTTP1 handler creates a ServerError task to handle the response writing.  ServerError wasn't including the HTTP status reason text.

Closes #490
