### PR TITLE
impl `From<Cow<'static, [u8]>>` for `Binary`

### DIFF
--- a/src/body.rs
+++ b/src/body.rs
@@ -210,6 +210,15 @@ impl From<String> for Binary {
     }
 }
 
+impl From<Cow<'static, str>> for Binary {
+    fn from(s: Cow<'static, str>) -> Binary {
+        match s {
+            Cow::Borrowed(s) => Binary::Slice(s.as_ref()),
+            Cow::Owned(s) => Binary::Bytes(Bytes::from(s)),
+        }
+    }
+}
+
 impl<'a> From<&'a String> for Binary {
     fn from(s: &'a String) -> Binary {
         Binary::Bytes(Bytes::from(AsRef::<[u8]>::as_ref(&s)))
@@ -298,6 +307,16 @@ mod tests {
     }
 
     #[test]
+    fn test_cow_str() {
+        let cow: Cow<'static, str> = Cow::Borrowed("test");
+        assert_eq!(Binary::from(cow.clone()).len(), 4);
+        assert_eq!(Binary::from(cow.clone()).as_ref(), b"test");
+        let cow: Cow<'static, str> = Cow::Owned("test".to_owned());
+        assert_eq!(Binary::from(cow.clone()).len(), 4);
+        assert_eq!(Binary::from(cow.clone()).as_ref(), b"test");
+    }
+
+    #[test]
     fn test_static_bytes() {
         assert_eq!(Binary::from(b"test".as_ref()).len(), 4);
         assert_eq!(Binary::from(b"test".as_ref()).as_ref(), b"test");
@@ -315,6 +334,16 @@ mod tests {
     fn test_bytes() {
         assert_eq!(Binary::from(Bytes::from("test")).len(), 4);
         assert_eq!(Binary::from(Bytes::from("test")).as_ref(), b"test");
+    }
+
+    #[test]
+    fn test_cow_bytes() {
+        let cow: Cow<'static, [u8]> = Cow::Borrowed(b"test");
+        assert_eq!(Binary::from(cow.clone()).len(), 4);
+        assert_eq!(Binary::from(cow.clone()).as_ref(), b"test");
+        let cow: Cow<'static, [u8]> = Cow::Owned(Vec::from("test"));
+        assert_eq!(Binary::from(cow.clone()).len(), 4);
+        assert_eq!(Binary::from(cow.clone()).as_ref(), b"test");
     }
 
     #[test]

--- a/src/body.rs
+++ b/src/body.rs
@@ -1,5 +1,6 @@
 use bytes::{Bytes, BytesMut};
 use futures::Stream;
+use std::borrow::Cow;
 use std::sync::Arc;
 use std::{fmt, mem};
 
@@ -191,6 +192,15 @@ impl From<&'static [u8]> for Binary {
 impl From<Vec<u8>> for Binary {
     fn from(vec: Vec<u8>) -> Binary {
         Binary::Bytes(Bytes::from(vec))
+    }
+}
+
+impl From<Cow<'static, [u8]>> for Binary {
+    fn from(b: Cow<'static, [u8]>) -> Binary {
+        match b {
+            Cow::Borrowed(s) => Binary::Slice(s),
+            Cow::Owned(vec) => Binary::Bytes(Bytes::from(vec)),
+        }
     }
 }
 


### PR DESCRIPTION
That way we can return `Cow<'static, [u8]>` from https://github.com/pyros2097/rust-embed and https://docs.rs/actix-web/0.7.14/actix_web/dev/struct.HttpResponseBuilder.html#method.body will chose the most appropiate `Binary` variant. Currently we have to write:
```rust
match Asset::get(path) {
    Some(content) => {
      let body: Body = match content {
        Cow::Borrowed(bytes) => bytes.into(),
        Cow::Owned(bytes) => bytes.into(),
      };
      HttpResponse::Ok().content_type(guess_mime_type(path).as_ref()).body(body)
    }
    None => HttpResponse::NotFound().body("404 Not Found"),
  }
```
With this change this would do the same:
```rust
match Asset::get(path) {
    Some(content) => Ok().content_type(guess_mime_type(path).as_ref()).body(content),
    None => HttpResponse::NotFound().body("404 Not Found"),
}
```

Related discussion https://github.com/pyros2097/rust-embed/issues/26.