### PR TITLE
Impl Responder for (T, StatusCode) where T: Responder

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## [1.0.4] - TBD
 
+### Added
+
+* Add `Responder` impl for `(T, StatusCode) where T: Responder`
+
 ### Changed
 
 * Upgrade `rand` dependency version to 0.7

--- a/src/responder.rs
+++ b/src/responder.rs
@@ -137,6 +137,22 @@ impl Responder for () {
     }
 }
 
+impl<T> Responder for (T, StatusCode)
+where
+    T: Responder,
+{
+    type Error = T::Error;
+    type Future = CustomResponderFut<T>;
+
+    fn respond_to(self, req: &HttpRequest) -> Self::Future {
+        CustomResponderFut {
+            fut: self.0.respond_to(req).into_future(),
+            status: Some(self.1),
+            headers: None,
+        }
+    }
+}
+
 impl Responder for &'static str {
     type Error = Error;
     type Future = FutureResult<Response, Error>;
@@ -617,6 +633,31 @@ pub(crate) mod tests {
         )
         .unwrap();
 
+        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(res.body().bin_ref(), b"test");
+        assert_eq!(
+            res.headers().get(CONTENT_TYPE).unwrap(),
+            HeaderValue::from_static("json")
+        );
+    }
+
+    #[test]
+    fn test_tuple_responder_with_status_code() {
+        let req = TestRequest::default().to_http_request();
+        let res = block_on(
+            ("test".to_string(), StatusCode::BAD_REQUEST).respond_to(&req)
+        )
+        .unwrap();
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(res.body().bin_ref(), b"test");
+
+        let req = TestRequest::default().to_http_request();
+        let res = block_on(
+            ("test".to_string(), StatusCode::OK)
+                .with_header("content-type", "json")
+                .respond_to(&req)
+        )
+        .unwrap();
         assert_eq!(res.status(), StatusCode::OK);
         assert_eq!(res.body().bin_ref(), b"test");
         assert_eq!(


### PR DESCRIPTION
It's quite common to respond with custom status code, for example in Python Flask web framework you can do:

```python
@app.errorhandler(404)
def not_found(error):
    return render_template('error.html'), 404
```

http://flask.pocoo.org/docs/1.0/quickstart/#about-responses

Adding this impl would make life easier when you want to return different status code in different situation. For example, return `201` when a record is created, `200` when a record is updated, consider that you may also need to handle errors, so the  route function might be defined as:

```rust
fn upsert() -> Result<web::Json<T>, Error> {
}
```

without this impl you have to return `impl Responder` or `HttpResponse` type, returning `HttpResponse` type isn't very convenient and with `impl Responder` you might have to do something like this:

```rust
fn upsert() -> impl Responder {
    let res: Result<(T, StatusCode), Error> = {
        // do something, return different status code
    };
    res.map(|(x, s)| web::Json(x).with_status(s))
}
```

which is better but not as clear as returning `(T, StatusCode)`

Ref #277