### PR TITLE
Support building Query<T> from a query string

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 ### Add
 
+* Add `Query<T>::from_query()` to extract parameters from a query string. #846
 * `QueryConfig`, similar to `JsonConfig` for customizing error handling of query extractors.
 
 ### Changes


### PR DESCRIPTION
Will close #843 

Had a bit of a struggle going with the original suggestions, but thought that since one can't clone `ServiceRequest` and so long as they could only get a reference to the underlying parts, the approach here might be alright, since that'd keep `ServiceRequest::from_parts` private. But I suspect I'm wrong here. 

Appreciate the help. :+1: 