### PR TITLE
Remove ring subsubdependency when using actix-files.

### DIFF
--- a/actix-files/CHANGES.md
+++ b/actix-files/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+## [0.1.2] - 2019-06-06
+
+* Fix ring dependency from actix-web default features for #741.
+
 ## [0.1.1] - 2019-06-01
 
 * Static files are incorrectly served as both chunked and with length #812

--- a/actix-files/Cargo.toml
+++ b/actix-files/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-files"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Nikolay Kim <fafhrd91@gmail.com>"]
 description = "Static files support for actix web."
 readme = "README.md"
@@ -18,7 +18,7 @@ name = "actix_files"
 path = "src/lib.rs"
 
 [dependencies]
-actix-web = "1.0.0-rc"
+actix-web = { version = "1.0.0", default-features = false }
 actix-http = "0.2.3"
 actix-service = "0.4.0"
 bitflags = "1"
@@ -32,4 +32,4 @@ percent-encoding = "1.0"
 v_htmlescape = "0.4"
 
 [dev-dependencies]
-actix-web = { version = "1.0.0-rc", features=["ssl"] }
+actix-web = { version = "1.0.0", features=["ssl"] }


### PR DESCRIPTION
This is basically the same PR as #895 but for actix-files rather than actix-multipart.