### PR TITLE
feat(files): add possibility to redirect to slash-ended path

### DIFF
--- a/actix-files/CHANGES.md
+++ b/actix-files/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+## [0.1.6] - TBD
+
+* Add option to redirect to a slash-ended path `Files` #1132
+
 ## [0.1.5] - 2019-10-08
 
 * Bump up `mime_guess` crate version to 2.0.1
@@ -7,17 +11,14 @@
 * Bump up `percent-encoding` crate version to 2.1
 
 * Allow user defined request guards for `Files` #1113
-
-
+  
 ## [0.1.4] - 2019-07-20
 
 * Allow to disable `Content-Disposition` header #686
 
-
 ## [0.1.3] - 2019-06-28
 
 * Do not set `Content-Length` header, let actix-http set it #930
-
 
 ## [0.1.2] - 2019-06-13
 


### PR DESCRIPTION
When accessing to a folder without a final slash, the index file will be loaded ok, but if it has
references (like a css or an image in an html file) these resources won't be loaded correctly if
they are using relative paths. In order to solve this, this PR adds the possibility to detect
folders without a final slash and make a 302 redirect to mitigate this issue. The behavior is off by
default. We're adding a new method called `redirect_to_slash_directory` which can be used to enable
this behavior.

Fixes #1132
Fixes #671 