### PR TITLE
Use old clippy attributes syntax

### DIFF
--- a/src/client/connector.rs
+++ b/src/client/connector.rs
@@ -287,7 +287,7 @@ impl Default for ClientConnector {
             }
         };
 
-        #[cfg_attr(feature = "cargo-clippy", allow(clippy::let_unit_value))]
+        #[cfg_attr(feature = "cargo-clippy", allow(let_unit_value))]
         ClientConnector::with_connector_impl(connector)
     }
 }

--- a/src/client/writer.rs
+++ b/src/client/writer.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(
     feature = "cargo-clippy",
-    allow(clippy::redundant_field_names)
+    allow(redundant_field_names)
 )]
 
 use std::cell::RefCell;

--- a/src/httpresponse.rs
+++ b/src/httpresponse.rs
@@ -694,7 +694,7 @@ impl HttpResponseBuilder {
 }
 
 #[inline]
-#[cfg_attr(feature = "cargo-clippy", allow(clippy::borrowed_box))]
+#[cfg_attr(feature = "cargo-clippy", allow(borrowed_box))]
 fn parts<'a>(
     parts: &'a mut Option<Box<InnerHttpResponse>>, err: &Option<HttpError>,
 ) -> Option<&'a mut Box<InnerHttpResponse>> {

--- a/src/info.rs
+++ b/src/info.rs
@@ -18,7 +18,7 @@ impl ConnectionInfo {
     /// Create *ConnectionInfo* instance for a request.
     #[cfg_attr(
         feature = "cargo-clippy",
-        allow(clippy::cyclomatic_complexity)
+        allow(cyclomatic_complexity)
     )]
     pub fn update(&mut self, req: &Request) {
         let mut host = None;

--- a/src/middleware/defaultheaders.rs
+++ b/src/middleware/defaultheaders.rs
@@ -48,7 +48,7 @@ impl DefaultHeaders {
 
     /// Set a header.
     #[inline]
-    #[cfg_attr(feature = "cargo-clippy", allow(clippy::match_wild_err_arm))]
+    #[cfg_attr(feature = "cargo-clippy", allow(match_wild_err_arm))]
     pub fn header<K, V>(mut self, key: K, value: V) -> Self
     where
         HeaderName: HttpTryFrom<K>,

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -61,7 +61,7 @@ pub struct Scope<S> {
 
 #[cfg_attr(
     feature = "cargo-clippy",
-    allow(clippy::new_without_default_derive)
+    allow(new_without_default_derive)
 )]
 impl<S: 'static> Scope<S> {
     /// Create a new scope

--- a/src/server/h2writer.rs
+++ b/src/server/h2writer.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(
     feature = "cargo-clippy",
-    allow(clippy::redundant_field_names)
+    allow(redundant_field_names)
 )]
 
 use std::{cmp, io};

--- a/src/server/http.rs
+++ b/src/server/http.rs
@@ -326,7 +326,7 @@ where
     #[doc(hidden)]
     #[cfg_attr(
         feature = "cargo-clippy",
-        allow(clippy::needless_pass_by_value)
+        allow(needless_pass_by_value)
     )]
     pub fn bind_with<S, A>(mut self, addr: S, acceptor: A) -> io::Result<Self>
     where

--- a/src/server/output.rs
+++ b/src/server/output.rs
@@ -438,7 +438,7 @@ impl ContentEncoder {
         }
     }
 
-    #[cfg_attr(feature = "cargo-clippy", allow(clippy::inline_always))]
+    #[cfg_attr(feature = "cargo-clippy", allow(inline_always))]
     #[inline(always)]
     pub fn write_eof(&mut self) -> Result<bool, io::Error> {
         let encoder =
@@ -480,7 +480,7 @@ impl ContentEncoder {
         }
     }
 
-    #[cfg_attr(feature = "cargo-clippy", allow(clippy::inline_always))]
+    #[cfg_attr(feature = "cargo-clippy", allow(inline_always))]
     #[inline(always)]
     pub fn write(&mut self, data: &[u8]) -> Result<(), io::Error> {
         match *self {

--- a/src/ws/frame.rs
+++ b/src/ws/frame.rs
@@ -46,7 +46,7 @@ impl Frame {
         Frame::message(payload, OpCode::Close, true, genmask)
     }
 
-    #[cfg_attr(feature = "cargo-clippy", allow(clippy::type_complexity))]
+    #[cfg_attr(feature = "cargo-clippy", allow(type_complexity))]
     fn read_copy_md<S>(
         pl: &mut PayloadBuffer<S>, server: bool, max_size: usize,
     ) -> Poll<Option<(usize, bool, OpCode, usize, Option<u32>)>, ProtocolError>

--- a/src/ws/mask.rs
+++ b/src/ws/mask.rs
@@ -1,5 +1,5 @@
 //! This is code from [Tungstenite project](https://github.com/snapview/tungstenite-rs)
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::cast_ptr_alignment))]
+#![cfg_attr(feature = "cargo-clippy", allow(cast_ptr_alignment))]
 use std::ptr::copy_nonoverlapping;
 use std::slice;
 
@@ -19,7 +19,7 @@ impl<'a> ShortSlice<'a> {
 
 /// Faster version of `apply_mask()` which operates on 8-byte blocks.
 #[inline]
-#[cfg_attr(feature = "cargo-clippy", allow(clippy::cast_lossless))]
+#[cfg_attr(feature = "cargo-clippy", allow(cast_lossless))]
 pub(crate) fn apply_mask(buf: &mut [u8], mask_u32: u32) {
     // Extend the mask to 64 bits
     let mut mask_u64 = ((mask_u32 as u64) << 32) | (mask_u32 as u64);
@@ -52,7 +52,7 @@ pub(crate) fn apply_mask(buf: &mut [u8], mask_u32: u32) {
 // a `ShortSlice` must be smaller than a u64.
 #[cfg_attr(
     feature = "cargo-clippy",
-    allow(clippy::needless_pass_by_value)
+    allow(needless_pass_by_value)
 )]
 fn xor_short(buf: ShortSlice, mask: u64) {
     // Unsafe: we know that a `ShortSlice` fits in a u64


### PR DESCRIPTION
As far as I can see, "old" syntax works both with nightly and stable clippy.

Closes #561.