### PR TITLE
Make UrlencodedError::Overflow more informative

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 
 * Allow to re-construct `ServiceRequest` from `HttpRequest` and `Payload`
 
+* Make UrlEncodedError::Overflow more informativve
 
 ## [1.0.7] - 2019-08-29
 


### PR DESCRIPTION
I got bitten by the fact that the error reported a limit of 256k while the actual default limit was far smaller.

With this patch, the actual limit is reported as well as the size of the oversized payload.
