### PR TITLE
Add explicit `dyn`s

### DIFF
--- a/actix-http/src/client/connector.rs
+++ b/actix-http/src/client/connector.rs
@@ -269,9 +269,9 @@ where
                                     .map(|protos| protos.windows(2).any(|w| w == H2))
                                     .unwrap_or(false);
                                 if h2 {
-                                    (Box::new(sock) as Box<Io>, Protocol::Http2)
+                                    (Box::new(sock) as Box<dyn Io>, Protocol::Http2)
                                 } else {
-                                    (Box::new(sock) as Box<Io>, Protocol::Http1)
+                                    (Box::new(sock) as Box<dyn Io>, Protocol::Http1)
                                 }
                             }),
                     ),
@@ -288,9 +288,9 @@ where
                                     .map(|protos| protos.windows(2).any(|w| w == H2))
                                     .unwrap_or(false);
                                 if h2 {
-                                    (Box::new(sock) as Box<Io>, Protocol::Http2)
+                                    (Box::new(sock) as Box<dyn Io>, Protocol::Http2)
                                 } else {
-                                    (Box::new(sock) as Box<Io>, Protocol::Http1)
+                                    (Box::new(sock) as Box<dyn Io>, Protocol::Http1)
                                 }
                             }),
                     ),

--- a/actix-http/src/error.rs
+++ b/actix-http/src/error.rs
@@ -1072,7 +1072,7 @@ mod tests {
     #[test]
     fn test_error_casting() {
         let err = PayloadError::Overflow;
-        let resp_err: &ResponseError = &err;
+        let resp_err: &dyn ResponseError = &err;
         let err = resp_err.downcast_ref::<PayloadError>().unwrap();
         assert_eq!(err.to_string(), "A payload reached size limit.");
         let not_err = resp_err.downcast_ref::<ContentTypeError>();

--- a/src/middleware/normalize.rs
+++ b/src/middleware/normalize.rs
@@ -151,5 +151,4 @@ mod tests {
         let res = block_on(normalize.call(req)).unwrap();
         assert!(res.status().is_success());
     }
-
 }

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -763,5 +763,4 @@ mod tests {
         let resp = call_service(&mut srv, req);
         assert_eq!(resp.status(), StatusCode::NO_CONTENT);
     }
-
 }

--- a/src/types/form.rs
+++ b/src/types/form.rs
@@ -482,5 +482,4 @@ mod tests {
         use crate::responder::tests::BodyTest;
         assert_eq!(resp.body().bin_ref(), b"hello=world&counter=123");
     }
-
 }


### PR DESCRIPTION
Fix clippy warnings (and remove unnecessary lines)