### PR TITLE
web-codegen: Add extra-traits to syn features

### DIFF
--- a/actix-web-codegen/Cargo.toml
+++ b/actix-web-codegen/Cargo.toml
@@ -13,7 +13,7 @@ proc-macro = true
 
 [dependencies]
 quote = "0.6"
-syn = { version = "0.15", features = ["full", "parsing"] }
+syn = { version = "0.15", features = ["full", "parsing", "extra-traits"] }
 
 [dev-dependencies]
 actix-web = { version = "1.0.0-beta.5" }


### PR DESCRIPTION
```rust
error[E0277]: `syn::attr::NestedMeta` doesn't implement `std::fmt::Debug`
   --> src/route.rs:149:57
    |
149 |                 attr => panic!("Unknown attribute{:?}", attr),
    |                                                         ^^^^ `syn::attr::NestedMeta` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`
    |
    = help: the trait `std::fmt::Debug` is not implemented for `syn::attr::NestedMeta`
    = note: required because of the requirements on the impl of `std::fmt::Debug` for `&syn::attr::NestedMeta`
    = note: required by `std::fmt::Debug::fmt`
```