### PR TITLE
Add ability to use `Infallible` as `HttpResponse` error type

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,8 +8,6 @@
 
 * Allow to re-construct `ServiceRequest` from `HttpRequest` and `Payload`
 
-* Allow to use `std::convert::Infallible` as `actix_http::error::Error`
-
 
 ## [1.0.7] - 2019-08-29
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@
 
 * Allow to re-construct `ServiceRequest` from `HttpRequest` and `Payload`
 
+* Allow to use `std::convert::Infallible` as `actix_http::error::Error`
+
 
 ## [1.0.7] - 2019-08-29
 

--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -6,6 +6,9 @@
 
 * Add support for sending HTTP requests with `Rc<RequestHead>` in addition to sending HTTP requests with `RequestHead`
 
+* Allow to use `std::convert::Infallible` as `actix_http::error::Error`
+
+
 ### Fixed
 
 * h2 will use error response #1080

--- a/actix-http/src/error.rs
+++ b/actix-http/src/error.rs
@@ -158,6 +158,14 @@ impl<E: ResponseError> ResponseError for TimeoutError<E> {
     }
 }
 
+/// Return `INTERNAL_SERVER_ERROR` for `std::convert::Infallible`
+impl ResponseError for std::convert::Infallible {
+    fn error_response(&self) -> Response {
+        // `std::convert::Infallible` should never happen
+        unreachable!()
+    }
+}
+
 #[derive(Debug, Display)]
 #[display(fmt = "UnknownError")]
 struct UnitError;

--- a/actix-http/src/error.rs
+++ b/actix-http/src/error.rs
@@ -132,7 +132,6 @@ impl std::error::Error for Error {
     }
 }
 
-/// Convert `INTERNAL_SERVER_ERROR` to `std::convert::Infallible`
 impl From<std::convert::Infallible> for Error {
     fn from(_: std::convert::Infallible) -> Self {
         // `std::convert::Infallible` should never happen

--- a/actix-http/src/error.rs
+++ b/actix-http/src/error.rs
@@ -166,14 +166,6 @@ impl<E: ResponseError> ResponseError for TimeoutError<E> {
     }
 }
 
-/// Return `INTERNAL_SERVER_ERROR` for `std::convert::Infallible`
-impl ResponseError for std::convert::Infallible {
-    fn error_response(&self) -> Response {
-        // `std::convert::Infallible` should never happen
-        unreachable!()
-    }
-}
-
 #[derive(Debug, Display)]
 #[display(fmt = "UnknownError")]
 struct UnitError;

--- a/actix-http/src/error.rs
+++ b/actix-http/src/error.rs
@@ -132,6 +132,14 @@ impl std::error::Error for Error {
     }
 }
 
+/// Convert `INTERNAL_SERVER_ERROR` to `std::convert::Infallible`
+impl From<std::convert::Infallible> for Error {
+    fn from(_: std::convert::Infallible) -> Self {
+        // `std::convert::Infallible` should never happen
+        unreachable!()
+    }
+}
+
 /// Convert `Error` to a `Response` instance
 impl From<Error> for Response {
     fn from(err: Error) -> Self {

--- a/actix-http/src/error.rs
+++ b/actix-http/src/error.rs
@@ -134,7 +134,8 @@ impl std::error::Error for Error {
 
 impl From<std::convert::Infallible> for Error {
     fn from(_: std::convert::Infallible) -> Self {
-        // `std::convert::Infallible` should never happen
+        // `std::convert::Infallible` indicates an error
+        // that will never happen
         unreachable!()
     }
 }


### PR DESCRIPTION
Sometimes there is 0 chance of having errors when returning user defined type as `HttpResponse`. 
Consider the following code:
```rust
pub struct MyResponse(String);

impl Responder for MyResponse {
    type Error = Infallible;
    type Future = Box<dyn futures::Future<Item = HttpResponse, Error = Infallible>>;

    fn respond_to(self, _: &HttpRequest) -> Self::Future {
        Box::new(futures::future::ok(
             HttpResponse::build(StatusCode::OK)
                .body(self.0)
        ))
    }
}

// `MyResponse` will be returned from `actix_web` handler directly somewhere later

fn main() {
    println!("It compiled!");
}
```

It does not compile with this error:

```console
error[E0277]: the trait bound `std::convert::Infallible: actix_http::error::ResponseError` is not satisfied
   --> src/main.rs:16:18
    |
 16 | impl Responder for MyResponse {
    |      ^^^^^^^^^ the trait `actix_http::error::ResponseError` is not implemented for `std::convert::Infallible`
    |
    = note: required because of the requirements on the impl of `std::convert::From<std::convert::Infallible>` for `actix_http::error::Error`
    = note: required because of the requirements on the impl of `std::convert::Into<actix_http::error::Error>` for `std::convert::Infallible`
```
 
In this case it would be nice to be able to use [`Infallible`](https://doc.rust-lang.org/beta/std/convert/enum.Infallible.html) (will become primitive type `never` in future) as error type to indicate that the result can never be `Err`.

P.S. Also please don't mind a lot of commits generated by me, I was trying to check this solution on existing codebase which didn't recompile crate