### PR TITLE
Handle fragmented websocket messages

### DIFF
--- a/actix-http/src/h1/dispatcher.rs
+++ b/actix-http/src/h1/dispatcher.rs
@@ -558,11 +558,13 @@ where
                 }
                 Ok(None) => break,
                 Err(ParseError::Io(e)) => {
+                    error!("IO error when parsing!");
                     self.client_disconnected();
                     self.error = Some(DispatchError::Io(e));
                     break;
                 }
                 Err(e) => {
+                    error!("Parsing error {:?}", e);
                     if let Some(mut payload) = self.payload.take() {
                         payload.set_error(PayloadError::EncodingCorrupted);
                     }

--- a/actix-http/src/ws/codec.rs
+++ b/actix-http/src/ws/codec.rs
@@ -122,6 +122,7 @@ impl Decoder for Codec {
                             Ok(Some(Frame::BeginText(payload)))
                         }
                         _ => {
+                            error!("Unfinished fragment {:?}", opcode);
                             Err(ProtocolError::NoContinuation)
                         }
                     };

--- a/actix-http/src/ws/codec.rs
+++ b/actix-http/src/ws/codec.rs
@@ -104,13 +104,21 @@ impl Decoder for Codec {
             Ok(Some((finished, opcode, payload))) => {
                 // continuation is not supported
                 if !finished {
+                    error!("No continuation 1");
                     return Err(ProtocolError::NoContinuation);
                 }
 
                 match opcode {
-                    OpCode::Continue => Err(ProtocolError::NoContinuation),
-                    OpCode::Bad => Err(ProtocolError::BadOpCode),
+                    OpCode::Continue => {
+                        error!("No continuation 2");
+                        Err(ProtocolError::NoContinuation)
+                    }
+                    OpCode::Bad => {
+                        error!("Bad opcode");
+                        Err(ProtocolError::BadOpCode)
+                    }
                     OpCode::Close => {
+                        warn!("Got a close frame!");
                         if let Some(ref pl) = payload {
                             let close_reason = Parser::parse_close_payload(pl);
                             Ok(Some(Frame::Close(close_reason)))

--- a/actix-http/src/ws/frame.rs
+++ b/actix-http/src/ws/frame.rs
@@ -32,10 +32,8 @@ impl Parser {
         // check masking
         let masked = second & 0x80 != 0;
         if !masked && server {
-            error!("Protocol unmasked frame");
             return Err(ProtocolError::UnmaskedFrame);
         } else if masked && !server {
-            error!("Protocol masked frame");
             return Err(ProtocolError::MaskedFrame);
         }
 
@@ -43,7 +41,6 @@ impl Parser {
         let opcode = OpCode::from(first & 0x0F);
 
         if let OpCode::Bad = opcode {
-            error!("Protocol invalid opcode");
             return Err(ProtocolError::InvalidOpcode(first & 0x0F));
         }
 
@@ -63,7 +60,6 @@ impl Parser {
             }
             let len = u64::from_be_bytes(TryFrom::try_from(&src[idx..idx + 8]).unwrap());
             if len > max_size as u64 {
-                error!("Protocol overflow 1");
                 return Err(ProtocolError::Overflow);
             }
             idx += 8;
@@ -74,7 +70,6 @@ impl Parser {
 
         // check for max allowed size
         if length > max_size {
-            error!("Protocol overflow 2");
             return Err(ProtocolError::Overflow);
         }
 
@@ -125,7 +120,6 @@ impl Parser {
         // control frames must have length <= 125
         match opcode {
             OpCode::Ping | OpCode::Pong if length > 125 => {
-                error!("Protocol invalid length");
                 return Err(ProtocolError::InvalidLength(length));
             }
             OpCode::Close if length > 125 => {

--- a/actix-http/src/ws/frame.rs
+++ b/actix-http/src/ws/frame.rs
@@ -32,8 +32,10 @@ impl Parser {
         // check masking
         let masked = second & 0x80 != 0;
         if !masked && server {
+            error!("Protocol unmasked frame");
             return Err(ProtocolError::UnmaskedFrame);
         } else if masked && !server {
+            error!("Protocol masked frame");
             return Err(ProtocolError::MaskedFrame);
         }
 
@@ -41,6 +43,7 @@ impl Parser {
         let opcode = OpCode::from(first & 0x0F);
 
         if let OpCode::Bad = opcode {
+            error!("Protocol invalid opcode");
             return Err(ProtocolError::InvalidOpcode(first & 0x0F));
         }
 
@@ -60,6 +63,7 @@ impl Parser {
             }
             let len = u64::from_be_bytes(TryFrom::try_from(&src[idx..idx + 8]).unwrap());
             if len > max_size as u64 {
+                error!("Protocol overflow 1");
                 return Err(ProtocolError::Overflow);
             }
             idx += 8;
@@ -70,6 +74,7 @@ impl Parser {
 
         // check for max allowed size
         if length > max_size {
+            error!("Protocol overflow 2");
             return Err(ProtocolError::Overflow);
         }
 
@@ -120,6 +125,7 @@ impl Parser {
         // control frames must have length <= 125
         match opcode {
             OpCode::Ping | OpCode::Pong if length > 125 => {
+                error!("Protocol invalid length");
                 return Err(ProtocolError::InvalidLength(length));
             }
             OpCode::Close if length > 125 => {

--- a/actix-http/src/ws/mod.rs
+++ b/actix-http/src/ws/mod.rs
@@ -48,8 +48,8 @@ pub enum ProtocolError {
     #[display(fmt = "Continuation is not supported.")]
     NoContinuation,
     /// Bad utf-8 encoding
-    #[display(fmt = "Bad utf-8 encoding.")]
-    BadEncoding,
+    #[display(fmt = "Bad utf-8 encoding: {}", _0)]
+    BadEncoding(std::str::Utf8Error),
     /// Io error
     #[display(fmt = "io error: {}", _0)]
     Io(io::Error),

--- a/actix-web-actors/Cargo.toml
+++ b/actix-web-actors/Cargo.toml
@@ -24,6 +24,7 @@ actix-http = "0.2.5"
 actix-codec = "0.1.2"
 bytes = "0.4"
 futures = "0.1.25"
+log = "0.4"
 
 [dev-dependencies]
 env_logger = "0.6"

--- a/actix-web-actors/src/ws.rs
+++ b/actix-web-actors/src/ws.rs
@@ -543,6 +543,12 @@ where
                 let msg = match frm {
                     Frame::Text(data) => {
                         Some(if let Some(data) = data {
+                            let text = std::str::from_utf8(&data);
+
+                            if text.is_err() {
+                                error!("Invalid UTF-8 encoding");
+                            }
+
                             Message::Text(std::str::from_utf8(&data)?.to_string())
                         } else {
                             Message::Text(String::new())

--- a/actix-web-actors/src/ws.rs
+++ b/actix-web-actors/src/ws.rs
@@ -549,7 +549,7 @@ where
                                 error!("Invalid UTF-8 encoding");
                             }
 
-                            Message::Text(std::str::from_utf8(&data)?.to_string())
+                            Message::Text(text?.to_string())
                         } else {
                             Message::Text(String::new())
                         })
@@ -604,8 +604,15 @@ where
                         match self.collector.take() {
                             Collector::Text(mut buf) => {
                                 buf.extend_from_slice(data);
+
+                                let text = std::str::from_utf8(&buf);
+
+                                if text.is_err() {
+                                    error!("Invalid UTF-8 encoding");
+                                }
+
                                 Some(Message::Text(
-                                    std::str::from_utf8(&buf)?.to_string()
+                                    text?.to_string()
                                 ))
                             }
                             Collector::Binary(mut buf) => {

--- a/actix-web-actors/src/ws.rs
+++ b/actix-web-actors/src/ws.rs
@@ -288,7 +288,7 @@ where
             inner: ContextParts::new(mb.sender_producer()),
             messages: VecDeque::new(),
         };
-        ctx.add_stream(WsStream::new(stream, codec));
+        ctx.add_stream(WsStream::new(stream, codec.clone()));
 
         WebsocketContextFut::new(ctx, actor, mb, codec)
     }


### PR DESCRIPTION
Closes #7. This PR implements handing of fragmented messages (using continuation frames) by adding a couple new `Frame` variants, and then concating them within `actix-web-actors`.

Some points for discussion:
+ I added some `error!` logs to help myself debug stuff, those could be changed to `debug!` or removed if there are any concerns.
+ The concatenation could be done within the `Codec` itself, although that requires attaching a buffer to the `Codec` which makes it non-`Copy`. I went with adding new frame variants instead as it matches the protocol better (continuation frames are separate frames after all).
+ There concatenation that happens within `actix-web-actors` is currently unconstrained. It could use the same `max_size` limit the `Codec` is enforcing (that's probably the easiest and least confusing way to do it, it basically changes the limit from "frame limit" to "message limit"), or be a setting of its own.