### PR TITLE
Added HTTP Authentication for Client

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+## [0.7.19] - 2019-04-19
+
+* Added client HTTP Authentication methods `.basic_auth()`  and `.bearer_auth()`. #540
+
 ## [0.7.11] - 2018-10-09
 
 ### Fixed

--- a/src/client/request.rs
+++ b/src/client/request.rs
@@ -12,6 +12,7 @@ use serde::Serialize;
 use serde_json;
 use serde_urlencoded;
 use url::Url;
+use base64::encode;
 
 use super::connector::{ClientConnector, Connection};
 use super::pipeline::SendRequest;
@@ -482,6 +483,29 @@ impl ClientRequestBuilder {
             };
         }
         self
+    }
+
+    /// Set HTTP basic authorization
+    pub fn basic_auth<U, P>(&mut self, username: U, password: Option<P>) -> &mut Self 
+    where 
+        U: fmt::Display,
+        P: fmt::Display,
+    {
+        let auth = match password {
+            Some(password) => format!("{}:{}", username, password),
+            None => format!("{}", username)
+        };
+        let header_value = format!("Basic {}", encode(&auth));
+        self.header(header::AUTHORIZATION, &*header_value)
+    }
+
+    /// Set HTTP bearer authentication
+    pub fn bearer_auth<T>( &mut self, token: T) -> &mut Self
+    where 
+        T: fmt::Display,
+    {
+        let header_value = format!("Bearer {}", token);
+        self.header(header::AUTHORIZATION, &*header_value)
     }
 
     /// Set content length

--- a/tests/test_client.rs
+++ b/tests/test_client.rs
@@ -506,3 +506,31 @@ fn client_read_until_eof() {
     let bytes = sys.block_on(response.body()).unwrap();
     assert_eq!(bytes, Bytes::from_static(b"welcome!"));
 }
+
+#[test]
+fn client_basic_auth() {
+    let mut srv =
+        test::TestServer::new(|app| app.handler(|_| HttpResponse::Ok().body(STR)));
+
+    let request = srv
+                    .get()
+                    .basic_auth("username",Some("password"))
+                    .finish()
+                    .unwrap();
+    let repr = format!("{:?}", request);
+    assert!(repr.contains("Basic dXNlcm5hbWU6cGFzc3dvcmQ="));
+}
+
+#[test]
+fn client_bearer_auth() {
+    let mut srv =
+        test::TestServer::new(|app| app.handler(|_| HttpResponse::Ok().body(STR)));
+
+    let request = srv
+                    .get()
+                    .bearer_auth("someS3cr3tAutht0k3n")
+                    .finish()
+                    .unwrap();
+    let repr = format!("{:?}", request);
+    assert!(repr.contains("Bearer someS3cr3tAutht0k3n"));
+}

--- a/tests/test_client.rs
+++ b/tests/test_client.rs
@@ -511,10 +511,10 @@ fn client_read_until_eof() {
 fn client_basic_auth() {
     let mut srv =
         test::TestServer::new(|app| app.handler(|_| HttpResponse::Ok().body(STR)));
-
+    /// set authorization header to Basic <base64 encoded username:password>
     let request = srv
                     .get()
-                    .basic_auth("username",Some("password"))
+                    .basic_auth("username", Some("password"))
                     .finish()
                     .unwrap();
     let repr = format!("{:?}", request);
@@ -525,7 +525,7 @@ fn client_basic_auth() {
 fn client_bearer_auth() {
     let mut srv =
         test::TestServer::new(|app| app.handler(|_| HttpResponse::Ok().body(STR)));
-
+    /// set authorization header to Bearer <token>
     let request = srv
                     .get()
                     .bearer_auth("someS3cr3tAutht0k3n")


### PR DESCRIPTION
#535 
Attempting to add support for HTTP basic and beaer authentication for the http client. While this could be done manually, I felt it was a common enough thing to have to be their own functions respectively.

side note, first pull request ever.