### PR TITLE
Remove `rustls` from `package.metadata.docs.rs`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [".gitignore", ".travis.yml", ".cargo/config", "appveyor.yml"]
 edition = "2018"
 
 [package.metadata.docs.rs]
-features = ["openssl", "rustls", "brotli", "flate2-zlib", "secure-cookies", "client"]
+features = ["openssl", "brotli", "flate2-zlib", "secure-cookies", "client"]
 
 [badges]
 travis-ci = { repository = "actix/actix-web", branch = "master" }


### PR DESCRIPTION
I think this is needed to disable `rustls` feature completely and build docs