### PR TITLE
Add `test::TestRequest::set_form` convenience method

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,9 @@
 
 * Add `into_inner` to `Data`
 
+* Add `test::TestRequest::set_form()` convenience method to automatically serialize data and set
+  the header in test requests.
+
 ### Changed
 
 * `Query` payload made `pub`. Allows user to pattern-match the payload.


### PR DESCRIPTION
Adds a `set_form` convenience method to `test::TestRequest`. The implementation mirrors that of `set_json`. Related to #851.

Motivation: When working to test my own web service built on `actix-web`, I found myself needing to test an endpoint that accepts data POSTed from a HTML form. I imagine this use case is common enough that the community would benefit from having a `set_form` convenience method in the framework.

- [x] I reviewed the Code of Conduct.

Thanks for the awesome framework!