### PR TITLE
[src/lib] Expose `application` publicly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,7 +165,6 @@ extern crate webpki;
 #[cfg(feature = "rust-tls")]
 extern crate webpki_roots;
 
-mod application;
 mod body;
 mod context;
 mod de;
@@ -190,6 +189,7 @@ mod scope;
 mod uri;
 mod with;
 
+pub mod application;
 pub mod client;
 pub mod error;
 pub mod fs;


### PR DESCRIPTION
When I develop server-side frameworks, I separate it into multiple files, like
```
$ tree --charset=ascii
.
|-- Cargo.lock
|-- Cargo.toml
|-- actix-diesel-auth-scaffold.iml
`-- src
    |-- auth
    |   `-- routes.rs
    |-- auth.rs
    |-- lib.rs
    |-- main.rs
    `-- user
        `-- routes.rs

3 directories, 8 files
```

Where `main.rs` is:
```rust
use actix_web::{http::Method, server, App, HttpRequest, Path, Responder};

use auth::routes::APP_AUTH;

fn index(_req: HttpRequest) -> impl Responder {
    "Hello from the index page"
}

fn hello(path: Path<String>) -> impl Responder {
    format!("Hello {}!", *path)
}

fn main() {
    let port: u16 = std::env::var("PORT")
        .or(Ok("8000".to_string()) as Result<String, std::env::VarError>)
        .unwrap()
        .parse()
        .unwrap();

    server::new(|| {
        vec![
            App::new()
                .resource("/", |r| r.method(Method::GET).with(index))
                .resource("/hello/{name}", |r| r.method(Method::GET).with(hello))
                .finish(),
            APP_AUTH,
            APP_USER,
        ]
    })
    .bind(format!("127.0.0.1:{}", port))
    .expect(&*format!("Can not bind to port {}", port))
    .run();
}
```

…and auth.rs contains:
```rust
use actix_web::{http::Method, App, application::HttpApplication, HttpRequest, Path, Responder};

fn index(_req: HttpRequest) -> impl Responder {
    "[auth_routes.rs] Hello from the index page"
}

fn hello(path: Path<String>) -> impl Responder {
    format!("[auth_routes.rs] Hello {}!", *path)
}

pub const APP_AUTH: HttpApplication = App::new()
    .resource("/", |r| r.method(Method::GET).with(index))
    .resource("/hello/{name}", |r| r.method(Method::GET).with(hello))
    .finish();
```

Unfortunately, this doesn't work, because `HttpApplication` can't be imported (since its module is private).