### PR TITLE
Switch brotli compressor to rust.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ default = ["brotli", "flate2-zlib", "client", "fail"]
 # http client
 client = ["awc"]
 
-# brotli encoding, requires c compiler
+# brotli encoding
 brotli = ["actix-http/brotli", "awc/brotli"]
 
 # miniz-sys backend for flate2 crate
@@ -111,7 +111,7 @@ actix-http-test = "1.0.0-alpha.3"
 rand = "0.7"
 env_logger = "0.6"
 serde_derive = "1.0"
-brotli2 = "0.3.2"
+brotli2 = { package = "brotli", version = "3.3.0" }
 flate2 = "1.0.2"
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [".gitignore", ".travis.yml", ".cargo/config", "appveyor.yml"]
 edition = "2018"
 
 [package.metadata.docs.rs]
-features = ["openssl", "brotli", "flate2-zlib", "secure-cookies", "client"]
+features = ["openssl", "flate2-zlib", "secure-cookies", "client"]
 
 [badges]
 travis-ci = { repository = "actix/actix-web", branch = "master" }
@@ -43,13 +43,10 @@ members = [
 ]
 
 [features]
-default = ["brotli", "flate2-zlib", "client", "fail"]
+default = ["flate2-zlib", "client", "fail"]
 
 # http client
 client = ["awc"]
-
-# brotli encoding
-brotli = ["actix-http/brotli", "awc/brotli"]
 
 # miniz-sys backend for flate2 crate
 flate2-zlib = ["actix-http/flate2-zlib", "awc/flate2-zlib"]
@@ -111,7 +108,7 @@ actix-http-test = "1.0.0-alpha.3"
 rand = "0.7"
 env_logger = "0.6"
 serde_derive = "1.0"
-brotli2 = { package = "brotli", version = "3.3.0" }
+brotli = "3.3.0"
 flate2 = "1.0.2"
 
 [profile.release]

--- a/actix-http/Cargo.toml
+++ b/actix-http/Cargo.toml
@@ -31,7 +31,7 @@ openssl = ["actix-tls/openssl", "actix-connect/openssl"]
 # rustls support
 rustls = ["actix-tls/rustls", "actix-connect/rustls"]
 
-# brotli encoding, requires c compiler
+# brotli encoding
 brotli = ["brotli2"]
 
 # miniz-sys backend for flate2 crate
@@ -88,7 +88,7 @@ time = "0.1.42"
 ring = { version = "0.16.9", optional = true }
 
 # compression
-brotli2 = { version="0.3.2", optional = true }
+brotli2 = { package = "brotli", version="3.3.0", optional = true }
 flate2 = { version="1.0.7", optional = true, default-features = false }
 
 # optional deps

--- a/actix-http/Cargo.toml
+++ b/actix-http/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 workspace = ".."
 
 [package.metadata.docs.rs]
-features = ["openssl", "rustls", "fail", "brotli", "flate2-zlib", "secure-cookies"]
+features = ["openssl", "rustls", "fail", "flate2-zlib", "secure-cookies"]
 
 [lib]
 name = "actix_http"
@@ -30,9 +30,6 @@ openssl = ["actix-tls/openssl", "actix-connect/openssl"]
 
 # rustls support
 rustls = ["actix-tls/rustls", "actix-connect/rustls"]
-
-# brotli encoding
-brotli = ["brotli2"]
 
 # miniz-sys backend for flate2 crate
 flate2-zlib = ["flate2/miniz-sys"]
@@ -88,7 +85,7 @@ time = "0.1.42"
 ring = { version = "0.16.9", optional = true }
 
 # compression
-brotli2 = { package = "brotli", version="3.3.0", optional = true }
+brotli = "3.3.0"
 flate2 = { version="1.0.7", optional = true, default-features = false }
 
 # optional deps

--- a/actix-http/src/client/connector.rs
+++ b/actix-http/src/client/connector.rs
@@ -87,9 +87,9 @@ impl Connector<(), ()> {
                 let protos = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
                 let mut config = ClientConfig::new();
                 config.set_protocols(&protos);
-                config.root_store.add_server_trust_anchors(
-                    &actix_tls::rustls::TLS_SERVER_ROOTS,
-                );
+                config
+                    .root_store
+                    .add_server_trust_anchors(&actix_tls::rustls::TLS_SERVER_ROOTS);
                 SslConnector::Rustls(Arc::new(config))
             }
             #[cfg(not(any(feature = "openssl", feature = "rustls")))]

--- a/actix-http/src/encoding/encoder.rs
+++ b/actix-http/src/encoding/encoder.rs
@@ -212,7 +212,7 @@ impl ContentEncoder {
             ContentEncoder::Br(ref mut encoder) => {
                 let mut encoder_new = CompressorWriter::new(Writer::new(), 0, 3, 0);
                 std::mem::swap(encoder, &mut encoder_new);
-                encoder_new.into_inner().take()
+                encoder_new.into_inner().freeze()
             }
             #[cfg(any(feature = "flate2-zlib", feature = "flate2-rust"))]
             ContentEncoder::Deflate(ref mut encoder) => encoder.get_mut().take(),

--- a/actix-http/src/encoding/encoder.rs
+++ b/actix-http/src/encoding/encoder.rs
@@ -6,7 +6,7 @@ use std::task::{Context, Poll};
 
 use actix_threadpool::{run, CpuFuture};
 #[cfg(feature = "brotli")]
-use brotli2::write::BrotliEncoder;
+use brotli2::CompressorWriter;
 use bytes::Bytes;
 #[cfg(any(feature = "flate2-zlib", feature = "flate2-rust"))]
 use flate2::write::{GzEncoder, ZlibEncoder};
@@ -178,7 +178,7 @@ enum ContentEncoder {
     #[cfg(any(feature = "flate2-zlib", feature = "flate2-rust"))]
     Gzip(GzEncoder<Writer>),
     #[cfg(feature = "brotli")]
-    Br(BrotliEncoder<Writer>),
+    Br(CompressorWriter<Writer>),
 }
 
 impl ContentEncoder {
@@ -195,9 +195,12 @@ impl ContentEncoder {
                 flate2::Compression::fast(),
             ))),
             #[cfg(feature = "brotli")]
-            ContentEncoding::Br => {
-                Some(ContentEncoder::Br(BrotliEncoder::new(Writer::new(), 3)))
-            }
+            ContentEncoding::Br => Some(ContentEncoder::Br(CompressorWriter::new(
+                Writer::new(),
+                0,
+                3,
+                0,
+            ))),
             _ => None,
         }
     }
@@ -206,7 +209,11 @@ impl ContentEncoder {
     pub(crate) fn take(&mut self) -> Bytes {
         match *self {
             #[cfg(feature = "brotli")]
-            ContentEncoder::Br(ref mut encoder) => encoder.get_mut().take(),
+            ContentEncoder::Br(ref mut encoder) => {
+                let mut encoder_new = CompressorWriter::new(Writer::new(), 0, 3, 0);
+                std::mem::swap(encoder, &mut encoder_new);
+                encoder_new.into_inner().take()
+            }
             #[cfg(any(feature = "flate2-zlib", feature = "flate2-rust"))]
             ContentEncoder::Deflate(ref mut encoder) => encoder.get_mut().take(),
             #[cfg(any(feature = "flate2-zlib", feature = "flate2-rust"))]
@@ -217,10 +224,7 @@ impl ContentEncoder {
     fn finish(self) -> Result<Bytes, io::Error> {
         match self {
             #[cfg(feature = "brotli")]
-            ContentEncoder::Br(encoder) => match encoder.finish() {
-                Ok(writer) => Ok(writer.buf.freeze()),
-                Err(err) => Err(err),
-            },
+            ContentEncoder::Br(encoder) => Ok(encoder.into_inner().buf.freeze()),
             #[cfg(any(feature = "flate2-zlib", feature = "flate2-rust"))]
             ContentEncoder::Gzip(encoder) => match encoder.finish() {
                 Ok(writer) => Ok(writer.buf.freeze()),

--- a/actix-http/src/encoding/mod.rs
+++ b/actix-http/src/encoding/mod.rs
@@ -22,6 +22,9 @@ impl Writer {
     fn take(&mut self) -> Bytes {
         self.buf.split().freeze()
     }
+    fn freeze(self) -> Bytes {
+        self.buf.freeze()
+    }
 }
 
 impl io::Write for Writer {

--- a/awc/Cargo.toml
+++ b/awc/Cargo.toml
@@ -21,19 +21,16 @@ name = "awc"
 path = "src/lib.rs"
 
 [package.metadata.docs.rs]
-features = ["openssl", "rustls", "brotli", "flate2-zlib"]
+features = ["openssl", "rustls", "flate2-zlib"]
 
 [features]
-default = ["brotli", "flate2-zlib"]
+default = ["flate2-zlib"]
 
 # openssl
 openssl = ["open-ssl", "actix-http/openssl"]
 
 # rustls
 rustls = ["rust-tls", "actix-http/rustls"]
-
-# brotli encoding
-brotli = ["actix-http/brotli"]
 
 # miniz-sys backend for flate2 crate
 flate2-zlib = ["actix-http/flate2-zlib"]
@@ -69,7 +66,7 @@ actix-http-test = { version = "1.0.0-alpha.3", features=["openssl"] }
 actix-utils = "1.0.0-alpha.3"
 actix-server = { version = "1.0.0-alpha.3" }
 actix-tls = { version = "1.0.0-alpha.3", features=["openssl", "rustls"] }
-brotli2 = { package = "brotli", version="3.3.0" }
+brotli = "3.3.0"
 flate2 = { version="1.0.2" }
 env_logger = "0.6"
 webpki = { version = "0.21" }

--- a/awc/Cargo.toml
+++ b/awc/Cargo.toml
@@ -32,7 +32,7 @@ openssl = ["open-ssl", "actix-http/openssl"]
 # rustls
 rustls = ["rust-tls", "actix-http/rustls"]
 
-# brotli encoding, requires c compiler
+# brotli encoding
 brotli = ["actix-http/brotli"]
 
 # miniz-sys backend for flate2 crate
@@ -69,7 +69,7 @@ actix-http-test = { version = "1.0.0-alpha.3", features=["openssl"] }
 actix-utils = "1.0.0-alpha.3"
 actix-server = { version = "1.0.0-alpha.3" }
 actix-tls = { version = "1.0.0-alpha.3", features=["openssl", "rustls"] }
-brotli2 = { version="0.3.2" }
+brotli2 = { package = "brotli", version="3.3.0" }
 flate2 = { version="1.0.2" }
 env_logger = "0.6"
 webpki = { version = "0.21" }

--- a/awc/src/request.rs
+++ b/awc/src/request.rs
@@ -23,13 +23,10 @@ use crate::frozen::FrozenClientRequest;
 use crate::sender::{PrepForSendingError, RequestSender, SendClientRequest};
 use crate::ClientConfig;
 
-#[cfg(any(feature = "brotli", feature = "flate2-zlib", feature = "flate2-rust"))]
+#[cfg(any(feature = "flate2-zlib", feature = "flate2-rust"))]
 const HTTPS_ENCODING: &str = "br, gzip, deflate";
-#[cfg(all(
-    any(feature = "flate2-zlib", feature = "flate2-rust"),
-    not(feature = "brotli")
-))]
-const HTTPS_ENCODING: &str = "gzip, deflate";
+#[cfg(not(any(feature = "flate2-zlib", feature = "flate2-rust")))]
+const HTTPS_ENCODING: &str = "br";
 
 /// An HTTP Client request builder
 ///
@@ -544,31 +541,23 @@ impl ClientRequest {
 
         let mut slf = self;
 
-        // enable br only for https
-        #[cfg(any(
-            feature = "brotli",
-            feature = "flate2-zlib",
-            feature = "flate2-rust"
-        ))]
-        {
-            if slf.response_decompress {
-                let https = slf
-                    .head
-                    .uri
-                    .scheme()
-                    .map(|s| s == &uri::Scheme::HTTPS)
-                    .unwrap_or(true);
+        if slf.response_decompress {
+            let https = slf
+                .head
+                .uri
+                .scheme()
+                .map(|s| s == &uri::Scheme::HTTPS)
+                .unwrap_or(true);
 
-                if https {
-                    slf = slf.set_header_if_none(header::ACCEPT_ENCODING, HTTPS_ENCODING)
-                } else {
-                    #[cfg(any(feature = "flate2-zlib", feature = "flate2-rust"))]
-                    {
-                        slf = slf
-                            .set_header_if_none(header::ACCEPT_ENCODING, "gzip, deflate")
-                    }
-                };
-            }
+            if https {
+                slf = slf.set_header_if_none(header::ACCEPT_ENCODING, HTTPS_ENCODING)
+            } else {
+                #[cfg(any(feature = "flate2-zlib", feature = "flate2-rust"))]
+                {
+                    slf =
+                        slf.set_header_if_none(header::ACCEPT_ENCODING, "gzip, deflate")
+                }
+            };
         }
 
         Ok(slf)

--- a/awc/tests/test_client.rs
+++ b/awc/tests/test_client.rs
@@ -4,7 +4,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
-use brotli2::write::BrotliEncoder;
+use brotli::write::BrotliEncoder;
 use bytes::Bytes;
 use flate2::read::GzDecoder;
 use flate2::write::GzEncoder;
@@ -568,7 +568,6 @@ async fn test_client_brotli_encoding() {
 //     assert_eq!(bytes, Bytes::from(data));
 // }
 
-// #[cfg(feature = "brotli")]
 // #[actix_rt::test]
 // async fn test_client_deflate_encoding() {
 //     let srv = test::TestServer::start(|app| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@
 //! * `rustls` - enables ssl support via `rustls` crate, supports `http/2`
 //! * `secure-cookies` - enables secure cookies support, includes `ring` crate as
 //!   dependency
-//! * `brotli` - enables `brotli` compression support, requires `c`
+//! * `brotli` - enables `brotli` compression support
 //!   compiler (default enabled)
 //! * `flate2-zlib` - enables `gzip`, `deflate` compression support, requires
 //!   `c` compiler (default enabled)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,8 +72,6 @@
 //! * `rustls` - enables ssl support via `rustls` crate, supports `http/2`
 //! * `secure-cookies` - enables secure cookies support, includes `ring` crate as
 //!   dependency
-//! * `brotli` - enables `brotli` compression support
-//!   compiler (default enabled)
 //! * `flate2-zlib` - enables `gzip`, `deflate` compression support, requires
 //!   `c` compiler (default enabled)
 //! * `flate2-rust` - experimental rust based implementation for

--- a/tests/test_server.rs
+++ b/tests/test_server.rs
@@ -6,7 +6,7 @@ use actix_http::http::header::{
 };
 use actix_http::{Error, HttpService, Response};
 use actix_http_test::TestServer;
-use brotli2::write::{BrotliDecoder, BrotliEncoder};
+use brotli::write::{BrotliDecoder, BrotliEncoder};
 use bytes::Bytes;
 use flate2::read::GzDecoder;
 use flate2::write::{GzEncoder, ZlibDecoder, ZlibEncoder};
@@ -296,7 +296,6 @@ async fn test_body_chunked_implicit() {
 }
 
 #[actix_rt::test]
-#[cfg(feature = "brotli")]
 async fn test_body_br_streaming() {
     let srv = TestServer::start(move || {
         HttpService::build()
@@ -411,7 +410,6 @@ async fn test_body_deflate() {
 }
 
 #[actix_rt::test]
-#[cfg(any(feature = "brotli"))]
 async fn test_body_brotli() {
     let srv = TestServer::start(move || {
         HttpService::build()
@@ -717,7 +715,7 @@ async fn test_brotli_encoding_large() {
     assert_eq!(bytes, Bytes::from(data));
 }
 
-// #[cfg(all(feature = "brotli", feature = "ssl"))]
+// #[cfg(feature = "ssl")]
 // #[actix_rt::test]
 // async fn test_brotli_encoding_large_ssl() {
 //     use actix::{Actor, System};


### PR DESCRIPTION
This PR switched the brotli compressor from [`brotli2`](https://crates.io/crates/brotli2) to [`brotli`](https://crates.io/crates/brotli).

The change is rather minimal.
Additionally I can implement a flag that leaves the old library intact like the `flate2` flag.