### PR TITLE
Add From<Payload> for crate::dev::Payload

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## [1.0.9] - 2019-xx-xx
+
+### Added
+
+* Add `Payload::into_inner` method and make stored `def::Payload` public. (#1110)
+
 ## [1.0.8] - 2019-09-25
 
 ### Added

--- a/src/types/payload.rs
+++ b/src/types/payload.rs
@@ -45,6 +45,12 @@ use crate::request::HttpRequest;
 /// ```
 pub struct Payload(crate::dev::Payload);
 
+impl From<Payload> for crate::dev::Payload {
+    fn from(payload: Payload) -> Self {
+        payload.0
+    }
+}
+
 impl Stream for Payload {
     type Item = Bytes;
     type Error = PayloadError;

--- a/src/types/payload.rs
+++ b/src/types/payload.rs
@@ -43,11 +43,12 @@ use crate::request::HttpRequest;
 ///     );
 /// }
 /// ```
-pub struct Payload(crate::dev::Payload);
+pub struct Payload(pub crate::dev::Payload);
 
-impl From<Payload> for crate::dev::Payload {
-    fn from(payload: Payload) -> Self {
-        payload.0
+impl Payload {
+    /// Deconstruct to a inner value
+    pub fn into_inner(self) -> crate::dev::Payload {
+        self.0
     }
 }
 


### PR DESCRIPTION
`actix_http::Payload` is visible through `dev` module, but users aren't enable to obtain it, because `types::Payload` wrapper doesn't have a conversion method.

However, `FromRequest::from_request` (which is also public) requires `dev::Payload`, so as for now users are unable to call this method.

So, an example to explain it better:

Some framework provides an interface to build API, and uses actix as a backend. Types of the processed data can differ, so framework has to parse request manually for each endpoint. For some endpoints, it's just `Query` parsed from query string. For others it's Json. 

Now, even given both `HttpRequest` and `Payload`, framework is unable to construct a `Json` object, because it can't access the `dev::Payload`.