### PR TITLE
Use NamedFile with an existing File

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## [x.x.xx] - xxxx-xx-xx
+
+### Added
+
+* Add `from_file` and `from_file_with_config` to `NamedFile` to allow sending files without a known path. #670
+
 ## [0.7.18] - 2019-01-10
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,6 +129,7 @@ tokio-uds = { version="0.2", optional = true }
 [dev-dependencies]
 env_logger = "0.6"
 serde_derive = "1.0"
+tempfile = "3.0"
 
 [build-dependencies]
 version_check = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,7 +129,6 @@ tokio-uds = { version="0.2", optional = true }
 [dev-dependencies]
 env_logger = "0.6"
 serde_derive = "1.0"
-tempfile = "3.0"
 
 [build-dependencies]
 version_check = "0.1"

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -128,17 +128,30 @@ impl NamedFile {
     /// # Examples
     ///
     /// ```rust
-    /// extern crate tempfile;
     /// extern crate actix_web;
     ///
     /// use actix_web::fs::NamedFile;
-    /// use tempfile::tempfile;
     /// use std::io::{self, Write};
+    /// use std::env;
+    /// # use std::fs::{self, File};
+    /// # use std::path::PathBuf;
+    /// #
+    /// # fn path() -> PathBuf {
+    /// #     let mut path = env::temp_dir();
+    /// #     path.push("actix-web-named-file-test-from-file");
+    /// #     path
+    /// # }
+    /// #
+    /// # fn tempfile() -> Result<File, io::Error> {
+    /// #     let file = File::create(path())?;
+    /// #     Ok(file)
+    /// # }
     ///
     /// fn main() -> io::Result<()> {
     ///     let mut file = tempfile()?;
     ///     file.write_all(b"Hello, world!")?;
     ///     let named_file = NamedFile::from_file(file, "foo.txt")?;
+    /// #   fs::remove_file(path())?;
     ///     Ok(())
     /// }
     /// ```
@@ -169,17 +182,30 @@ impl<C: StaticFileConfig> NamedFile<C> {
     /// # Examples
     ///
     /// ```rust
-    /// extern crate tempfile;
     /// extern crate actix_web;
     ///
-    /// use actix_web::fs::{NamedFile, DefaultConfig};
-    /// use tempfile::tempfile;
+    /// use actix_web::fs::{DefaultConfig, NamedFile};
     /// use std::io::{self, Write};
+    /// use std::env;
+    /// # use std::fs::{self, File};
+    /// # use std::path::PathBuf;
+    /// #
+    /// # fn path() -> PathBuf {
+    /// #     let mut path = env::temp_dir();
+    /// #     path.push("actix-web-named-file-test-from-file-with-config");
+    /// #     path
+    /// # }
+    /// #
+    /// # fn tempfile() -> Result<File, io::Error> {
+    /// #     let file = File::create(path())?;
+    /// #     Ok(file)
+    /// # }
     ///
     /// fn main() -> io::Result<()> {
     ///     let mut file = tempfile()?;
     ///     file.write_all(b"Hello, world!")?;
     ///     let named_file = NamedFile::from_file_with_config(file, "foo.txt", DefaultConfig)?;
+    /// #   fs::remove_file(path())?;
     ///     Ok(())
     /// }
     /// ```
@@ -225,6 +251,7 @@ impl<C: StaticFileConfig> NamedFile<C> {
             _cd_map: PhantomData,
         })
     }
+
     /// Attempts to open a file in read-only mode using provided configuration.
     ///
     /// # Examples

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -127,31 +127,18 @@ impl NamedFile {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```no_run
     /// extern crate actix_web;
     ///
     /// use actix_web::fs::NamedFile;
     /// use std::io::{self, Write};
     /// use std::env;
-    /// # use std::fs::{self, File};
-    /// # use std::path::PathBuf;
-    /// #
-    /// # fn path() -> PathBuf {
-    /// #     let mut path = env::temp_dir();
-    /// #     path.push("actix-web-named-file-test-from-file");
-    /// #     path
-    /// # }
-    /// #
-    /// # fn tempfile() -> Result<File, io::Error> {
-    /// #     let file = File::create(path())?;
-    /// #     Ok(file)
-    /// # }
+    /// use std::fs::File;
     ///
     /// fn main() -> io::Result<()> {
-    ///     let mut file = tempfile()?;
+    ///     let mut file = File::create("foo.txt")?;
     ///     file.write_all(b"Hello, world!")?;
-    ///     let named_file = NamedFile::from_file(file, "foo.txt")?;
-    /// #   fs::remove_file(path())?;
+    ///     let named_file = NamedFile::from_file(file, "bar.txt")?;
     ///     Ok(())
     /// }
     /// ```
@@ -181,31 +168,18 @@ impl<C: StaticFileConfig> NamedFile<C> {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```no_run
     /// extern crate actix_web;
     ///
     /// use actix_web::fs::{DefaultConfig, NamedFile};
     /// use std::io::{self, Write};
     /// use std::env;
-    /// # use std::fs::{self, File};
-    /// # use std::path::PathBuf;
-    /// #
-    /// # fn path() -> PathBuf {
-    /// #     let mut path = env::temp_dir();
-    /// #     path.push("actix-web-named-file-test-from-file-with-config");
-    /// #     path
-    /// # }
-    /// #
-    /// # fn tempfile() -> Result<File, io::Error> {
-    /// #     let file = File::create(path())?;
-    /// #     Ok(file)
-    /// # }
+    /// use std::fs::File;
     ///
     /// fn main() -> io::Result<()> {
-    ///     let mut file = tempfile()?;
+    ///     let mut file = File::create("foo.txt")?;
     ///     file.write_all(b"Hello, world!")?;
-    ///     let named_file = NamedFile::from_file_with_config(file, "foo.txt", DefaultConfig)?;
-    /// #   fs::remove_file(path())?;
+    ///     let named_file = NamedFile::from_file_with_config(file, "bar.txt", DefaultConfig)?;
     ///     Ok(())
     /// }
     /// ```

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -120,6 +120,32 @@ pub struct NamedFile<C = DefaultConfig> {
 }
 
 impl NamedFile {
+    /// Creates an instance from a previously opened file.
+    ///
+    /// The given `path` need not exist and is only used to determine the `ContentType` and
+    /// `ContentDisposition` headers.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// extern crate tempfile;
+    /// extern crate actix_web;
+    ///
+    /// use actix_web::fs::NamedFile;
+    /// use tempfile::tempfile;
+    /// use std::io::{self, Write};
+    ///
+    /// fn main() -> io::Result<()> {
+    ///     let mut file = tempfile()?;
+    ///     file.write_all(b"Hello, world!")?;
+    ///     let named_file = NamedFile::from_file(file, "foo.txt")?;
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn from_file<P: AsRef<Path>>(file: File, path: P) -> io::Result<NamedFile> {
+        Self::from_file_with_config(file, path, DefaultConfig)
+    }
+
     /// Attempts to open a file in read-only mode.
     ///
     /// # Examples
@@ -135,16 +161,29 @@ impl NamedFile {
 }
 
 impl<C: StaticFileConfig> NamedFile<C> {
-    /// Attempts to open a file in read-only mode using provided configiration.
+    /// Creates an instance from a previously opened file using the provided configuration.
+    ///
+    /// The given `path` need not exist and is only used to determine the `ContentType` and
+    /// `ContentDisposition` headers.
     ///
     /// # Examples
     ///
     /// ```rust
-    /// use actix_web::fs::{DefaultConfig, NamedFile};
+    /// extern crate tempfile;
+    /// extern crate actix_web;
     ///
-    /// let file = NamedFile::open_with_config("foo.txt", DefaultConfig);
+    /// use actix_web::fs::{NamedFile, DefaultConfig};
+    /// use tempfile::tempfile;
+    /// use std::io::{self, Write};
+    ///
+    /// fn main() -> io::Result<()> {
+    ///     let mut file = tempfile()?;
+    ///     file.write_all(b"Hello, world!")?;
+    ///     let named_file = NamedFile::from_file_with_config(file, "foo.txt", DefaultConfig)?;
+    ///     Ok(())
+    /// }
     /// ```
-    pub fn open_with_config<P: AsRef<Path>>(path: P, _: C) -> io::Result<NamedFile<C>> {
+    pub fn from_file_with_config<P: AsRef<Path>>(file: File, path: P, _: C) -> io::Result<NamedFile<C>> {
         let path = path.as_ref().to_path_buf();
 
         // Get the name of the file and use it to construct default Content-Type
@@ -169,7 +208,6 @@ impl<C: StaticFileConfig> NamedFile<C> {
             (ct, cd)
         };
 
-        let file = File::open(&path)?;
         let md = file.metadata()?;
         let modified = md.modified().ok();
         let cpu_pool = None;
@@ -186,6 +224,18 @@ impl<C: StaticFileConfig> NamedFile<C> {
             status_code: StatusCode::OK,
             _cd_map: PhantomData,
         })
+    }
+    /// Attempts to open a file in read-only mode using provided configuration.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use actix_web::fs::{DefaultConfig, NamedFile};
+    ///
+    /// let file = NamedFile::open_with_config("foo.txt", DefaultConfig);
+    /// ```
+    pub fn open_with_config<P: AsRef<Path>>(path: P, config: C) -> io::Result<NamedFile<C>> {
+        Self::from_file_with_config(File::open(&path)?, path, config)
     }
 
     /// Returns reference to the underlying `File` object.


### PR DESCRIPTION
Resolves #659.

This adds `NamedFile::from_file` and `NamedFile::from_file_with_config` next to the usual `NamedFile::open` and `NamedFile::open_with_config`.

I have included documentation and an example/doctest for both methods.