### PR TITLE
Fix body propagation in Response::from_error.

### DIFF
--- a/actix-http/src/response.rs
+++ b/actix-http/src/response.rs
@@ -1,7 +1,7 @@
 //! Http response
 use std::cell::{Ref, RefMut};
 use std::io::Write;
-use std::{fmt, io, str};
+use std::{fmt, str};
 
 use bytes::{BufMut, Bytes, BytesMut};
 use futures::future::{ok, FutureResult, IntoFuture};
@@ -52,12 +52,8 @@ impl Response<Body> {
     #[inline]
     pub fn from_error(error: Error) -> Response {
         let mut resp = error.as_response_error().error_response();
-        let mut buf = BytesMut::new();
-        let _ = write!(Writer(&mut buf), "{}", error);
-        resp.headers_mut()
-            .insert(header::CONTENT_TYPE, HeaderValue::from_static("text/plain"));
         resp.error = Some(error);
-        resp.set_body(Body::from(buf))
+        resp
     }
 
     /// Convert response to response with body
@@ -294,18 +290,6 @@ impl<'a> Iterator for CookieIter<'a> {
             }
         }
         None
-    }
-}
-
-pub struct Writer<'a>(pub &'a mut BytesMut);
-
-impl<'a> io::Write for Writer<'a> {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.0.extend_from_slice(buf);
-        Ok(buf.len())
-    }
-    fn flush(&mut self) -> io::Result<()> {
-        Ok(())
     }
 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -64,7 +64,7 @@ where
         InitError = (),
     >,
 {
-    /// Set application data. Applicatin data could be accessed
+    /// Set application data. Application data could be accessed
     /// by using `Data<T>` extractor where `T` is data type.
     ///
     /// **Note**: http server accepts an application factory rather than

--- a/src/data.rs
+++ b/src/data.rs
@@ -25,7 +25,7 @@ pub(crate) trait DataFactoryResult {
 /// during application configuration process
 /// with `App::data()` method.
 ///
-/// Applicatin data could be accessed by using `Data<T>`
+/// Application data could be accessed by using `Data<T>`
 /// extractor where `T` is data type.
 ///
 /// **Note**: http server accepts an application factory rather than

--- a/src/error.rs
+++ b/src/error.rs
@@ -31,7 +31,7 @@ pub enum UrlencodedError {
     #[display(fmt = "Can not decode chunked transfer encoding")]
     Chunked,
     /// Payload size is bigger than allowed. (default: 256kB)
-    #[display(fmt = "Urlencoded payload size is bigger than allowed. (default: 256kB)")]
+    #[display(fmt = "Urlencoded payload size is bigger than allowed (default: 256kB)")]
     Overflow,
     /// Payload size is now known
     #[display(fmt = "Payload size is now known")]
@@ -66,7 +66,7 @@ impl ResponseError for UrlencodedError {
 #[derive(Debug, Display, From)]
 pub enum JsonPayloadError {
     /// Payload size is bigger than allowed. (default: 32kB)
-    #[display(fmt = "Json payload size is bigger than allowed.")]
+    #[display(fmt = "Json payload size is bigger than allowed")]
     Overflow,
     /// Content type error
     #[display(fmt = "Content type error")]

--- a/test-server/src/lib.rs
+++ b/test-server/src/lib.rs
@@ -107,7 +107,7 @@ impl TestServer {
         TestServerRuntime { addr, rt, client }
     }
 
-    /// Get firat available unused address
+    /// Get first available unused address
     pub fn unused_addr() -> net::SocketAddr {
         let addr: net::SocketAddr = "127.0.0.1:0".parse().unwrap();
         let socket = TcpBuilder::new_v4().unwrap();


### PR DESCRIPTION
Fix error body propagation in Response::from_error.

Also:

* Fix typos.
* Remove period from error messages.
* Add test for custom response in json error handler.