### PR TITLE
Remove ring subsubdependency when using actix-multipart.

### DIFF
--- a/actix-multipart/CHANGES.md
+++ b/actix-multipart/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+## [0.1.3] - 2019-06-06
+
+* Fix ring dependency from actix-web default features for #741.
+
 ## [0.1.2] - 2019-06-02
 
 * Fix boundary parsing #876

--- a/actix-multipart/Cargo.toml
+++ b/actix-multipart/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-multipart"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Nikolay Kim <fafhrd91@gmail.com>"]
 description = "Multipart support for actix web framework."
 readme = "README.md"
@@ -18,7 +18,7 @@ name = "actix_multipart"
 path = "src/lib.rs"
 
 [dependencies]
-actix-web = "1.0.0-rc"
+actix-web = { version = "1.0.0", default-features = false }
 actix-service = "0.4.0"
 bytes = "0.4"
 derive_more = "0.14"


### PR DESCRIPTION
This is related to #741. 

Setting the default features to false seems like an anti-pattern but it doesn't seem to be a feature to [disable single features in cargo](rust-lang/cargo#3126) yet.