### PR TITLE
awc: Add support for setting query from Serialize type for client request

### DIFF
--- a/awc/CHANGES.md
+++ b/awc/CHANGES.md
@@ -1,5 +1,8 @@
 # Changes
 
+## [0.2.8] - 2019-10-24
+
+* Add support for setting query from Serialize type for client request.
 
 ## [0.2.7] - 2019-09-25
 


### PR DESCRIPTION
This solves #1060 but I have one minor issue resolve, I'm leaving a followup comment on the code to discuss.