### PR TITLE
Fix no_http2 flag in HttpServer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@
 
 * Responses with the following codes: 100, 101, 102, 204 -- are sent without Content-Length header. #521
 
+* Correct usage of `no_http2` flag in `bind_*` methods. #519
 
 ## [0.7.8] - 2018-09-17
 

--- a/src/server/http.rs
+++ b/src/server/http.rs
@@ -414,7 +414,7 @@ where
         use actix_net::service::NewServiceExt;
 
         // alpn support
-        let flags = if !self.no_http2 {
+        let flags = if self.no_http2 {
             ServerFlags::HTTP1
         } else {
             ServerFlags::HTTP1 | ServerFlags::HTTP2
@@ -437,7 +437,7 @@ where
         use actix_net::service::NewServiceExt;
 
         // alpn support
-        let flags = if !self.no_http2 {
+        let flags = if self.no_http2 {
             ServerFlags::HTTP1
         } else {
             ServerFlags::HTTP1 | ServerFlags::HTTP2


### PR DESCRIPTION
While these methods are going to get deprecated, they are still incorrectly interpreter `no_http2` flag 😄 

Fixes #519