### PR TITLE
Allow HeaderMap to be cloned

### DIFF
--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## [0.2.8] - 2019-07-xx
 
+### Changed
+
+* Add `Clone` impl for `HeaderMap`
+
 ### Fixed
 
 * Invalid response with compression middleware enabled, but compression-related features disabled #997

--- a/actix-http/src/header/map.rs
+++ b/actix-http/src/header/map.rs
@@ -9,12 +9,12 @@ use http::HttpTryFrom;
 /// `HeaderMap` is an multimap of [`HeaderName`] to values.
 ///
 /// [`HeaderName`]: struct.HeaderName.html
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct HeaderMap {
     pub(crate) inner: HashMap<HeaderName, Value>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) enum Value {
     One(HeaderValue),
     Multi(Vec<HeaderValue>),


### PR DESCRIPTION
This was possible in the previous actix-web and I quite liked that. I don't see any reason this shouldn't be cloneable.