### PR TITLE
Bump v_htmlescape version to 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ cell = ["actix-net/cell"]
 actix = "0.7.9"
 actix-net = "0.2.6"
 
-v_htmlescape = "0.3.2"
+v_htmlescape = "0.4"
 base64 = "0.10"
 bitflags = "1.0"
 failure = "^0.1.2"

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -11,7 +11,7 @@ use std::{cmp, io};
 #[cfg(unix)]
 use std::os::unix::fs::MetadataExt;
 
-use v_htmlescape::HTMLEscape;
+use v_htmlescape::escape as escape_html_entity;
 use bytes::Bytes;
 use futures::{Async, Future, Poll, Stream};
 use futures_cpupool::{CpuFuture, CpuPool};
@@ -567,11 +567,6 @@ macro_rules! encode_file_url {
     ($path:ident) => {
         utf8_percent_encode(&$path.to_string_lossy(), DEFAULT_ENCODE_SET)
     };
-}
-
-#[inline]
-fn escape_html_entity(s: &str) -> HTMLEscape {
-    HTMLEscape::from(s)
 }
 
 // " -- &quot;  & -- &amp;  ' -- &#x27;  < -- &lt;  > -- &gt;  / -- &#x2f;


### PR DESCRIPTION
#### Fix
- https://github.com/rust-iendo/v_htmlescape/issues/17

#### Improve
- https://github.com/rust-iendo/v_htmlescape/pull/20
- https://github.com/rust-iendo/v_htmlescape/pull/14/commits/d5d226c32669b593498deaf8d1bd0290228c63ce