### PR TITLE
[0.7] Fix never-ending HTTP2 empty response

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,8 @@
 
 * Fix preflight CORS header compliance; refactor previous patch (#603). #717
 
+* Fix never-ending HTTP2 request when response is empty (#709). #737
+
 ## [0.7.18] - 2019-01-10
 
 ### Added


### PR DESCRIPTION
This is the fix I mentioned in #709. I ended up with testing this change with our code base, and it seems to work fine.

I tested with sending 5000 requests to the server via curl sequentially as well as sending the requests simultaneously (with empty responses mixed).