### PR TITLE
decode reserved characters when extracting path with configuration

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,9 @@
 
 * Add method to configure `SameSite` option in `CookieIdentityPolicy`.
 
+* By default, `Path` extractor now percent decode all characters. This behaviour can be disabled
+  with `PathConfig::default().disable_decoding()`
+
 
 ### Fixed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,12 @@
 
 * `QueryConfig` and `PathConfig` are made public.
 
+### Added
+
+* By default, `Path` extractor now percent decode all characters. This behaviour can be disabled
+  with `PathConfig::default().disable_decoding()`
+
+
 ## [0.7.14] - 2018-11-14
 
 ### Added

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,3 +1,31 @@
+## 0.7.14
+
+* The `' '` character is not percent decoded anymore before matching routes. If you need to use it in
+  your routes, you should use `%20`.
+
+  instead of
+
+    ```rust
+    fn main() {
+         let app = App::new().resource("/my index", |r| {
+             r.method(http::Method::GET)
+                    .with(index);
+         });
+    }
+    ```
+
+  use
+
+    ```rust
+    fn main() {
+         let app = App::new().resource("/my%20index", |r| {
+             r.method(http::Method::GET)
+                    .with(index);
+         });
+    }
+    ```
+
+
 ## 0.7.4
 
 * `Route::with_config()`/`Route::with_async_config()` always passes configuration objects as tuple

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,4 +1,4 @@
-## 0.7.14
+## 0.7.15
 
 * The `' '` character is not percent decoded anymore before matching routes. If you need to use it in
   your routes, you should use `%20`.

--- a/src/de.rs
+++ b/src/de.rs
@@ -19,8 +19,8 @@ macro_rules! unsupported_type {
 macro_rules! percent_decode_if_needed {
     ($value:expr, $decode:expr) => {
         if $decode {
-            if let Some(ref value) = RESERVED_QUOTER.requote($value.as_bytes()) {
-                Rc::make_mut(&mut value.clone()).parse()
+            if let Some(ref mut value) = RESERVED_QUOTER.requote($value.as_bytes()) {
+                Rc::make_mut(value).parse()
             } else {
                 $value.parse()
             }

--- a/src/extractor.rs
+++ b/src/extractor.rs
@@ -18,7 +18,8 @@ use httpmessage::{HttpMessage, MessageBody, UrlEncoded};
 use httprequest::HttpRequest;
 
 #[derive(PartialEq, Eq, PartialOrd, Ord)]
-/// Extract typed information from the request's path.
+/// Extract typed information from the request's path. Information from the path is
+/// URL decoded. Decoding of special characters can be disabled through `PathConfig`.
 ///
 /// ## Example
 ///
@@ -161,7 +162,7 @@ impl<S> PathConfig<S> {
         self
     }
 
-    /// Disable decoding
+    /// Disable decoding of URL encoded special charaters from the path
     pub fn disable_decoding(&mut self) -> &mut Self
     {
         self.decode = false;

--- a/src/param.rs
+++ b/src/param.rs
@@ -8,7 +8,7 @@ use http::StatusCode;
 use smallvec::SmallVec;
 
 use error::{InternalError, ResponseError, UriSegmentError};
-use uri::Url;
+use uri::{Url, RESERVED_QUOTER};
 
 /// A trait to abstract the idea of creating a new instance of a type from a
 /// path parameter.
@@ -101,6 +101,17 @@ impl Params {
         } else {
             None
         }
+    }
+
+    /// Get URL-decoded matched parameter by name without type conversion
+    pub fn get_decoded(&self, key: &str) -> Option<String> {
+        self.get(key).map(|value| {
+            if let Some(ref mut value) = RESERVED_QUOTER.requote(value.as_bytes()) {
+                Rc::make_mut(value).to_string()
+            } else {
+                value.to_string()
+            }
+        })
     }
 
     /// Get unprocessed part of path
@@ -298,6 +309,26 @@ mod tests {
         assert_eq!(
             PathBuf::from_param("/seg1/../seg2/"),
             Ok(PathBuf::from_iter(vec!["seg2"]))
+        );
+    }
+
+    #[test]
+    fn test_get_param_by_name() {
+        let mut params = Params::new();
+        params.add_static("item1", "path");
+        params.add_static("item2", "http%3A%2F%2Flocalhost%3A80%2Ffoo");
+
+        assert_eq!(params.get("item0"), None);
+        assert_eq!(params.get_decoded("item0"), None);
+        assert_eq!(params.get("item1"), Some("path"));
+        assert_eq!(params.get_decoded("item1"), Some("path".to_string()));
+        assert_eq!(
+            params.get("item2"),
+            Some("http%3A%2F%2Flocalhost%3A80%2Ffoo")
+        );
+        assert_eq!(
+            params.get_decoded("item2"),
+            Some("http://localhost:80/foo".to_string())
         );
     }
 }

--- a/src/uri.rs
+++ b/src/uri.rs
@@ -10,9 +10,9 @@ const SUB_DELIMS: &[u8] = b"!$'()*,+?=;";
 
 // https://tools.ietf.org/html/rfc3986#section-2.2
 #[allow(dead_code)]
-const RESERVED: &[u8] = b":/?#[]@!$'()*,+?=;";
+const RESERVED: &[u8] = b":/?#[]@!$&'()*,+?;=";
 #[allow(dead_code)]
-const RESERVED_PLUS_PERCENT: &[u8] = b":/?#[]@!$'()*,+?=;%";
+const RESERVED_PLUS_EXTRA: &[u8] = b":/?#[]@!$&'()*,+?;=%^ <>\"\\`{}|";
 
 // https://tools.ietf.org/html/rfc3986#section-2.3
 #[allow(dead_code)]
@@ -39,7 +39,7 @@ fn set_bit(array: &mut [u8], ch: u8) {
 
 lazy_static! {
     static ref UNRESERVED_QUOTER: Quoter = { Quoter::new(UNRESERVED, b"") };
-    pub(crate) static ref RESERVED_QUOTER: Quoter = { Quoter::new(RESERVED_PLUS_PERCENT, b"") };
+    pub(crate) static ref RESERVED_QUOTER: Quoter = { Quoter::new(RESERVED_PLUS_EXTRA, b"") };
 }
 
 #[derive(Default, Clone, Debug)]

--- a/tests/test_handlers.rs
+++ b/tests/test_handlers.rs
@@ -672,6 +672,6 @@ fn test_unsafe_path_route() {
     let bytes = srv.execute(response.body()).unwrap();
     assert_eq!(
         bytes,
-        Bytes::from_static(b"success: http:%2F%2Fexample.com")
+        Bytes::from_static(b"success: http%3A%2F%2Fexample.com")
     );
 }


### PR DESCRIPTION
concerning #556

I limited default decoding to unreserved characters as per [RFC3986](
https://tools.ietf.org/html/rfc3986#section-2.4) those can be decoded anytime.

I then added an option to path extractor (enabled by default) to also decoded the reserved characters.

I'm open to discussion if you think anything can be improved