### PR TITLE
fix h2 not using error response

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,9 @@
 
 *  Add `middleware::Conditon` that conditionally enables another middleware
 
+### Fixed
+
+* h2 will use error response #1080
 
 ## [1.0.7] - 2019-08-29
 

--- a/actix-http/src/h2/dispatcher.rs
+++ b/actix-http/src/h2/dispatcher.rs
@@ -257,8 +257,8 @@ where
                         }
                     }
                     Ok(Async::NotReady) => Ok(Async::NotReady),
-                    Err(_e) => {
-                        let res: Response = Response::InternalServerError().finish();
+                    Err(e) => {
+                        let res: Response = e.into().into();
                         let (res, body) = res.replace_body(());
 
                         let mut send = send.take().unwrap();

--- a/actix-http/tests/test_rustls_server.rs
+++ b/actix-http/tests/test_rustls_server.rs
@@ -454,9 +454,9 @@ fn test_h2_service_error() {
     });
 
     let response = srv.block_on(srv.sget("/").send()).unwrap();
-    assert_eq!(response.status(), http::StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(response.status(), http::StatusCode::BAD_REQUEST);
 
     // read response
     let bytes = srv.load_body(response).unwrap();
-    assert!(bytes.is_empty());
+    assert_eq!(bytes, Bytes::from_static(b"error"));
 }

--- a/actix-http/tests/test_ssl_server.rs
+++ b/actix-http/tests/test_ssl_server.rs
@@ -449,11 +449,11 @@ fn test_h2_service_error() {
     });
 
     let response = srv.block_on(srv.sget("/").send()).unwrap();
-    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 
     // read response
     let bytes = srv.load_body(response).unwrap();
-    assert!(bytes.is_empty());
+    assert_eq!(bytes, Bytes::from_static(b"error"));
 }
 
 #[test]


### PR DESCRIPTION
There is a discrepancy in error response thrown from ServiceResponse errors between h1 and h2 connections. 

h2 requests will always end up with a code 500 error with no body.

The behaviour in h1 should be the preferred behaviour instead since `actx_http::ResponseError` maybe returned by a Service with specific client error responses.