### PR TITLE
let the reference of HttpRequest in the ServiceRequest could be access

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -80,6 +80,12 @@ impl ServiceRequest {
         ServiceResponse::new(self.0, res.into_body())
     }
 
+    /// This method returns reference to the request
+    #[inline]
+    pub fn request(&self) -> &HttpRequest {
+        &self.0
+    }
+
     /// This method returns reference to the request head
     #[inline]
     pub fn head(&self) -> &RequestHead {


### PR DESCRIPTION
The HttpRequest is needed when writing auth middleware, Such that could be possible

```
use actix_web::{middleware::identity::Identity, FromRequest};

impl<S, B> Service for CheckLoginMiddleware<S>
where
    S: Service<Request = ServiceRequest, Response = ServiceResponse<B>, Error = Error>,
    S::Future: 'static,
{
    type Request = ServiceRequest;
    type Response = ServiceResponse<B>;
    type Error = Error;
    type Future = Either<S::Future, FutureResult<Self::Response, Self::Error>>;

    fn call(&mut self, req: ServiceRequest) -> Self::Future {
        let is_logged_in = Identity::extract(&req.request())
            .ok()
            .and_then(|id| id.identity())
            .is_some();

        if is_logged_in {
            Either::A(self.service.call(req))
        } else {
            if req.path() == "/login" {
                Either::A(self.service.call(req))
            } else {
                Either::B(ok(req.into_response(
                    HttpResponse::Found()
                        .header(http::header::LOCATION, "/login")
                        .finish()
                        .into_body(),
                )))
            }
        }
    }
}
```