### PR TITLE
Allow user to provide addr to custom resolver

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 ## Changed
 
+* `ClientConnector::resolver` now accepts `Into<Recipient>` instead of `Addr`. It enables user to implement own resolver.
+
 * `QueryConfig` and `PathConfig` are made public.
 
 ## [0.7.14] - 2018-11-14

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ flate2-rust = ["flate2/rust_backend"]
 cell = ["actix-net/cell"]
 
 [dependencies]
-actix = "0.7.6"
+actix = "0.7.7"
 actix-net = "0.2.2"
 
 askama_escape = "0.1.0"


### PR DESCRIPTION
We basically swaps Addr with Recipient to enable user to use custom resolver

Closes #599

It is technically a breaking change, but with `Into` impl for `Addr` there should be no breakage of user code

Should be possible for user to define own resolver after commit https://github.com/actix/actix/commit/d51c9eac33ffa924e4002bc0ffbae9d9b63a46be