### PR TITLE
Increase timeouts in test-server

### DIFF
--- a/test-server/CHANGES.md
+++ b/test-server/CHANGES.md
@@ -5,6 +5,7 @@
 ### Changed
 
 * Update serde_urlencoded to "0.6.1"
+* Increase TestServerRuntime timeouts from 500ms to 3000ms
 
 ### Fixed
 

--- a/test-server/src/lib.rs
+++ b/test-server/src/lib.rs
@@ -144,7 +144,7 @@ impl TestServer {
                         .map_err(|e| log::error!("Can not set alpn protocol: {:?}", e));
                     Connector::new()
                         .conn_lifetime(time::Duration::from_secs(0))
-                        .timeout(time::Duration::from_millis(500))
+                        .timeout(time::Duration::from_millis(3000))
                         .ssl(builder.build())
                         .finish()
                 }
@@ -152,7 +152,7 @@ impl TestServer {
                 {
                     Connector::new()
                         .conn_lifetime(time::Duration::from_secs(0))
-                        .timeout(time::Duration::from_millis(500))
+                        .timeout(time::Duration::from_millis(3000))
                         .finish()
                 }
             };


### PR DESCRIPTION
Due to https://github.com/actix/actix-web/issues/1149, I think the timeout should be increased. I am not sure about the exact value, but I think it should not be too strict. When I test my code on a CI server, it spuriously fails about 10% of the time. Sometimes it fails several times in a row within a few minutes. This makes me suspect that it does have something to do with the IO load on the server. In any case, such spurious timeouts should never happen. It's difficult to reproduce because it has to do with the hardware, and on my own desktop it very rarely happens (but I have seen it).