### PR TITLE
Add DataRaw type.

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -12,7 +12,7 @@ use futures::{Future, IntoFuture};
 
 use crate::app_service::{AppEntry, AppInit, AppRoutingFactory};
 use crate::config::{AppConfig, AppConfigInner, ServiceConfig};
-use crate::data::{Data, DataFactory};
+use crate::data::{AppData, Data, DataFactory, DataRaw};
 use crate::dev::ResourceDef;
 use crate::error::Error;
 use crate::resource::Resource;
@@ -104,6 +104,11 @@ where
         self
     }
 
+    pub fn data_raw<U: Send + Sync + Clone + 'static>(mut self, data: U) -> Self {
+        self.data.push(Box::new(DataRaw::new(data)));
+        self
+    }
+
     /// Set application data factory. This function is
     /// similar to `.data()` but it accepts data factory. Data object get
     /// constructed asynchronously during application initialization.
@@ -130,8 +135,8 @@ where
     }
 
     /// Set application data. Application data could be accessed
-    /// by using `Data<T>` extractor where `T` is data type.
-    pub fn register_data<U: 'static>(mut self, data: Data<U>) -> Self {
+    /// by using `Data<T>`or `DataRaw<T>` extractor where `T` is data type.
+    pub fn register_data<U: AppData + Clone + 'static>(mut self, data: U) -> Self {
         self.data.push(Box::new(data));
         self
     }

--- a/src/data.rs
+++ b/src/data.rs
@@ -13,6 +13,21 @@ pub(crate) trait DataFactory {
     fn create(&self, extensions: &mut Extensions) -> bool;
 }
 
+/// AppData is a trait generic over `Data<T>` and `DataRaw<T>`.
+/// A type impl this trait can use `FromRequest` and `DataFactory` to extract and push data to extension
+pub trait AppData {
+    type Data;
+    type Inner;
+    /// Create new `Data` instance.
+    fn new(state: Self::Data) -> Self;
+
+    /// Get reference to inner app data.
+    fn get_ref(&self) -> &Self::Data;
+
+    /// Convert to the internal Data.
+    fn into_inner(self) -> Self::Inner;
+}
+
 /// Application data.
 ///
 /// Application data is an arbitrary data attached to the app.
@@ -37,7 +52,7 @@ pub(crate) trait DataFactory {
 ///
 /// ```rust
 /// use std::sync::Mutex;
-/// use actix_web::{web, App};
+/// use actix_web::{web::{self, AppData}, App};
 ///
 /// struct MyData {
 ///     counter: usize,
@@ -63,27 +78,6 @@ pub(crate) trait DataFactory {
 #[derive(Debug)]
 pub struct Data<T>(Arc<T>);
 
-impl<T> Data<T> {
-    /// Create new `Data` instance.
-    ///
-    /// Internally `Data` type uses `Arc`. if your data implements
-    /// `Send` + `Sync` traits you can use `web::Data::new()` and
-    /// avoid double `Arc`.
-    pub fn new(state: T) -> Data<T> {
-        Data(Arc::new(state))
-    }
-
-    /// Get reference to inner app data.
-    pub fn get_ref(&self) -> &T {
-        self.0.as_ref()
-    }
-
-    /// Convert to the internal Arc<T>
-    pub fn into_inner(self) -> Arc<T> {
-        self.0
-    }
-}
-
 impl<T> Deref for Data<T> {
     type Target = T;
 
@@ -98,7 +92,99 @@ impl<T> Clone for Data<T> {
     }
 }
 
-impl<T: 'static> FromRequest for Data<T> {
+impl<T> AppData for Data<T> {
+    type Data = T;
+    type Inner = Arc<T>;
+    fn new(state: Self::Data) -> Self {
+        Data(Arc::new(state))
+    }
+
+    fn get_ref(&self) -> &Self::Data {
+        self.0.as_ref()
+    }
+
+    fn into_inner(self) -> Self::Inner {
+        self.0
+    }
+}
+
+/// Raw Application data.
+///
+/// Raw Application data shares the same principle of Application data.
+/// The difference is Raw Application data explicitly require the data type to be `Send + Sync + Clone`.
+///
+/// This is useful when you introduce a foreign type(from other crates for example) that is already thread safe.
+/// By using Raw Application data you can avoid the additional layer of `Arc` provided by `web::Data`
+/// ```rust
+/// use std::sync::{Arc, Mutex};
+/// use actix_web::{web::{self, AppData}, App};
+///
+/// struct ForeignType {
+///     inner: Arc<Mutex<usize>>
+/// }
+///
+/// impl Clone for ForeignType {
+///     fn clone(&self) -> Self {
+///         ForeignType {
+///             inner: self.inner.clone()
+///         }
+///     }
+/// }
+///
+/// /// Use `DataRaw<T>` extractor to access data in handler.
+/// fn index(data: web::DataRaw<ForeignType>) {
+///     let mut data = data.inner.lock().unwrap();
+///     *data += 1;
+/// }
+///
+/// fn main() {
+///     let data = ForeignType {
+///         inner: Arc::new(Mutex::new(1usize))
+///     };
+///
+///     let app = App::new()
+///         // Store `ForeignTypeType` in application storage.
+///         .data_raw(data.clone())
+///         .service(
+///             web::resource("/index.html").route(
+///                 web::get().to(index)));
+/// }
+/// ```
+#[derive(Debug)]
+pub struct DataRaw<T: Send + Sync + Clone>(T);
+
+impl<T: Send + Sync + Clone> Clone for DataRaw<T> {
+    fn clone(&self) -> DataRaw<T> {
+        DataRaw(self.0.clone())
+    }
+}
+
+impl<T: Send + Sync + Clone> Deref for DataRaw<T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        &self.0
+    }
+}
+
+impl<T> AppData for DataRaw<T>
+    where T: Send + Sync + Clone {
+    type Data = T;
+    type Inner = T;
+    fn new(state: Self::Data) -> Self {
+        DataRaw(state)
+    }
+
+    fn get_ref(&self) -> &Self::Data {
+        &*self
+    }
+
+    fn into_inner(self) -> Self::Inner {
+        self.0
+    }
+}
+
+impl<T: AppData + Clone + 'static> FromRequest for T {
     type Config = ();
     type Error = Error;
     type Future = Result<Self, Error>;
@@ -120,10 +206,10 @@ impl<T: 'static> FromRequest for Data<T> {
     }
 }
 
-impl<T: 'static> DataFactory for Data<T> {
+impl<T: AppData + Clone + 'static> DataFactory for T {
     fn create(&self, extensions: &mut Extensions) -> bool {
-        if !extensions.contains::<Data<T>>() {
-            extensions.insert(Data(self.0.clone()));
+        if !extensions.contains::<T>() {
+            extensions.insert(self.clone());
             true
         } else {
             false
@@ -133,6 +219,9 @@ impl<T: 'static> DataFactory for Data<T> {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Mutex;
+    use std::sync::atomic::{AtomicUsize, AtomicU32};
+
     use actix_service::Service;
 
     use super::*;
@@ -223,4 +312,54 @@ mod tests {
         let resp = block_on(srv.call(req)).unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
     }
+
+    #[test]
+    fn test_data_raw_extractor() {
+        let mut srv =
+            init_service(App::new().data_raw(Arc::new(Mutex::new(1usize))).service(
+                web::resource("/").to(|_: web::DataRaw<Arc<Mutex<usize>>>| HttpResponse::Ok()),
+            ));
+
+        let req = TestRequest::default().to_request();
+        let resp = block_on(srv.call(req)).unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let mut srv =
+            init_service(App::new().data_raw(Arc::new(AtomicUsize::new(1))).service(
+                web::resource("/").to(|_: web::DataRaw<Arc<AtomicUsize>>| HttpResponse::Ok()),
+            ));
+
+        let req = TestRequest::default().to_request();
+        let resp = block_on(srv.call(req)).unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let mut srv =
+            init_service(App::new().data_raw(Arc::new(AtomicUsize::new(1))).service(
+                web::resource("/").to(|_: web::DataRaw<Arc<AtomicU32>>| HttpResponse::Ok()),
+            ));
+        let req = TestRequest::default().to_request();
+        let resp = block_on(srv.call(req)).unwrap();
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[test]
+    fn test_register_data_raw_extractor() {
+        let mut srv =
+            init_service(App::new().register_data(DataRaw::new(Arc::new(AtomicUsize::new(1)))).service(
+                web::resource("/").to(|_: web::DataRaw<Arc<AtomicUsize>>| HttpResponse::Ok()),
+            ));
+
+        let req = TestRequest::default().to_request();
+        let resp = block_on(srv.call(req)).unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let mut srv =
+            init_service(App::new().register_data(DataRaw::new(Arc::new(AtomicUsize::new(1)))).service(
+                web::resource("/").to(|_: web::DataRaw<Arc<AtomicU32>>| HttpResponse::Ok()),
+            ));
+        let req = TestRequest::default().to_request();
+        let resp = block_on(srv.call(req)).unwrap();
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -218,8 +218,8 @@ impl HttpRequest {
 
     /// Get an application data stored with `App::data()` method during
     /// application configuration.
-    pub fn get_app_data<T: 'static>(&self) -> Option<Data<T>> {
-        if let Some(st) = self.0.app_data.get::<Data<T>>() {
+    pub fn get_app_data<T: Clone + 'static>(&self) -> Option<T> {
+        if let Some(st) = self.0.app_data.get::<T>() {
             Some(st.clone())
         } else {
             None

--- a/src/test.rs
+++ b/src/test.rs
@@ -19,7 +19,7 @@ pub use actix_http::test::TestBuffer;
 pub use actix_testing::{block_fn, block_on, run_on};
 
 use crate::config::{AppConfig, AppConfigInner};
-use crate::data::Data;
+use crate::data::{AppData, Data};
 use crate::dev::{Body, MessageBody, Payload};
 use crate::request::HttpRequestPool;
 use crate::rmap::ResourceMap;
@@ -521,8 +521,8 @@ mod tests {
         assert!(req.headers().contains_key(header::DATE));
         assert_eq!(&req.match_info()["test"], "123");
         assert_eq!(req.version(), Version::HTTP_2);
-        let data = req.get_app_data::<u32>().unwrap();
-        assert!(req.get_app_data::<u64>().is_none());
+        let data = req.get_app_data::<web::Data<u32>>().unwrap();
+        assert!(req.get_app_data::<web::Data<u64>>().is_none());
         assert_eq!(*data, 10);
         assert_eq!(*data.get_ref(), 10);
 

--- a/src/web.rs
+++ b/src/web.rs
@@ -15,7 +15,7 @@ use crate::scope::Scope;
 use crate::service::WebService;
 
 pub use crate::config::ServiceConfig;
-pub use crate::data::Data;
+pub use crate::data::{AppData, Data, DataRaw};
 pub use crate::request::HttpRequest;
 pub use crate::types::*;
 


### PR DESCRIPTION
I want to introduce a foreign type from other crates to `App::data`. 
Although it's already a `Send + Sync`type but the `web::Data` will still wrap it with another layer of `Arc`. So I added this `DataRaw` type which share the same principle with `Data` but it explicitly require the type to be `Send + Sync + Clone` so that it doesn't have to be wrapped in `Arc`.