### PR TITLE
Add HTTP 429 Too Many Requests

### DIFF
--- a/actix-http/src/httpcodes.rs
+++ b/actix-http/src/httpcodes.rs
@@ -61,6 +61,7 @@ impl Response {
     STATIC_RESP!(RangeNotSatisfiable, StatusCode::RANGE_NOT_SATISFIABLE);
     STATIC_RESP!(ExpectationFailed, StatusCode::EXPECTATION_FAILED);
     STATIC_RESP!(UnprocessableEntity, StatusCode::UNPROCESSABLE_ENTITY);
+    STATIC_RESP!(TooManyRequests, StatusCode::TOO_MANY_REQUESTS);
 
     STATIC_RESP!(InternalServerError, StatusCode::INTERNAL_SERVER_ERROR);
     STATIC_RESP!(NotImplemented, StatusCode::NOT_IMPLEMENTED);


### PR DESCRIPTION
This PR adds the `HttpResponse::TooManyRequests()` function for HTTP `429` status code, which is used quite commonly for API server implementations.