### PR TITLE
Actix-web client: Always append a colon after username in basic auth

### DIFF
--- a/awc/CHANGES.md
+++ b/awc/CHANGES.md
@@ -1,5 +1,12 @@
 # Changes
 
+## [0.2.2] - TBD
+
+### Changed
+
+* Always append a colon after username in basic auth
+
+
 ## [0.2.1] - 2019-06-05
 
 ### Added

--- a/awc/src/builder.rs
+++ b/awc/src/builder.rs
@@ -115,7 +115,7 @@ impl ClientBuilder {
     {
         let auth = match password {
             Some(password) => format!("{}:{}", username, password),
-            None => format!("{}", username),
+            None => format!("{}:", username),
         };
         self.header(
             header::AUTHORIZATION,
@@ -164,7 +164,7 @@ mod tests {
                 .unwrap()
                 .to_str()
                 .unwrap(),
-            "Basic dXNlcm5hbWU="
+            "Basic dXNlcm5hbWU6"
         );
     }
 

--- a/awc/src/request.rs
+++ b/awc/src/request.rs
@@ -280,7 +280,7 @@ impl ClientRequest {
     {
         let auth = match password {
             Some(password) => format!("{}:{}", username, password),
-            None => format!("{}", username),
+            None => format!("{}:", username),
         };
         self.header(
             header::AUTHORIZATION,
@@ -664,7 +664,7 @@ mod tests {
                 .unwrap()
                 .to_str()
                 .unwrap(),
-            "Basic dXNlcm5hbWU="
+            "Basic dXNlcm5hbWU6"
         );
     }
 

--- a/awc/src/ws.rs
+++ b/awc/src/ws.rs
@@ -195,7 +195,7 @@ impl WebsocketsRequest {
     {
         let auth = match password {
             Some(password) => format!("{}:{}", username, password),
-            None => format!("{}", username),
+            None => format!("{}:", username),
         };
         self.header(AUTHORIZATION, format!("Basic {}", base64::encode(&auth)))
     }
@@ -443,7 +443,7 @@ mod tests {
                 .unwrap()
                 .to_str()
                 .unwrap(),
-            "Basic dXNlcm5hbWU="
+            "Basic dXNlcm5hbWU6"
         );
     }
 


### PR DESCRIPTION
I was trying to access a service using the API key as the username for basic auth, but kept getting 500 Internal Server Error whenever trying to do it with actix-web client.

It turned out that it's because actix-web client does now append a colon after the username with `.basic_auth(username, None)`.

While [RFC7617](https://tools.ietf.org/html/rfc7617) does not explicitly mention what to do if with no password, the original [RFC2617](https://tools.ietf.org/html/rfc2617#section-2) does include the BNF in which the ":" is not optional:

```
base64-user-pass  = <base64 [4] encoding of user-pass,
                       except not limited to 76 char/line>
      user-pass   = userid ":" password
      userid      = *<TEXT excluding ":">
      password    = *TEXT
```

Looking at actual implementations:
* curl automatically appends it:
`curl -v http://user@example.com` yields `Authorization: Basic dXNlcjo=` which is `user:`
* reqwest also [appends it](https://docs.rs/reqwest/0.9.18/src/reqwest/request.rs.html#232-243).
* Python [requests](https://2.python-requests.org/en/master/user/authentication/#basic-authentication) library takes a tuple for username/password. Passing `('user', None)` results in literal "None" for the password.
* APIs for other languages that implement basic auth take a username and password, with no special mention of no-password scenario.