### PR TITLE
Fix typo

### DIFF
--- a/src/server/http.rs
+++ b/src/server/http.rs
@@ -451,9 +451,8 @@ impl<H: IntoHttpHandler, F: Fn() -> H + Send + Clone> HttpServer<H, F> {
     /// For each address this method starts separate thread which does
     /// `accept()` in a loop.
     ///
-    /// This methods panics if no socket addresses get bound.
-    ///
-    /// This method requires to run within properly configured `Actix` system.
+    /// This methods panics if no socket address can be bound or an `Actix` system is not yet
+    /// configured.
     ///
     /// ```rust
     /// extern crate actix_web;


### PR DESCRIPTION
The original
> This method requires to run within properly configured Actix system.

was not correct, so merged it with the previous statement about panicking (since it panics for me if I try to launch it /wo an actix system).

Could alternatively be
> This method requires a properly configured Actix system.

or a number of similar variants if the behaviour when run without an Actix system must remain undefined.