### PR TITLE
Static Files refactoring

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Changes
 
+## [0.8.0] - 2019-xx-xx
+
+## Changed
+
+* `StaticFiles` no longer redirects to index file and instead attempts to return its content
+
+* `StaticFiles` configuration is moved to `StaticFileConfig` completely.
+
 ## [0.7.15] - 2018-xx-xx
 
 ## Changed

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,3 +1,12 @@
+## 0.8.0
+
+`StaticFiles` configuration methods are removed:
+
+- `show_files_listing` - use custom configuration with `StaticFileConfig::show_index`
+- `files_listing_renderer` - use custom configuration with `StaticFileConfig::directory_listing`
+- `index_file` - use custom configuration with `StaticFileConfig::index_file`
+- `default_handler` - use custom configuration with `StaticFileConfig::default_handler`
+
 ## 0.7.15
 
 * The `' '` character is not percent decoded anymore before matching routes. If you need to use it in
@@ -36,9 +45,9 @@
 
 * `HttpRequest` does not implement `Stream` anymore. If you need to read request payload
   use `HttpMessage::payload()` method.
-  
+
   instead of
-  
+
     ```rust
     fn index(req: HttpRequest) -> impl Responder {
          req
@@ -64,8 +73,8 @@
   trait uses `&HttpRequest` instead of `&mut HttpRequest`.
 
 * Removed `Route::with2()` and `Route::with3()` use tuple of extractors instead.
-    
-    instead of 
+
+    instead of
 
     ```rust
     fn index(query: Query<..>, info: Json<MyStruct) -> impl Responder {}
@@ -81,7 +90,7 @@
 
 * `Handler::handle()` accepts reference to `HttpRequest<_>` instead of value
 
-* Removed deprecated `HttpServer::threads()`, use 
+* Removed deprecated `HttpServer::threads()`, use
   [HttpServer::workers()](https://actix.rs/actix-web/actix_web/server/struct.HttpServer.html#method.workers) instead.
 
 * Renamed `client::ClientConnectorError::Connector` to
@@ -90,7 +99,7 @@
 * `Route::with()` does not return `ExtractorConfig`, to configure
   extractor use `Route::with_config()`
 
-    instead of 
+    instead of
 
     ```rust
     fn main() {
@@ -101,11 +110,11 @@
          });
     }
     ```
-    
-    use 
-    
+
+    use
+
     ```rust
-  
+
     fn main() {
          let app = App::new().resource("/index.html", |r| {
              r.method(http::Method::GET)
@@ -135,12 +144,12 @@
 * `HttpRequest::extensions()` returns read only reference to the request's Extension
   `HttpRequest::extensions_mut()` returns mutable reference.
 
-* Instead of 
+* Instead of
 
    `use actix_web::middleware::{
         CookieSessionBackend, CookieSessionError, RequestSession,
         Session, SessionBackend, SessionImpl, SessionStorage};`
-                                
+
   use `actix_web::middleware::session`
 
    `use actix_web::middleware::session{CookieSessionBackend, CookieSessionError,


### PR DESCRIPTION
This PR is prepared for eventual 0.8 as it contains breaking changes:

1. Redirect now is replaced with return of index file content, if any. Closes #557
2. All configuration is moved to `StaticFilesConfig`, when approved, need to update book

@fafhrd91 If  you're ok with it, I'll prepare CHANGES.md and MIGRATION.md