### PR TITLE
Refactor resource route parsing to allow repetition in the regexes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@
 ### Fixed
 
 * Fix system_exit in HttpServer #501
-
+* Fix parsing of route param containin regexes with repetition #500
 
 ## [0.7.5] - 2018-09-04
 


### PR DESCRIPTION
This should fix issue #500.

Please check if it is returning `len` correctly as I didn't follow the logic of this parameter.