### PR TITLE
Make `App::configure` take an `FnOnce`

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -128,7 +128,7 @@ where
     /// ```
     pub fn configure<F>(mut self, f: F) -> Self
     where
-        F: Fn(&mut ServiceConfig),
+        F: FnOnce(&mut ServiceConfig),
     {
         let mut cfg = ServiceConfig::new();
         f(&mut cfg);


### PR DESCRIPTION
I noticed that this function is only ever called once, so it would be nice to have it be more flexible on what arguments can be passed.