### PR TITLE
Add static lifetime requirements in StaticFileConfig trait (0.8)

### DIFF
--- a/src/fs.rs
+++ b/src/fs.rs
@@ -109,14 +109,14 @@ pub trait StaticFileConfig: Default {
     /// Directory renderer
     ///
     /// Uses default one, unless re-defined.
-    fn directory_listing<S>(dir: &Directory, req: &HttpRequest<S>) -> Result<HttpResponse, io::Error> {
+    fn directory_listing<S: 'static>(dir: &Directory, req: &HttpRequest<S>) -> Result<HttpResponse, io::Error> {
         directory_listing(dir, req)
     }
 
     /// Default handler for StaticFiles.
     ///
     /// Responses with NotFound by default
-    fn default_handler<S>(_req: &HttpRequest<S>) -> AsyncResult<HttpResponse> {
+    fn default_handler<S: 'static>(_req: &HttpRequest<S>) -> AsyncResult<HttpResponse> {
         HttpResponse::new(StatusCode::NOT_FOUND).into()
     }
 }


### PR DESCRIPTION
I've been looking into actix-web 0.8; recently I found that the StaticFiles API was updated in #604. Before, the `default_handler` method took a `Handler` as an argument, such as [this 404 handler](https://github.com/actix/examples/blob/master/basics/src/main.rs#L49) from the basic actix-web example -- I could just pass `.default_handler(p404)` and it would work fine.

In the 0.8 branch, aside from turning into a trait method, the params for [`default_handler`](https://github.com/actix/actix-web/commit/580dcb8d6fae9276f739b2acfa1c33d47bae7328#diff-b45d845f139c97025a9348344f529958R119) were changed slightly, and I couldn't find a way to modify that handler function accordingly. My best guess was to call `p404(req).unwrap().respond_to(req).into()` in the new trait method, but I got an error saying "the parameter type `S` may not live long enough so that the type `S` will meet its required lifetime bounds". The compiler recommended adding an explicit `'static` lifetime bound on `S`, which wasn't compatible with the `StaticFileConfig` trait definition.

This change makes the above adaptation work as expected.