### PR TITLE
Implement Responder for () converting it into OK/200.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ### Added
 
 * Add `from_file` and `from_file_with_config` to `NamedFile` to allow sending files without a known path. #670
+* Implement `Responder` for `()` returning 200 with empty body to allow handlers to return a unit.
 
 ### Fixed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@
 ### Added
 
 * Add `from_file` and `from_file_with_config` to `NamedFile` to allow sending files without a known path. #670
-* Implement `Responder` for `()` returning 200 with empty body to allow handlers to return a unit.
+* Support handlers returning `()`. Unit is converted to 200 response with an empty body.
 
 ### Fixed
 

--- a/src/application.rs
+++ b/src/application.rs
@@ -825,7 +825,7 @@ mod tests {
     }
 
     #[test]
-    fn test_unit_responser() {
+    fn test_unit_responder() {
         let app = App::new().resource("/unit", |r| r.f(|_| {})).finish();
 
         let req = TestRequest::with_uri("/unit").request();

--- a/src/application.rs
+++ b/src/application.rs
@@ -825,6 +825,16 @@ mod tests {
     }
 
     #[test]
+    fn test_unit_responser() {
+        let app = App::new().resource("/unit", |r| r.f(|_| {})).finish();
+
+        let req = TestRequest::with_uri("/unit").request();
+        let resp = app.run(req);
+        assert_eq!(resp.as_msg().status(), StatusCode::OK);
+        assert_eq!(resp.as_msg().body(), &Body::Empty);
+    }
+
+    #[test]
     fn test_option_responder() {
         let app = App::new()
             .resource("/none", |r| r.f(|_| -> Option<&'static str> { None }))

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -32,7 +32,8 @@ pub trait Responder {
 
     /// Convert itself to `AsyncResult` or `Error`.
     fn respond_to<S: 'static>(
-        self, req: &HttpRequest<S>,
+        self,
+        req: &HttpRequest<S>,
     ) -> Result<Self::Item, Self::Error>;
 }
 
@@ -103,7 +104,8 @@ where
     type Error = Error;
 
     fn respond_to<S: 'static>(
-        self, req: &HttpRequest<S>,
+        self,
+        req: &HttpRequest<S>,
     ) -> Result<AsyncResult<HttpResponse>, Error> {
         match self {
             Either::A(a) => match a.respond_to(req) {
@@ -142,7 +144,8 @@ where
     type Error = Error;
 
     fn respond_to<S: 'static>(
-        self, req: &HttpRequest<S>,
+        self,
+        req: &HttpRequest<S>,
     ) -> Result<AsyncResult<HttpResponse>, Error> {
         match self {
             Some(t) => match t.respond_to(req) {
@@ -151,6 +154,18 @@ where
             },
             None => Ok(req.build_response(StatusCode::NOT_FOUND).finish().into()),
         }
+    }
+}
+
+impl Responder for () {
+    type Item = HttpResponse;
+    type Error = Error;
+
+    fn respond_to<S: 'static>(
+        self,
+        req: &HttpRequest<S>,
+    ) -> Result<Self::Item, Self::Error> {
+        Ok(req.build_response(StatusCode::OK).finish())
     }
 }
 
@@ -293,7 +308,8 @@ impl Responder for AsyncResult<HttpResponse> {
     type Error = Error;
 
     fn respond_to<S>(
-        self, _: &HttpRequest<S>,
+        self,
+        _: &HttpRequest<S>,
     ) -> Result<AsyncResult<HttpResponse>, Error> {
         Ok(self)
     }
@@ -305,7 +321,8 @@ impl Responder for HttpResponse {
 
     #[inline]
     fn respond_to<S>(
-        self, _: &HttpRequest<S>,
+        self,
+        _: &HttpRequest<S>,
     ) -> Result<AsyncResult<HttpResponse>, Error> {
         Ok(AsyncResult(Some(AsyncResultItem::Ok(self))))
     }
@@ -389,7 +406,8 @@ where
 
     #[inline]
     fn respond_to<S: 'static>(
-        self, req: &HttpRequest<S>,
+        self,
+        req: &HttpRequest<S>,
     ) -> Result<AsyncResult<HttpResponse>, Error> {
         let req = req.clone();
         let fut = self


### PR DESCRIPTION
This allows to easily write handlers returning an empty body on success:

```rust
fn delete_user(path: Path<String>) -> Result<()> {
    Ok(())
}
```

or even just (in case a handler can't fail)

```rust
fn delete_user(path: Path<String>) {}
```
