### PR TITLE
Add flate2/libc feature for flate2-zlib

### DIFF
--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## [0.2.10] - unreleased
+
+### Fixed
+
+* Add flate2/libc feature for flate2-zlib to fix compliation issue
+
 ## [0.2.9] - 2019-08-13
 
 ### Changed

--- a/actix-http/Cargo.toml
+++ b/actix-http/Cargo.toml
@@ -35,7 +35,7 @@ rust-tls = ["rustls", "webpki-roots", "actix-connect/rust-tls"]
 brotli = ["brotli2"]
 
 # miniz-sys backend for flate2 crate
-flate2-zlib = ["flate2/miniz-sys"]
+flate2-zlib = ["flate2/miniz-sys", "flate2/libc"]
 
 # rust backend for flate2 crate
 flate2-rust = ["flate2/rust_backend"]


### PR DESCRIPTION
Due to a change in flate2 1.0.10, when "default-features" is false, it is now required to specfy "libc" when specifying the "miniz-sys" feature, in order to compile correctly.

See the comments in https://github.com/alexcrichton/flate2-rs/issues/205