### PR TITLE
content-length bug fix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,7 +19,7 @@
 
 * Websocket server finished() isn't called if client disconnects #511
 
-* A responses with the following codes: 100, 101, 102, 204 -- are sent without Content-Length header. #521
+* Responses with the following codes: 100, 101, 102, 204 -- are sent without Content-Length header. #521
 
 
 ## [0.7.8] - 2018-09-17

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,8 @@
 
 * Websocket server finished() isn't called if client disconnects #511
 
+* A responses with the following codes: 100, 101, 102, 204 -- are sent without Content-Length header. #521
+
 
 ## [0.7.8] - 2018-09-17
 


### PR DESCRIPTION
Now responses with the following codes: 100, 101, 102, 204 -- are sent without Content-Length header.

Fixes #521