### PR TITLE
Remove `mem::uninitialized()`

### DIFF
--- a/actix-http/src/client/connector.rs
+++ b/actix-http/src/client/connector.rs
@@ -212,7 +212,7 @@ where
     pub fn finish(
         self,
     ) -> impl Service<Request = Connect, Response = impl Connection, Error = ConnectError>
-                 + Clone {
+           + Clone {
         #[cfg(not(any(feature = "ssl", feature = "rust-tls")))]
         {
             let connector = TimeoutService::new(

--- a/actix-http/src/h1/decoder.rs
+++ b/actix-http/src/h1/decoder.rs
@@ -1,5 +1,6 @@
+use std::io;
 use std::marker::PhantomData;
-use std::{io, mem};
+use std::mem::MaybeUninit;
 
 use actix_codec::Decoder;
 use bytes::{Bytes, BytesMut};
@@ -186,11 +187,12 @@ impl MessageType for Request {
     fn decode(src: &mut BytesMut) -> Result<Option<(Self, PayloadType)>, ParseError> {
         // Unsafe: we read only this data only after httparse parses headers into.
         // performance bump for pipeline benchmarks.
-        let mut headers: [HeaderIndex; MAX_HEADERS] = unsafe { mem::uninitialized() };
+        let mut headers: [HeaderIndex; MAX_HEADERS] =
+            unsafe { MaybeUninit::uninit().assume_init() };
 
         let (len, method, uri, ver, h_len) = {
             let mut parsed: [httparse::Header; MAX_HEADERS] =
-                unsafe { mem::uninitialized() };
+                unsafe { MaybeUninit::uninit().assume_init() };
 
             let mut req = httparse::Request::new(&mut parsed);
             match req.parse(src)? {
@@ -260,11 +262,12 @@ impl MessageType for ResponseHead {
     fn decode(src: &mut BytesMut) -> Result<Option<(Self, PayloadType)>, ParseError> {
         // Unsafe: we read only this data only after httparse parses headers into.
         // performance bump for pipeline benchmarks.
-        let mut headers: [HeaderIndex; MAX_HEADERS] = unsafe { mem::uninitialized() };
+        let mut headers: [HeaderIndex; MAX_HEADERS] =
+            unsafe { MaybeUninit::uninit().assume_init() };
 
         let (len, ver, status, h_len) = {
             let mut parsed: [httparse::Header; MAX_HEADERS] =
-                unsafe { mem::uninitialized() };
+                unsafe { MaybeUninit::uninit().assume_init() };
 
             let mut res = httparse::Response::new(&mut parsed);
             match res.parse(src)? {

--- a/actix-http/src/helpers.rs
+++ b/actix-http/src/helpers.rs
@@ -115,7 +115,7 @@ pub fn write_content_length(mut n: usize, bytes: &mut BytesMut) {
 
 pub(crate) fn convert_usize(mut n: usize, bytes: &mut BytesMut) {
     let mut curr: isize = 39;
-    let mut buf: [u8; 41] = unsafe { mem::uninitialized() };
+    let mut buf: [u8; 41] = unsafe { mem::MaybeUninit::uninit().assume_init() };
     buf[39] = b'\r';
     buf[40] = b'\n';
     let buf_ptr = buf.as_mut_ptr();

--- a/actix-http/src/test.rs
+++ b/actix-http/src/test.rs
@@ -150,7 +150,7 @@ impl TestRequest {
 
     /// Complete request creation and generate `Request` instance
     pub fn finish(&mut self) -> Request {
-        let inner = self.0.take().expect("cannot reuse test request builder");;
+        let inner = self.0.take().expect("cannot reuse test request builder");
 
         let mut req = if let Some(pl) = inner.payload {
             Request::with_payload(pl)


### PR DESCRIPTION
`mem::uninitialized()` will be deprecated in 1.39 ([docs.rs](https://doc.rust-lang.org/nightly/std/mem/fn.uninitialized.html)). This replaces it with `MaybeUninit`.