### PR TITLE
Improve change askama_escape in favor of v_htmlescape

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ cell = ["actix-net/cell"]
 actix = "0.7.9"
 actix-net = "0.2.6"
 
-askama_escape = "0.1.0"
+v_htmlescape = "0.3.2"
 base64 = "0.10"
 bitflags = "1.0"
 failure = "^0.1.2"

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -11,7 +11,7 @@ use std::{cmp, io};
 #[cfg(unix)]
 use std::os::unix::fs::MetadataExt;
 
-use askama_escape::{escape as escape_html_entity};
+use v_htmlescape::HTMLEscape;
 use bytes::Bytes;
 use futures::{Async, Future, Poll, Stream};
 use futures_cpupool::{CpuFuture, CpuPool};
@@ -567,6 +567,11 @@ macro_rules! encode_file_url {
     ($path:ident) => {
         utf8_percent_encode(&$path.to_string_lossy(), DEFAULT_ENCODE_SET)
     };
+}
+
+#[inline]
+fn escape_html_entity(s: &str) -> HTMLEscape {
+    HTMLEscape::from(s)
 }
 
 // " -- &quot;  & -- &amp;  ' -- &#x27;  < -- &lt;  > -- &gt;  / -- &#x2f;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,6 @@ extern crate failure;
 extern crate lazy_static;
 #[macro_use]
 extern crate futures;
-extern crate askama_escape;
 extern crate cookie;
 extern crate futures_cpupool;
 extern crate http as modhttp;
@@ -137,6 +136,7 @@ extern crate serde_urlencoded;
 extern crate percent_encoding;
 extern crate serde_json;
 extern crate smallvec;
+extern crate v_htmlescape;
 
 extern crate actix_net;
 #[macro_use]


### PR DESCRIPTION
Improves the performance losses of false positives (all no html escapable between ascii 34 and 62) and adds support for SIMD. [Benches on Travis](https://travis-ci.org/rust-iendo/v_htmlescape/jobs/472791580#L688)