### PR TITLE
Change htmlescape in favor of askama_escape

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,11 +64,11 @@ cell = ["actix-net/cell"]
 actix = "^0.7.5"
 actix-net = "^0.1.1"
 
+askama_escape = "0.1.0"
 base64 = "0.10"
 bitflags = "1.0"
 failure = "^0.1.2"
 h2 = "0.1"
-htmlescape = "0.3"
 http = "^0.1.8"
 httparse = "1.3"
 log = "0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,9 +100,9 @@ extern crate failure;
 extern crate lazy_static;
 #[macro_use]
 extern crate futures;
+extern crate askama_escape;
 extern crate cookie;
 extern crate futures_cpupool;
-extern crate htmlescape;
 extern crate http as modhttp;
 extern crate httparse;
 extern crate language_tags;


### PR DESCRIPTION
I have adjusted the lifetime of `file_name` and `file_url` because they did not need beyond the if.