### PR TITLE
Fix system_exit in HttpServer

### DIFF
--- a/src/server/http.rs
+++ b/src/server/http.rs
@@ -73,7 +73,7 @@ where
             backlog: 2048,
             keep_alive: KeepAlive::Os,
             shutdown_timeout: 30,
-            exit: true,
+            exit: false,
             no_http2: false,
             no_signals: false,
             maxconn: 102_400,


### PR DESCRIPTION
This fixes a bug that prevents disabling system exit on `HttpServer` shutdown. The default for `exit` was set to _true_ where it should be _false_ (see [Server](https://github.com/actix/actix-web/blob/4ca9fd2ad165118d79be478fac0a6bd5750c1cc7/src/server/server.rs#L90) for reference). The default should be _false_ since [signals would set it to true later](https://github.com/actix/actix-web/blob/4ca9fd2ad165118d79be478fac0a6bd5750c1cc7/src/server/server.rs#L288) and there is no other way to turn it off otherwise.

This bug occurs when signals are disabled `HttpServer::disable_signals` but `HttpServer::system_exit` is **not** called. 

Please let me know if you'd need me to contribute a test case for this.