### PR TITLE
show index if index file doesn't exist

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@
 
 * `StaticFiles` configuration is moved to `StaticFileConfig` completely.
 
+* `StaticFiles` now serves both index file and directory index.
+
 ## [0.7.17] - 2018-xx-xx
 
 ### Fixed

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -749,6 +749,11 @@ impl<C: StaticFileConfig> StaticFiles<C> {
         if path.is_dir() {
             if let Some(redir_index) = C::index_file() {
                 path.push(redir_index);
+                if !path.exists() {
+                    path.pop();
+                    let dir = Directory::new(self.directory.clone(), path);
+                    return Ok(C::directory_listing(&dir, &req)?.into())
+                }
             } else if C::show_index() {
                 let dir = Directory::new(self.directory.clone(), path);
                 return Ok(C::directory_listing(&dir, &req)?.into())

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -749,7 +749,7 @@ impl<C: StaticFileConfig> StaticFiles<C> {
         if path.is_dir() {
             if let Some(redir_index) = C::index_file() {
                 path.push(redir_index);
-                if !path.exists() {
+                if C::show_index() && !path.exists() {
                     path.pop();
                     let dir = Directory::new(self.directory.clone(), path);
                     return Ok(C::directory_listing(&dir, &req)?.into())


### PR DESCRIPTION
Currently, `show_index` is completely ignored if `index_file` is set. It's saner to show index if the designated index file doesn't exist.