### PR TITLE
Fix Logger time format (use rfc3339)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,8 @@
 
 ### Fixed
 
+* Fix Logger request time format, and use rfc3339. #867
+
 * Clear http requests pool on app service drop #860
 
 


### PR DESCRIPTION
The current implementation of Logger middleware logs the following for `"%t"` log format:

```bash
TmFmt { tm: Tm { tm_sec: 36, tm_min: 0, tm_hour: 17, tm_mday: 27, tm_mon: 4, tm_year: 119, tm_wday: 1, tm_yday: 146, tm_isdst: 1, tm_utcoff: 7200, tm_nsec: 149522000 }, format: Str("[%d/%b/%Y:%H:%M:%S %z]") }
```

This PR fixes this behavior and uses `rfc3339` format.

I am not entirely sure if we are Ok with rfc3339 or we need to keep the Nginx like access log time format (`%d/%b/%Y:%H:%M:%S %z`). If so, I will adjust the PR to use it.
