### PR TITLE
Reduce code covered by `unsafe` blocks

### DIFF
--- a/src/server/channel.rs
+++ b/src/server/channel.rs
@@ -209,31 +209,35 @@ impl<T> Node<T> {
     }
 
     fn insert<I>(&mut self, next_el: &mut Node<I>) {
-        unsafe {
-            let next: *mut Node<T> = next_el as *const _ as *mut _;
+        let next: *mut Node<T> = next_el as *const _ as *mut _;
 
-            if let Some(next2) = self.next {
+        if let Some(next2) = self.next {
+            unsafe {
                 let n = next2.as_mut().unwrap();
                 n.prev = Some(next);
-                next_el.next = Some(next2 as *mut _);
             }
-            self.next = Some(next);
+            next_el.next = Some(next2 as *mut _);
+        }
+        self.next = Some(next);
 
+        unsafe {
             let next: &mut Node<T> = &mut *next;
             next.prev = Some(self as *mut _);
         }
     }
 
     fn remove(&mut self) {
-        unsafe {
-            self.element = ptr::null_mut();
-            let next = self.next.take();
-            let prev = self.prev.take();
+        self.element = ptr::null_mut();
+        let next = self.next.take();
+        let prev = self.prev.take();
 
-            if let Some(prev) = prev {
+        if let Some(prev) = prev {
+            unsafe {
                 prev.as_mut().unwrap().next = next;
             }
-            if let Some(next) = next {
+        }
+        if let Some(next) = next {
+            unsafe {
                 next.as_mut().unwrap().prev = prev;
             }
         }

--- a/src/server/helpers.rs
+++ b/src/server/helpers.rs
@@ -29,20 +29,24 @@ pub(crate) fn write_status_line(version: Version, mut n: u16, bytes: &mut BytesM
     let lut_ptr = DEC_DIGITS_LUT.as_ptr();
     let four = n > 999;
 
+    // decode 2 more chars, if > 2 chars
+    let d1 = (n % 100) << 1;
+    n /= 100;
+    curr -= 2;
     unsafe {
-        // decode 2 more chars, if > 2 chars
-        let d1 = (n % 100) << 1;
-        n /= 100;
-        curr -= 2;
         ptr::copy_nonoverlapping(lut_ptr.offset(d1 as isize), buf_ptr.offset(curr), 2);
+    }
 
-        // decode last 1 or 2 chars
-        if n < 10 {
-            curr -= 1;
+    // decode last 1 or 2 chars
+    if n < 10 {
+        curr -= 1;
+        unsafe {
             *buf_ptr.offset(curr) = (n as u8) + b'0';
-        } else {
-            let d1 = n << 1;
-            curr -= 2;
+        }
+    } else {
+        let d1 = n << 1;
+        curr -= 2;
+        unsafe {
             ptr::copy_nonoverlapping(
                 lut_ptr.offset(d1 as isize),
                 buf_ptr.offset(curr),
@@ -107,47 +111,55 @@ pub fn write_content_length(mut n: usize, bytes: &mut BytesMut) {
 }
 
 pub(crate) fn convert_usize(mut n: usize, bytes: &mut BytesMut) {
-    unsafe {
-        let mut curr: isize = 39;
-        let mut buf: [u8; 41] = mem::uninitialized();
-        buf[39] = b'\r';
-        buf[40] = b'\n';
-        let buf_ptr = buf.as_mut_ptr();
-        let lut_ptr = DEC_DIGITS_LUT.as_ptr();
+    let mut curr: isize = 39;
+    let mut buf: [u8; 41] = unsafe { mem::uninitialized() };
+    buf[39] = b'\r';
+    buf[40] = b'\n';
+    let buf_ptr = buf.as_mut_ptr();
+    let lut_ptr = DEC_DIGITS_LUT.as_ptr();
 
-        // eagerly decode 4 characters at a time
-        while n >= 10_000 {
-            let rem = (n % 10_000) as isize;
-            n /= 10_000;
+    // eagerly decode 4 characters at a time
+    while n >= 10_000 {
+        let rem = (n % 10_000) as isize;
+        n /= 10_000;
 
-            let d1 = (rem / 100) << 1;
-            let d2 = (rem % 100) << 1;
-            curr -= 4;
+        let d1 = (rem / 100) << 1;
+        let d2 = (rem % 100) << 1;
+        curr -= 4;
+        unsafe {
             ptr::copy_nonoverlapping(lut_ptr.offset(d1), buf_ptr.offset(curr), 2);
             ptr::copy_nonoverlapping(lut_ptr.offset(d2), buf_ptr.offset(curr + 2), 2);
         }
+    }
 
-        // if we reach here numbers are <= 9999, so at most 4 chars long
-        let mut n = n as isize; // possibly reduce 64bit math
+    // if we reach here numbers are <= 9999, so at most 4 chars long
+    let mut n = n as isize; // possibly reduce 64bit math
 
-        // decode 2 more chars, if > 2 chars
-        if n >= 100 {
-            let d1 = (n % 100) << 1;
-            n /= 100;
-            curr -= 2;
+    // decode 2 more chars, if > 2 chars
+    if n >= 100 {
+        let d1 = (n % 100) << 1;
+        n /= 100;
+        curr -= 2;
+        unsafe {
             ptr::copy_nonoverlapping(lut_ptr.offset(d1), buf_ptr.offset(curr), 2);
         }
+    }
 
-        // decode last 1 or 2 chars
-        if n < 10 {
-            curr -= 1;
+    // decode last 1 or 2 chars
+    if n < 10 {
+        curr -= 1;
+        unsafe {
             *buf_ptr.offset(curr) = (n as u8) + b'0';
-        } else {
-            let d1 = n << 1;
-            curr -= 2;
+        }
+    } else {
+        let d1 = n << 1;
+        curr -= 2;
+        unsafe {
             ptr::copy_nonoverlapping(lut_ptr.offset(d1), buf_ptr.offset(curr), 2);
         }
+    }
 
+    unsafe {
         bytes.extend_from_slice(slice::from_raw_parts(
             buf_ptr.offset(curr),
             41 - curr as usize,

--- a/src/uri.rs
+++ b/src/uri.rs
@@ -148,7 +148,7 @@ impl Quoter {
         if let Some(data) = cloned {
             // Unsafe: we get data from http::Uri, which does utf-8 checks already
             // this code only decodes valid pct encoded values
-            Some(unsafe { Rc::new(String::from_utf8_unchecked(data)) })
+            Some(Rc::new(unsafe { String::from_utf8_unchecked(data) }))
         } else {
             None
         }


### PR DESCRIPTION
Feel free to reject this if its overly pedantic, but I noticed that some of the `unsafe` blocks in the code covered more than they needed to, so I've tried to split them up and reduce the total lines covered by `unsafe` blocks. This means that there are more `unsafe` blocks than there were before however, but I don't think thats an especially good way of measuring code soundness.