### PR TITLE
Remove usage of upcoming keyword async

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@
 
 * `QueryConfig` and `PathConfig` are made public.
 
+* `AsyncResult::async` is changed to `AsyncResult::future` as `async` is reserved keyword in 2018 edition.
+
 ### Added
 
 * By default, `Path` extractor now percent decode all characters. This behaviour can be disabled

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -25,6 +25,8 @@
     }
     ```
 
+* If you used `AsyncResult::async` you need to replace it with `AsyncResult::future`
+
 
 ## 0.7.4
 

--- a/src/client/connector.rs
+++ b/src/client/connector.rs
@@ -942,7 +942,7 @@ impl Handler<Connect> for ClientConnector {
         }
 
         let host = uri.host().unwrap().to_owned();
-        let port = uri.port().unwrap_or_else(|| proto.port());
+        let port = uri.port_part().map(|port| port.as_u16()).unwrap_or_else(|| proto.port());
         let key = Key {
             host,
             port,

--- a/src/client/request.rs
+++ b/src/client/request.rs
@@ -631,7 +631,7 @@ impl ClientRequestBuilder {
                     if !parts.headers.contains_key(header::HOST) {
                         let mut wrt = BytesMut::with_capacity(host.len() + 5).writer();
 
-                        let _ = match parts.uri.port() {
+                        let _ = match parts.uri.port_part().map(|port| port.as_u16()) {
                             None | Some(80) | Some(443) => write!(wrt, "{}", host),
                             Some(port) => write!(wrt, "{}:{}", host, port),
                         };

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -250,7 +250,7 @@ pub(crate) enum AsyncResultItem<I, E> {
 impl<I, E> AsyncResult<I, E> {
     /// Create async response
     #[inline]
-    pub fn async(fut: Box<Future<Item = I, Error = E>>) -> AsyncResult<I, E> {
+    pub fn future(fut: Box<Future<Item = I, Error = E>>) -> AsyncResult<I, E> {
         AsyncResult(Some(AsyncResultItem::Future(fut)))
     }
 
@@ -401,7 +401,7 @@ where
                 },
                 Err(e) => err(e),
             });
-        Ok(AsyncResult::async(Box::new(fut)))
+        Ok(AsyncResult::future(Box::new(fut)))
     }
 }
 
@@ -502,7 +502,7 @@ where
                 Err(e) => Either::A(err(e)),
             }
         });
-        AsyncResult::async(Box::new(fut))
+        AsyncResult::future(Box::new(fut))
     }
 }
 

--- a/src/middleware/csrf.rs
+++ b/src/middleware/csrf.rs
@@ -76,7 +76,7 @@ impl ResponseError for CsrfError {
 }
 
 fn uri_origin(uri: &Uri) -> Option<String> {
-    match (uri.scheme_part(), uri.host(), uri.port()) {
+    match (uri.scheme_part(), uri.host(), uri.port_part().map(|port| port.as_u16())) {
         (Some(scheme), Some(host), Some(port)) => {
             Some(format!("{}://{}:{}", scheme, host, port))
         }

--- a/src/route.rs
+++ b/src/route.rs
@@ -57,7 +57,7 @@ impl<S: 'static> Route<S> {
     pub(crate) fn compose(
         &self, req: HttpRequest<S>, mws: Rc<Vec<Box<Middleware<S>>>>,
     ) -> AsyncResult<HttpResponse> {
-        AsyncResult::async(Box::new(Compose::new(req, mws, self.handler.clone())))
+        AsyncResult::future(Box::new(Compose::new(req, mws, self.handler.clone())))
     }
 
     /// Add match predicate to route.

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -356,7 +356,7 @@ impl<S: 'static> RouteHandler<S> for Scope<S> {
         if self.middlewares.is_empty() {
             self.router.handle(&req2)
         } else {
-            AsyncResult::async(Box::new(Compose::new(
+            AsyncResult::future(Box::new(Compose::new(
                 req2,
                 Rc::clone(&self.router),
                 Rc::clone(&self.middlewares),

--- a/src/with.rs
+++ b/src/with.rs
@@ -86,7 +86,7 @@ where
 
         match fut.poll() {
             Ok(Async::Ready(resp)) => AsyncResult::ok(resp),
-            Ok(Async::NotReady) => AsyncResult::async(Box::new(fut)),
+            Ok(Async::NotReady) => AsyncResult::future(Box::new(fut)),
             Err(e) => AsyncResult::err(e),
         }
     }
@@ -208,7 +208,7 @@ where
 
         match fut.poll() {
             Ok(Async::Ready(resp)) => AsyncResult::ok(resp),
-            Ok(Async::NotReady) => AsyncResult::async(Box::new(fut)),
+            Ok(Async::NotReady) => AsyncResult::future(Box::new(fut)),
             Err(e) => AsyncResult::err(e),
         }
     }


### PR DESCRIPTION
AsyncResult::async is replaced with AsyncResult::future

I also removed usage of deprecated `Uri::port` to stop compiler from issuing warnings on it.

Closes #613