### PR TITLE
impl ResponseError for SendError when possible

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+* `SendError` now implements `ResponseError`.
+
 ## [0.7.15] - 2018-12-05
 
 ## Changed

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,7 +5,7 @@ use std::string::FromUtf8Error;
 use std::sync::Mutex;
 use std::{fmt, io, result};
 
-use actix::MailboxError;
+use actix::{MailboxError, SendError};
 use cookie;
 use failure::{self, Backtrace, Fail};
 use futures::Canceled;
@@ -134,6 +134,10 @@ pub trait ResponseError: Fail + InternalResponseErrorAsFail {
     fn error_response(&self) -> HttpResponse {
         HttpResponse::new(StatusCode::INTERNAL_SERVER_ERROR)
     }
+}
+
+impl<T> ResponseError for SendError<T>
+where T: Send + Sync + 'static {
 }
 
 impl fmt::Display for Error {


### PR DESCRIPTION
#528 explains the motivations for this change.

I took the liberty of update the CHANGES.md to include a note on this change, cause I saw some chatter about doing so in other PRs. If I should let the maintenance team do that, or format it in a different way, just let me know.

Closes #528