### PR TITLE
Reset keepalive timer when it required

### DIFF
--- a/src/server/h1.rs
+++ b/src/server/h1.rs
@@ -560,6 +560,7 @@ where
 
         if self.ka_timer.is_some() && updated {
             if let Some(expire) = self.settings.keep_alive_expire() {
+                self.ka_timer.as_mut().unwrap().reset(expire);
                 self.ka_expire = expire;
             }
         }


### PR DESCRIPTION
This PR fix #439 keepalive connection .

In the current master implementation, keepalive expire time is updated without a reset keepalive timer. If a timer's firing time occurs during within keepalive, a connection remains until next request, and is closed with RST (means without handle the request).