### PR TITLE
Add support for serde_json::Value to be passed as argument to ResponseBuilder.body()

### DIFF
--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -1,5 +1,12 @@
 # Changes
 
+## Not released yet
+
+### Added
+
+* Add support for serde_json::Value to be passed as argument to ResponseBuilder.body()
+
+
 ## [0.2.11] - 2019-09-11
 
 ### Added

--- a/actix-http/src/body.rs
+++ b/actix-http/src/body.rs
@@ -234,6 +234,12 @@ impl From<BytesMut> for Body {
     }
 }
 
+impl From<serde_json::Value> for Body {
+    fn from(v: serde_json::Value) -> Body {
+        Body::Bytes(v.to_string().into())
+    }
+}
+
 impl<S> From<SizedStream<S>> for Body
 where
     S: Stream<Item = Bytes, Error = Error> + 'static,
@@ -547,5 +553,18 @@ mod tests {
         assert!(format!("{:?}", Body::None).contains("Body::None"));
         assert!(format!("{:?}", Body::Empty).contains("Body::Empty"));
         assert!(format!("{:?}", Body::Bytes(Bytes::from_static(b"1"))).contains("1"));
+    }
+
+    #[test]
+    fn test_serde_json() {
+        use serde_json::json;
+        assert_eq!(
+            Body::from(serde_json::Value::String("test".into())).size(),
+            BodySize::Sized(6)
+        );
+        assert_eq!(
+            Body::from(json!({"test-key":"test-value"})).size(),
+            BodySize::Sized(25)
+        );
     }
 }

--- a/actix-http/src/response.rs
+++ b/actix-http/src/response.rs
@@ -993,6 +993,14 @@ mod tests {
     }
 
     #[test]
+    fn test_serde_json_in_body() {
+        use serde_json::json;
+        let resp =
+            Response::build(StatusCode::OK).body(json!({"test-key":"test-value"}));
+        assert_eq!(resp.body().get_ref(), br#"{"test-key":"test-value"}"#);
+    }
+
+    #[test]
     fn test_into_response() {
         let resp: Response = "test".into();
         assert_eq!(resp.status(), StatusCode::OK);


### PR DESCRIPTION
Implements https://github.com/actix/actix-web/issues/1086

Admittedly, it is not a great addition, as it adds support for a _specific_ type `serde_json::Value` as opposed to a more generic from like `T : Serialize` which unfortunately conflicts with other `impl`. 