### PR TITLE
HttpServer::shutdown_timeout u16 to u64

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -207,7 +207,7 @@ where
     /// dropped.
     ///
     /// By default shutdown timeout sets to 30 seconds.
-    pub fn shutdown_timeout(mut self, sec: u16) -> Self {
+    pub fn shutdown_timeout(mut self, sec: u64) -> Self {
         self.builder = Some(self.builder.take().unwrap().shutdown_timeout(sec));
         self
     }


### PR DESCRIPTION
Increase maximum graceful shutdown time from 18 hours.

For issue #848.