### PR TITLE
Support Host guards when Host header is unset

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@
 
 * Add `Payload::into_inner` method and make stored `def::Payload` public. (#1110)
 
+### Changed
+
+* Support `Host` guards when the `Host` header is unset (e.g. HTTP/2 requests) (#1129)
+
 ## [1.0.8] - 2019-09-25
 
 ### Added


### PR DESCRIPTION
Followup to #1050 - it is indeed possible to get the host from the URI, so that should be used as a fallback when the `Host` header has not been set (e.g. HTTP/2 requests).

Fixes #1078 