### PR TITLE
Make JsonConfig send

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@
 ### Changes
 
 * `App::configure` take an `FnOnce` instead of `Fn`
-
+* `JsonConfig` is now `Send + Sync`, this implies that `error_handler` must be `Send + Sync` too.
 
 ## [1.0.0-beta.3] - 2019-05-04
 

--- a/src/types/json.rs
+++ b/src/types/json.rs
@@ -236,7 +236,7 @@ where
 #[derive(Clone)]
 pub struct JsonConfig {
     limit: usize,
-    ehandler: Option<Arc<Fn(JsonPayloadError, &HttpRequest) -> Error>>,
+    ehandler: Option<Arc<dyn Fn(JsonPayloadError, &HttpRequest) -> Error + Send>>,
 }
 
 impl JsonConfig {
@@ -249,7 +249,7 @@ impl JsonConfig {
     /// Set custom error handler
     pub fn error_handler<F>(mut self, f: F) -> Self
     where
-        F: Fn(JsonPayloadError, &HttpRequest) -> Error + 'static,
+        F: Fn(JsonPayloadError, &HttpRequest) -> Error + Send + 'static,
     {
         self.ehandler = Some(Arc::new(f));
         self

--- a/src/types/json.rs
+++ b/src/types/json.rs
@@ -236,7 +236,7 @@ where
 #[derive(Clone)]
 pub struct JsonConfig {
     limit: usize,
-    ehandler: Option<Arc<dyn Fn(JsonPayloadError, &HttpRequest) -> Error + Send>>,
+    ehandler: Option<Arc<dyn Fn(JsonPayloadError, &HttpRequest) -> Error + Send + Sync>>,
 }
 
 impl JsonConfig {
@@ -249,7 +249,7 @@ impl JsonConfig {
     /// Set custom error handler
     pub fn error_handler<F>(mut self, f: F) -> Self
     where
-        F: Fn(JsonPayloadError, &HttpRequest) -> Error + Send + 'static,
+        F: Fn(JsonPayloadError, &HttpRequest) -> Error + Send + Sync + 'static,
     {
         self.ehandler = Some(Arc::new(f));
         self

--- a/src/types/json.rs
+++ b/src/types/json.rs
@@ -1,6 +1,6 @@
 //! Json extractor/responder
 
-use std::rc::Rc;
+use std::sync::Arc;
 use std::{fmt, ops};
 
 use bytes::BytesMut;
@@ -236,7 +236,7 @@ where
 #[derive(Clone)]
 pub struct JsonConfig {
     limit: usize,
-    ehandler: Option<Rc<Fn(JsonPayloadError, &HttpRequest) -> Error>>,
+    ehandler: Option<Arc<Fn(JsonPayloadError, &HttpRequest) -> Error>>,
 }
 
 impl JsonConfig {
@@ -251,7 +251,7 @@ impl JsonConfig {
     where
         F: Fn(JsonPayloadError, &HttpRequest) -> Error + 'static,
     {
-        self.ehandler = Some(Rc::new(f));
+        self.ehandler = Some(Arc::new(f));
         self
     }
 }

--- a/src/types/json.rs
+++ b/src/types/json.rs
@@ -176,7 +176,7 @@ where
     fn from_request(req: &HttpRequest, payload: &mut Payload) -> Self::Future {
         let req2 = req.clone();
         let (limit, err) = req
-            .app_data::<JsonConfig>()
+            .app_data::<Self::Config>()
             .map(|c| (c.limit, c.ehandler.clone()))
             .unwrap_or((32768, None));
 

--- a/src/types/json.rs
+++ b/src/types/json.rs
@@ -168,9 +168,9 @@ impl<T> FromRequest for Json<T>
 where
     T: DeserializeOwned + 'static,
 {
-    type Config = JsonConfig;
     type Error = Error;
     type Future = Box<Future<Item = Self, Error = Error>>;
+    type Config = JsonConfig;
 
     #[inline]
     fn from_request(req: &HttpRequest, payload: &mut Payload) -> Self::Future {


### PR DESCRIPTION
Fixes #827 

Note that `ehandler` now must be Send + Sync, I don't know if this may cause compatibility issues:

```rust
// ...

pub struct JsonConfig {
    limit: usize,
    ehandler: Option<Arc<Fn(JsonPayloadError, &HttpRequest) -> Error + Send + Sync>>, // <--
}

// ...
```
