### PR TITLE
Make interface of Router public

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -417,7 +417,7 @@ pub trait RouteHandler<S>: 'static {
     fn finish(&mut self) {}
 }
 
-/// Route handler wrapper for Handler
+/// Route handler wrapper for Handler.
 pub struct WrapHandler<S, H, R>
 where
     H: Handler<S, Result = R>,
@@ -434,6 +434,8 @@ where
     R: Responder,
     S: 'static,
 {
+    /// Creates new route handler wrapper for Handler.
+    /// This method should be used to register handler in Router manually.
     pub fn new(h: H) -> Self {
         WrapHandler { h, s: PhantomData }
     }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -405,7 +405,7 @@ where
     }
 }
 
-pub(crate) trait RouteHandler<S>: 'static {
+pub trait RouteHandler<S>: 'static {
     fn handle(&self, &HttpRequest<S>) -> AsyncResult<HttpResponse>;
 
     fn has_default_resource(&self) -> bool {
@@ -418,7 +418,7 @@ pub(crate) trait RouteHandler<S>: 'static {
 }
 
 /// Route handler wrapper for Handler
-pub(crate) struct WrapHandler<S, H, R>
+pub struct WrapHandler<S, H, R>
 where
     H: Handler<S, Result = R>,
     R: Responder,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -254,7 +254,7 @@ pub mod dev {
     pub use body::BodyStream;
     pub use context::Drain;
     pub use extractor::{FormConfig, PayloadConfig, QueryConfig, PathConfig, EitherConfig, EitherCollisionStrategy};
-    pub use handler::{AsyncResult, Handler};
+    pub use handler::{AsyncResult, Handler, WrapHandler};
     pub use httpmessage::{MessageBody, Readlines, UrlEncoded};
     pub use httpresponse::HttpResponseBuilder;
     pub use info::ConnectionInfo;

--- a/src/router.rs
+++ b/src/router.rs
@@ -301,11 +301,11 @@ impl<S: 'static> Router<S> {
         }
     }
 
-    pub(crate) fn set_prefix(&mut self, path: &str) {
+    pub fn set_prefix(&mut self, path: &str) {
         Rc::get_mut(&mut self.rmap).unwrap().root = ResourceDef::new(path);
     }
 
-    pub(crate) fn register_resource(&mut self, resource: Resource<S>) {
+    pub fn register_resource(&mut self, resource: Resource<S>) {
         {
             let rmap = Rc::get_mut(&mut self.rmap).unwrap();
 
@@ -325,7 +325,7 @@ impl<S: 'static> Router<S> {
         self.resources.push(ResourceItem::Resource(resource));
     }
 
-    pub(crate) fn register_scope(&mut self, mut scope: Scope<S>) {
+    pub fn register_scope(&mut self, mut scope: Scope<S>) {
         Rc::get_mut(&mut self.rmap)
             .unwrap()
             .patterns
@@ -341,7 +341,7 @@ impl<S: 'static> Router<S> {
         self.resources.push(ResourceItem::Scope(scope));
     }
 
-    pub(crate) fn register_handler(
+    pub fn register_handler(
         &mut self, path: &str, hnd: Box<RouteHandler<S>>,
         filters: Option<Vec<Box<Predicate<S>>>>,
     ) {
@@ -354,15 +354,15 @@ impl<S: 'static> Router<S> {
         self.patterns.push(ResourcePattern::Handler(rdef, filters));
     }
 
-    pub(crate) fn has_default_resource(&self) -> bool {
+    pub fn has_default_resource(&self) -> bool {
         self.default.is_some()
     }
 
-    pub(crate) fn register_default_resource(&mut self, resource: DefaultResource<S>) {
+    pub fn register_default_resource(&mut self, resource: DefaultResource<S>) {
         self.default = Some(resource);
     }
 
-    pub(crate) fn finish(&mut self) {
+    pub fn finish(&mut self) {
         for resource in &mut self.resources {
             match resource {
                 ResourceItem::Resource(_) => (),
@@ -387,7 +387,7 @@ impl<S: 'static> Router<S> {
         }
     }
 
-    pub(crate) fn register_external(&mut self, name: &str, rdef: ResourceDef) {
+    pub fn register_external(&mut self, name: &str, rdef: ResourceDef) {
         let rmap = Rc::get_mut(&mut self.rmap).unwrap();
         assert!(
             !rmap.named.contains_key(name),
@@ -397,7 +397,7 @@ impl<S: 'static> Router<S> {
         rmap.named.insert(name.to_owned(), rdef);
     }
 
-    pub(crate) fn register_route<T, F, R>(&mut self, path: &str, method: Method, f: F)
+    pub fn register_route<T, F, R>(&mut self, path: &str, method: Method, f: F)
     where
         F: WithFactory<T, S, R>,
         R: Responder + 'static,


### PR DESCRIPTION
This PR does not change any logic, but makes interface of the `Router` structure public.

Motivation: Router provides interfaces for (suprisingly) routing management, but currently its interface is almost completely hidden under `pub(crate)`. Making it public will allow users to implement non-trivial routing rules, such as ability to enable/disable some parts of application in the runtime by creating a multiple routers on their side.