### PR TITLE
Data::to_arc

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@
 
 * Form immplements Responder, returning a `application/x-www-form-urlencoded` response
 
+* Add `into_inner` to `Data`
+
 ### Changed
 
 * `Query` payload made `pub`. Allows user to pattern-match the payload.

--- a/src/data.rs
+++ b/src/data.rs
@@ -77,6 +77,11 @@ impl<T> Data<T> {
     pub fn get_ref(&self) -> &T {
         self.0.as_ref()
     }
+
+    /// Convert to the internal Arc<T>
+    pub fn into_inner(self) -> Arc<T> {
+        self.0
+    }
 }
 
 impl<T> Deref for Data<T> {


### PR DESCRIPTION
I find this function to be convenient, because sometimes you would like to share the Arc<T> with for example a function that takes Arc<T>.
Otherwise, all my functions who needed some shared state from the actix web server needed to depend on the Data type.