### PR TITLE
Ensure that awc::ws::WebsocketsRequest sets the Host header

### DIFF
--- a/awc/CHANGES.md
+++ b/awc/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## [0.2.5] - 2019-09-06
+
+### Changed
+
+* Ensure that the `Host` header is set when initiating a WebSocket client connection.
+
 ## [0.2.4] - 2019-08-13
 
 ### Changed

--- a/awc/src/ws.rs
+++ b/awc/src/ws.rs
@@ -233,7 +233,9 @@ impl WebsocketsRequest {
             return Either::A(err(InvalidUrl::UnknownScheme.into()));
         }
 
-        self.head.headers.insert(header::HOST, HeaderValue::from_str(uri.host().unwrap()).unwrap());
+        if !self.head.headers.contains_key(header::HOST) {
+            self.head.headers.insert(header::HOST, HeaderValue::from_str(uri.host().unwrap()).unwrap());
+        }
 
         // set cookies
         if let Some(ref mut jar) = self.cookies {

--- a/awc/src/ws.rs
+++ b/awc/src/ws.rs
@@ -233,6 +233,8 @@ impl WebsocketsRequest {
             return Either::A(err(InvalidUrl::UnknownScheme.into()));
         }
 
+        self.head.headers.insert(header::HOST, HeaderValue::from_str(uri.host().unwrap()).unwrap());
+
         // set cookies
         if let Some(ref mut jar) = self.cookies {
             let mut cookie = String::new();


### PR DESCRIPTION
Before connecting, this sets the `Host` header to the `uri` host value. Not doing this will cause 400 Bad Request errors to be returned from a WebSocket server.