### PR TITLE
Add io handling for ECONNRESET when data has already been received

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -303,6 +303,8 @@ pub trait IoStream: AsyncRead + AsyncWrite + 'static {
                         } else {
                             Ok(Async::NotReady)
                         }
+                    } else if e.kind() == io::ErrorKind::ConnectionReset && read_some {
+                        Ok(Async::Ready((read_some, true)))
                     } else {
                         Err(e)
                     };


### PR DESCRIPTION
I came across a case, in a project where I'm using the actix_web client, where the remote http server would close the connection immediately after sending the response. This would cause the client to get the data, but then get an ECONNRESET resulting in a failed transaction. Because the response was fully received, the io layer should return that it received data and the stream has closed.

Here is the strace of the issue where both the client and server are in the same process. PID 2148 is the server, PID 2147 is the actix_web::client. The server sends all the data, then closes the connection, the client receives all the data and on the next poll gets an ECONNRESET.

```
[pid  2148] sendto(4, "HTTP/1.1 200 OK\r\nConnection: clo"..., 2616, MSG_NOSIGNAL, NULL, 0) = 2616
[pid  2147] <... epoll_wait resumed> [{EPOLLIN|EPOLLOUT, {u32=4194305, u64=4194305}}], 1024, 941) = 1
[pid  2148] close(4 <unfinished ...>
[pid  2147] recvfrom(9,  <unfinished ...>
[pid  2148] <... close resumed> )       = 0
[pid  2147] <... recvfrom resumed> "HTTP/1.1 200 OK\r\nConnection: clo"..., 32768, 0, NULL, NULL) = 2616
[pid  2147] recvfrom(9, 0x7f2dafd2cbb8, 30152, 0, NULL, NULL) = -1 ECONNRESET (Connection reset by peer)
```

This patch could be changed to use a match expression if needed.
