### PR TITLE
Fix extra line feed in logs

### DIFF
--- a/actix-http/src/error.rs
+++ b/actix-http/src/error.rs
@@ -108,7 +108,7 @@ impl fmt::Display for Error {
 
 impl fmt::Debug for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        writeln!(f, "{:?}", &self.cause)
+        write!(f, "{:?}", &self.cause)
     }
 }
 


### PR DESCRIPTION
Fix the extra line feed in the Debug implementation of Error.
This issue has been detected thanks to the [logger middleware](https://github.com/actix/actix-web/blob/6c9f9fff735023005a99bb3d17d3359bb46339c0/src/middleware/logger.rs#L217) because debug  macro also adds the new line.