### PR TITLE
Convert documentation examples to Rust 2018 edition

### DIFF
--- a/src/extract.rs
+++ b/src/extract.rs
@@ -46,9 +46,9 @@ pub trait FromRequest: Sized {
 /// ## Example
 ///
 /// ```rust
-/// # #[macro_use] extern crate serde_derive;
 /// use actix_web::{web, dev, App, Error, HttpRequest, FromRequest};
 /// use actix_web::error::ErrorBadRequest;
+/// use serde_derive::Deserialize;
 /// use rand;
 ///
 /// #[derive(Debug, Deserialize)]
@@ -119,9 +119,9 @@ where
 /// ## Example
 ///
 /// ```rust
-/// # #[macro_use] extern crate serde_derive;
 /// use actix_web::{web, dev, App, Result, Error, HttpRequest, FromRequest};
 /// use actix_web::error::ErrorBadRequest;
+/// use serde_derive::Deserialize;
 /// use rand;
 ///
 /// #[derive(Debug, Deserialize)]

--- a/src/request.rs
+++ b/src/request.rs
@@ -271,8 +271,8 @@ impl Drop for HttpRequest {
 /// ## Example
 ///
 /// ```rust
-/// # #[macro_use] extern crate serde_derive;
 /// use actix_web::{web, App, HttpRequest};
+/// use serde_derive::Deserialize;
 ///
 /// /// extract `Thing` from request
 /// fn index(req: HttpRequest) -> String {

--- a/src/route.rs
+++ b/src/route.rs
@@ -178,8 +178,8 @@ impl Route {
     /// Set handler function, use request extractors for parameters.
     ///
     /// ```rust
-    /// #[macro_use] extern crate serde_derive;
     /// use actix_web::{web, http, App};
+    /// use serde_derive::Deserialize;
     ///
     /// #[derive(Deserialize)]
     /// struct Info {
@@ -239,9 +239,9 @@ impl Route {
     ///
     /// ```rust
     /// # use futures::future::ok;
-    /// #[macro_use] extern crate serde_derive;
     /// use actix_web::{web, App, Error};
     /// use futures::Future;
+    /// use serde_derive::Deserialize;
     ///
     /// #[derive(Deserialize)]
     /// struct Info {

--- a/src/types/form.rs
+++ b/src/types/form.rs
@@ -35,9 +35,8 @@ use crate::responder::Responder;
 ///
 /// ### Example
 /// ```rust
-/// # extern crate actix_web;
-/// #[macro_use] extern crate serde_derive;
-/// use actix_web::{web, App};
+/// use actix_web::web;
+/// use serde_derive::Deserialize;
 ///
 /// #[derive(Deserialize)]
 /// struct FormData {
@@ -61,9 +60,9 @@ use crate::responder::Responder;
 ///
 /// ### Example
 /// ```rust
-/// # #[macro_use] extern crate serde_derive;
-/// # use actix_web::*;
-/// #
+/// use actix_web::*;
+/// use serde_derive::Serialize;
+///
 /// #[derive(Serialize)]
 /// struct SomeForm {
 ///     name: String,
@@ -167,8 +166,8 @@ impl<T: Serialize> Responder for Form<T> {
 /// Form extractor configuration
 ///
 /// ```rust
-/// #[macro_use] extern crate serde_derive;
 /// use actix_web::{web, App, FromRequest, Result};
+/// use serde_derive::Deserialize;
 ///
 /// #[derive(Deserialize)]
 /// struct FormData {

--- a/src/types/json.rs
+++ b/src/types/json.rs
@@ -33,8 +33,8 @@ use crate::responder::Responder;
 /// ## Example
 ///
 /// ```rust
-/// #[macro_use] extern crate serde_derive;
 /// use actix_web::{web, App};
+/// use serde_derive::Deserialize;
 ///
 /// #[derive(Deserialize)]
 /// struct Info {
@@ -60,9 +60,9 @@ use crate::responder::Responder;
 /// trait from *serde*.
 ///
 /// ```rust
-/// # #[macro_use] extern crate serde_derive;
-/// # use actix_web::*;
-/// #
+/// use actix_web::*;
+/// use serde_derive::Serialize;
+///
 /// #[derive(Serialize)]
 /// struct MyObj {
 ///     name: String,
@@ -144,8 +144,8 @@ impl<T: Serialize> Responder for Json<T> {
 /// ## Example
 ///
 /// ```rust
-/// #[macro_use] extern crate serde_derive;
 /// use actix_web::{web, App};
+/// use serde_derive::Deserialize;
 ///
 /// #[derive(Deserialize)]
 /// struct Info {
@@ -203,8 +203,8 @@ where
 /// Json extractor configuration
 ///
 /// ```rust
-/// #[macro_use] extern crate serde_derive;
 /// use actix_web::{error, web, App, FromRequest, HttpResponse};
+/// use serde_derive::Deserialize;
 ///
 /// #[derive(Deserialize)]
 /// struct Info {

--- a/src/types/path.rs
+++ b/src/types/path.rs
@@ -39,8 +39,8 @@ use crate::FromRequest;
 /// implements `Deserialize` trait from *serde*.
 ///
 /// ```rust
-/// #[macro_use] extern crate serde_derive;
 /// use actix_web::{web, App, Error};
+/// use serde_derive::Deserialize;
 ///
 /// #[derive(Deserialize)]
 /// struct Info {
@@ -134,8 +134,8 @@ impl<T: fmt::Display> fmt::Display for Path<T> {
 /// implements `Deserialize` trait from *serde*.
 ///
 /// ```rust
-/// #[macro_use] extern crate serde_derive;
 /// use actix_web::{web, App, Error};
+/// use serde_derive::Deserialize;
 ///
 /// #[derive(Deserialize)]
 /// struct Info {
@@ -190,10 +190,9 @@ where
 /// Path extractor configuration
 ///
 /// ```rust
-/// # #[macro_use]
-/// # extern crate serde_derive;
 /// use actix_web::web::PathConfig;
 /// use actix_web::{error, web, App, FromRequest, HttpResponse};
+/// use serde_derive::Deserialize;
 ///
 /// #[derive(Deserialize, Debug)]
 /// enum Folder {

--- a/src/types/query.rs
+++ b/src/types/query.rs
@@ -21,8 +21,8 @@ use crate::request::HttpRequest;
 /// ## Example
 ///
 /// ```rust
-/// #[macro_use] extern crate serde_derive;
 /// use actix_web::{web, App};
+/// use serde_derive::Deserialize;
 ///
 /// #[derive(Debug, Deserialize)]
 /// pub enum ResponseType {
@@ -99,8 +99,8 @@ impl<T: fmt::Display> fmt::Display for Query<T> {
 /// ## Example
 ///
 /// ```rust
-/// #[macro_use] extern crate serde_derive;
 /// use actix_web::{web, App};
+/// use serde_derive::Deserialize;
 ///
 /// #[derive(Debug, Deserialize)]
 /// pub enum ResponseType {
@@ -169,8 +169,8 @@ where
 /// ## Example
 ///
 /// ```rust
-/// #[macro_use] extern crate serde_derive;
 /// use actix_web::{error, web, App, FromRequest, HttpResponse};
+/// use serde_derive::Deserialize;
 ///
 /// #[derive(Deserialize)]
 /// struct Info {


### PR DESCRIPTION
This is a RFC pull request to convert at least `types::query` examples to Rust 2018 edition.

If this is accepted, I will look into converting other examples too.