### PR TITLE
Add the start_with_addr() function

### DIFF
--- a/actix-web-actors/CHANGES.md
+++ b/actix-web-actors/CHANGES.md
@@ -4,6 +4,9 @@
 
 * Allow to use custom ws codec with `WebsocketContext` #925
 
+* Add `ws::start_with_addr()`, returning the address of the created actor, along
+  with the `HttpResponse`.
+
 ## [1.0.0] - 2019-05-29
 
 * Update actix-http and actix-web

--- a/actix-web-actors/src/ws.rs
+++ b/actix-web-actors/src/ws.rs
@@ -35,6 +35,31 @@ where
     Ok(res.streaming(WebsocketContext::create(actor, stream)))
 }
 
+/// Do websocket handshake and start ws actor.
+///
+/// `req` is an HTTP Request that should be requesting a websocket protocol
+/// change. `stream` should be a `Bytes` stream (such as
+/// `actix_web::web::Payload`) that contains a stream of the body request.
+///
+/// If there is a problem with the handshake, an error is returned.
+///
+/// If successful, returns a pair where the first item is an address for the
+/// created actor and the second item is the response that should be returned
+/// from the websocket request.
+pub fn start_with_addr<A, T>(
+    actor: A,
+    req: &HttpRequest,
+    stream: T,
+) -> Result<(Addr<A>, HttpResponse), Error>
+where
+    A: Actor<Context = WebsocketContext<A>> + StreamHandler<Message, ProtocolError>,
+    T: Stream<Item = Bytes, Error = PayloadError> + 'static,
+{
+    let mut res = handshake(req)?;
+    let (addr, out_stream) = WebsocketContext::create_with_addr(actor, stream);
+    Ok((addr, res.streaming(out_stream)))
+}
+
 /// Prepare `WebSocket` handshake response.
 ///
 /// This function returns handshake `HttpResponse`, ready to send to peer.
@@ -172,6 +197,24 @@ where
         A: StreamHandler<Message, ProtocolError>,
         S: Stream<Item = Bytes, Error = PayloadError> + 'static,
     {
+        let (_, stream) = WebsocketContext::create_with_addr(actor, stream);
+        stream
+    }
+
+    #[inline]
+    /// Create a new Websocket context from a request and an actor.
+    ///
+    /// Returns a pair, where the first item is an addr for the created actor,
+    /// and the second item is a stream intended to be set as part of the
+    /// response via `HttpResponseBuilder::streaming()`.
+    pub fn create_with_addr<S>(
+        actor: A,
+        stream: S,
+    ) -> (Addr<A>, impl Stream<Item = Bytes, Error = Error>)
+    where
+        A: StreamHandler<Message, ProtocolError>,
+        S: Stream<Item = Bytes, Error = PayloadError> + 'static,
+    {
         let mb = Mailbox::default();
         let mut ctx = WebsocketContext {
             inner: ContextParts::new(mb.sender_producer()),
@@ -179,7 +222,9 @@ where
         };
         ctx.add_stream(WsStream::new(stream, Codec::new()));
 
-        WebsocketContextFut::new(ctx, actor, mb, Codec::new())
+        let addr = ctx.address();
+
+        (addr, WebsocketContextFut::new(ctx, actor, mb, Codec::new()))
     }
 
     #[inline]


### PR DESCRIPTION
This function allows a client to obtain an address to the target websocket actor on construction.