### PR TITLE
set the actix-web client send the http2 packet without ssl.

### DIFF
--- a/awc/src/lib.rs
+++ b/awc/src/lib.rs
@@ -96,6 +96,17 @@ impl Client {
         Client::default()
     }
 
+    /// Create new client instance with http2 settings.
+    pub fn set_http2() -> Client {
+        Client(Rc::new(ClientConfig {
+            connector: RefCell::new(Box::new(ConnectorWrapper(
+                Connector::new().finish_for_h2(),
+            ))),
+            headers: HeaderMap::new(),
+            timeout: Some(Duration::from_secs(5)),
+        }))
+    }
+
     /// Build client instance.
     pub fn build() -> ClientBuilder {
         ClientBuilder::new()


### PR DESCRIPTION
I have created the interface to send http2 packets without ssl by following the method of sending http1.1 packets. And now I can send HTTP2 packets without ssl with use of set_http2() api.Do you guys think this is a feasible method? If not, can you tell me any good way to send HTTP2 packets without the SSL protocol. Thank you.