### PR TITLE
Don't DISCONNECT from stream when reader is empty

### DIFF
--- a/actix-http/src/h1/dispatcher.rs
+++ b/actix-http/src/h1/dispatcher.rs
@@ -799,7 +799,7 @@ where
         match read {
             Ok(n) => {
                 if n == 0 {
-                    return Ok(Some(true));
+                    return Ok(Some(false));
                 } else {
                     read_some = true;
                     unsafe {

--- a/actix-http/src/h1/dispatcher.rs
+++ b/actix-http/src/h1/dispatcher.rs
@@ -693,18 +693,20 @@ where
                     }
                 } else {
                     // read socket into a buf
-                    if !inner.flags.contains(Flags::READ_DISCONNECT) {
-                        if let Some(true) =
-                            read_available(&mut inner.io, &mut inner.read_buf)?
-                        {
-                            inner.flags.insert(Flags::READ_DISCONNECT);
-                            if let Some(mut payload) = inner.payload.take() {
-                                payload.feed_eof();
-                            }
-                        }
-                    }
+                    let should_disconnect = if !inner.flags.contains(Flags::READ_DISCONNECT) {
+                        read_available(&mut inner.io, &mut inner.read_buf)?
+                    } else {
+                        None
+                    };
 
                     inner.poll_request()?;
+                    if let Some(true) = should_disconnect {
+                        inner.flags.insert(Flags::READ_DISCONNECT);
+                        if let Some(mut payload) = inner.payload.take() {
+                            payload.feed_eof();
+                        }
+                    };
+
                     loop {
                         if inner.write_buf.remaining_mut() < LW_BUFFER_SIZE {
                             inner.write_buf.reserve(HW_BUFFER_SIZE);
@@ -799,7 +801,7 @@ where
         match read {
             Ok(n) => {
                 if n == 0 {
-                    return Ok(Some(false));
+                    return Ok(Some(true));
                 } else {
                     read_some = true;
                     unsafe {


### PR DESCRIPTION
This should fix #868 

The issue seemed to be that `read_available` would return `true` when nothing has been read from the stream, which disconnects the connection. However, for chunked transfers, it could be that nothing is read from the stream at some point (?)