### PR TITLE
Fix test server listener thread leak

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@
 
 * StaticFiles decode special characters in request's path
 
+* Fix test server listener leak #654
+
 ## [0.7.17] - 2018-12-25
 
 ### Added


### PR DESCRIPTION
Sends a `actix::actors::signal::SignalType::Term` signal to the TestServer's backend when dropped to prevent leaking listener threads in tests. 

Fixes https://github.com/actix/actix-web/issues/654