### PR TITLE
Remove usage of async keyword in code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ flate2-rust = ["flate2/rust_backend"]
 cell = ["actix-net/cell"]
 
 [dependencies]
-actix = "0.7.9"
+actix = "0.7.10"
 actix-net = "0.2.6"
 
 v_htmlescape = "0.3.2"

--- a/src/client/connector.rs
+++ b/src/client/connector.rs
@@ -953,7 +953,7 @@ impl Handler<Connect> for ClientConnector {
         if self.paused.is_paused() {
             let rx = self.wait_for(key.clone(), wait_timeout, conn_timeout);
             self.stats.waits += 1;
-            return ActorResponse::async(
+            return ActorResponse::future(
                 rx.map_err(|_| ClientConnectorError::Disconnected)
                     .into_actor(self)
                     .and_then(move |res, act, ctx| match res {
@@ -984,7 +984,7 @@ impl Handler<Connect> for ClientConnector {
             };
             self.connect_waiter(&key, waiter, ctx);
 
-            return ActorResponse::async(
+            return ActorResponse::future(
                 rx.map_err(|_| ClientConnectorError::Disconnected)
                     .into_actor(self)
                     .and_then(move |res, act, ctx| match res {
@@ -1005,14 +1005,14 @@ impl Handler<Connect> for ClientConnector {
                 // use existing connection
                 conn.pool = Some(AcquiredConn(key, Some(self.acq_tx.clone())));
                 self.stats.reused += 1;
-                ActorResponse::async(fut::ok(conn))
+                ActorResponse::future(fut::ok(conn))
             }
             Acquire::NotAvailable => {
                 // connection is not available, wait
                 let rx = self.wait_for(key.clone(), wait_timeout, conn_timeout);
                 self.stats.waits += 1;
 
-                ActorResponse::async(
+                ActorResponse::future(
                     rx.map_err(|_| ClientConnectorError::Disconnected)
                         .into_actor(self)
                         .and_then(move |res, act, ctx| match res {
@@ -1041,7 +1041,7 @@ impl Handler<Connect> for ClientConnector {
                 };
                 self.connect_waiter(&key, waiter, ctx);
 
-                ActorResponse::async(
+                ActorResponse::future(
                     rx.map_err(|_| ClientConnectorError::Disconnected)
                         .into_actor(self)
                         .and_then(move |res, act, ctx| match res {

--- a/src/route.rs
+++ b/src/route.rs
@@ -104,7 +104,7 @@ impl<S: 'static> Route<S> {
         R: Responder + 'static,
         E: Into<Error> + 'static,
     {
-        self.handler = InnerHandler::async(handler);
+        self.handler = InnerHandler::future(handler);
     }
 
     /// Set handler function, use request extractor for parameters.
@@ -306,7 +306,7 @@ impl<S: 'static> InnerHandler<S> {
     }
 
     #[inline]
-    fn async<H, R, F, E>(h: H) -> Self
+    fn future<H, R, F, E>(h: H) -> Self
     where
         H: Fn(&HttpRequest<S>) -> F + 'static,
         F: Future<Item = R, Error = E> + 'static,


### PR DESCRIPTION
Remove usage of `async` keyword to be more compatible with 2018 compiler