### PR TITLE
 Let ResponseError render w/ 'text/plain; charset=utf-8' header (#1118)

### DIFF
--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -6,6 +6,10 @@
 
 * Add support for serde_json::Value to be passed as argument to ResponseBuilder.body()
 
+### Fixed
+
+* To be compatible with non-English error responses, `ResponseError` rendered with `text/plain; charset=utf-8` header #1118
+
 
 ## [0.2.10] - 2019-09-11
 

--- a/actix-http/src/error.rs
+++ b/actix-http/src/error.rs
@@ -75,7 +75,7 @@ pub trait ResponseError: fmt::Debug + fmt::Display {
         let _ = write!(Writer(&mut buf), "{}", self);
         resp.headers_mut().insert(
             header::CONTENT_TYPE,
-            header::HeaderValue::from_static("text/plain"),
+            header::HeaderValue::from_static("text/plain; charset=utf-8"),
         );
         resp.set_body(Body::from(buf))
     }
@@ -536,7 +536,7 @@ where
                 let _ = write!(Writer(&mut buf), "{}", self);
                 res.headers_mut().insert(
                     header::CONTENT_TYPE,
-                    header::HeaderValue::from_static("text/plain"),
+                    header::HeaderValue::from_static("text/plain; charset=utf-8"),
                 );
                 res.set_body(Body::from(buf))
             }


### PR DESCRIPTION
Trait ResponseError originally render Error messages with header
`text/plain` , which causes browsers (i.e. Firefox 70.0) with
Non-English locale unable to render UTF-8 responses with non-English
characters correctly. i.e. emoji.

This fix solved this problem by specifying the charset of `text/plain`
as utf-8, which is the default charset in rust.

Before actix-web consider to support other charsets, this hotfix is
enough.

Test case:

```rust
fn test() -> Result<String, actix_web::Error> {
    Err(actix_web::error::ErrorForbidden("😋test"))
}
```

Fixes #1118
