### PR TITLE
Add with-cookie init-method for TestRequest

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Changes
 
+## [0.7.18] - 2019-01-02
+
+### Added
+
+* Add `with_cookie` for `TestRequest` to allow users to customize request cookie. #647
+* Add `cookie` method for `TestRequest` to allow users to add cookie dynamically. 
+
 ## [0.7.17] - 2018-12-25
 
 ### Added

--- a/src/test.rs
+++ b/src/test.rs
@@ -507,6 +507,10 @@ impl TestRequest<()> {
     {
         TestRequest::default().header(key, value)
     }
+    /// Create TestRequest and set request cookie
+    pub fn with_cookie(cookie: Cookie<'static>) -> TestRequest<()> {
+        TestRequest::default().cookie(cookie)
+    }
 }
 
 impl<S: 'static> TestRequest<S> {
@@ -540,6 +544,27 @@ impl<S: 'static> TestRequest<S> {
     /// Set HTTP Uri of this request
     pub fn uri(mut self, path: &str) -> Self {
         self.uri = Uri::from_str(path).unwrap();
+        self
+    }
+
+    /// set cookie of this request
+    pub fn cookie(mut self, cookie: Cookie<'static>) -> Self {
+        let mut should_insert = true;
+        let mut cookies = match self.cookies {
+            Some(old_cookies) => {
+                for old_cookie in &old_cookies {
+                    if old_cookie == &cookie {
+                        should_insert = false
+                    };
+                }
+                old_cookies
+            }
+            None => { Vec::<Cookie>::new() }
+        };
+        if should_insert {
+            cookies.push(cookie)
+        };
+        self.cookies = Some(cookies);
         self
     }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -550,21 +550,19 @@ impl<S: 'static> TestRequest<S> {
     /// set cookie of this request
     pub fn cookie(mut self, cookie: Cookie<'static>) -> Self {
         let mut should_insert = true;
-        let mut cookies = match self.cookies {
+        match &mut self.cookies {
             Some(old_cookies) => {
-                for old_cookie in &old_cookies {
+                for old_cookie in old_cookies.iter() {
                     if old_cookie == &cookie {
                         should_insert = false
                     };
-                }
-                old_cookies
+                };
+                if should_insert {
+                    old_cookies.push(cookie);
+                };
             }
-            None => { Vec::<Cookie>::new() }
+            None => {}
         };
-        if should_insert {
-            cookies.push(cookie)
-        };
-        self.cookies = Some(cookies);
         self
     }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -549,19 +549,19 @@ impl<S: 'static> TestRequest<S> {
 
     /// set cookie of this request
     pub fn cookie(mut self, cookie: Cookie<'static>) -> Self {
-        let mut should_insert = true;
-        match &mut self.cookies {
-            Some(old_cookies) => {
-                for old_cookie in old_cookies.iter() {
-                    if old_cookie == &cookie {
-                        should_insert = false
-                    };
+        if self.cookies.is_none() {
+            let mut should_insert = true;
+            let old_cookies = self.cookies.as_mut().unwrap();
+            for old_cookie in old_cookies.iter() {
+                if old_cookie == &cookie {
+                    should_insert = false
                 };
-                if should_insert {
-                    old_cookies.push(cookie);
-                };
-            }
-            None => {}
+            };
+            if should_insert {
+                old_cookies.push(cookie);
+            };
+        } else {
+            self.cookies = Some(vec![cookie]);
         };
         self
     }

--- a/src/test.rs
+++ b/src/test.rs
@@ -507,6 +507,7 @@ impl TestRequest<()> {
     {
         TestRequest::default().header(key, value)
     }
+
     /// Create TestRequest and set request cookie
     pub fn with_cookie(cookie: Cookie<'static>) -> TestRequest<()> {
         TestRequest::default().cookie(cookie)


### PR DESCRIPTION
Thanks for your great works on actix-web, it's really awesome.
I've made a PR for actix-web's test suite to meet my needs, I'll appreciate that if you could help to review.

# What
+ Add the ability to allow us to add cookie to `test::TestRequest` object

# Why
While writing tests, I want to customized my request cookie to test if the handler can read proper values and compare them to some other value in headers, just like: 

```rust
fn validate_request_token<T>(request: &HttpRequest<T>) -> bool {
    let token_in_cookie = match request.cookie("some-cookie") {
        None => return false,
        Some(c) => c.value().to_owned(),
    };
    // do something with token_in_cookie.
    true
}
```

But in TestRequest ( which located in test.rs), I found that there is no way for us to set cookies for TestRequest and a private method named "set_cookies" seems working for actix-web itself.

So I add a method to help us to add cookie to our TestRequest.

**If test for this feature is required, please let me know, thanks**
 