### PR TITLE
Only return a single Origin value

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 * HTTP1 decoder should perform case-insentive comparison for client requests (e.g. `Keep-Alive`). #631
+* Access-Control-Allow-Origin header should only a return a single, matching origin. #603
 
 ## [0.7.16] - 2018-12-11
 


### PR DESCRIPTION
Browsers do not accept a list of origins in the A-C-A-O header [1] [2] [3]. This pull request returns only a single origin if a match was found.

fixes #603.

[1] https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS/Errors/CORSMultipleAllowOriginNotAllowed
[2] https://www.w3.org/TR/cors/#access-control-allow-origin-response-header
[3] https://cs.chromium.org/chromium/src/services/network/cross_origin_read_blocking.cc?sq=package:chromium&dr=C&g=0&l=245-266