### PR TITLE
add a way to configure error treatment for Query extractor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@
 
 * HttpServer now treats streaming bodies the same for HTTP/1.x protocols. #549
 
+### Added
+
+* Add method to configure custom error handler to `Query` and `Path` extractors.
+
 ## [0.7.13] - 2018-10-14
 
 ### Fixed


### PR DESCRIPTION
The goal is to be able to reply with an error explaining the issue to help the caller fix her call

```rust
#[derive(Debug, Serialize, Deserialize)]
struct MyObj {
    name: String,
    number: i32,
}

fn extract_item(item: Query<MyObj>) -> HttpResponse {
    println!("model: {:?}", &item);
    HttpResponse::Ok().json("ok")
}

fn main() {
    server::new(|| {
        App::new()
            .resource("/qp", |r| r.method(http::Method::GET).with(extract_item))
            .resource("/qp2", |r| {
                r.method(http::Method::GET)
                    .with_config(extract_item, |cfg| {
                        cfg.0.error_handler(|e, _| {
                            error::InternalError::from_response(
                                "missing query parameter",
                                HttpResponse::build(StatusCode::BAD_REQUEST).body(format!("{}", e)),
                            ).into()
                        });
                    })
            })
    }).bind("127.0.0.1:8080")
    .unwrap()
    .run();
}
```

```
> curl -i localhost:8080/qp\?name=1
HTTP/1.1 400 Bad Request
content-length: 0
date: Mon, 15 Oct 2018 17:57:38 GMT

> curl -i localhost:8080/qp2\?name=1
HTTP/1.1 400 Bad Request
content-length: 22
date: Mon, 15 Oct 2018 17:57:32 GMT

missing field `number`
```