### PR TITLE
feat: add access to the session also from immutable references

### DIFF
--- a/actix-session/CHANGES.md
+++ b/actix-session/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+
+## [0.3.0-alpha.4] - 2019-12-xx
+
+* Allow access to sessions also from not mutable references to the request
+
 ## [0.3.0-alpha.3] - 2019-12-xx
 
 * Add access to the session from RequestHead for use of session from guard methods

--- a/actix-session/src/lib.rs
+++ b/actix-session/src/lib.rs
@@ -85,23 +85,23 @@ pub struct Session(Rc<RefCell<SessionInner>>);
 
 /// Helper trait that allows to get session
 pub trait UserSession {
-    fn get_session(&mut self) -> Session;
+    fn get_session(&self) -> Session;
 }
 
 impl UserSession for HttpRequest {
-    fn get_session(&mut self) -> Session {
+    fn get_session(&self) -> Session {
         Session::get_session(&mut *self.extensions_mut())
     }
 }
 
 impl UserSession for ServiceRequest {
-    fn get_session(&mut self) -> Session {
+    fn get_session(&self) -> Session {
         Session::get_session(&mut *self.extensions_mut())
     }
 }
 
 impl UserSession for RequestHead {
-    fn get_session(&mut self) -> Session {
+    fn get_session(&self) -> Session {
         Session::get_session(&mut *self.extensions_mut())
     }
 }


### PR DESCRIPTION
Hi,

As the title this add the ability to access to the session from not mutable request instances, the current implementation allow that, but if for API cleanness you prefer have mutable request feel free to not accept this PR