### PR TITLE
Enable GitHub Actions for Windows and macOS builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,67 @@
+name: CI
+
+on: [push, pull_request]
+
+env:
+  VCPKGRS_DYNAMIC: 1
+
+jobs:
+  build_and_test:
+    strategy:
+      fail-fast: false
+      matrix:
+        toolchain:
+          - x86_64-pc-windows-msvc
+          - i686-pc-windows-msvc
+          - x86_64-apple-darwin
+        version:
+          - stable
+          - nightly
+        include:
+        - toolchain: x86_64-pc-windows-msvc
+          os: windows-latest
+          arch: x64
+        - toolchain: i686-pc-windows-msvc
+          os: windows-latest
+          arch: x86
+        - toolchain: x86_64-apple-darwin
+          os: macOS-latest
+
+    name: ${{ matrix.version }} - ${{ matrix.toolchain }}
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Install ${{ matrix.version }}
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.version }}-${{ matrix.toolchain }}
+          default: true
+
+      - name: Install OpenSSL
+        if: matrix.os == 'windows-latest'
+        run: |
+          vcpkg integrate install
+          vcpkg install openssl:${{ matrix.arch }}-windows
+
+      - name: check nightly
+        if: matrix.version == 'nightly'
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --all --benches --bins --examples --tests
+
+      - name: check stable
+        if: matrix.version == 'stable'
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --all --bins --examples --tests
+
+      - name: tests
+        if: matrix.toolchain != 'x86_64-pc-windows-gnu'
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --all --all-features -- --nocapture

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         toolchain:
           - x86_64-pc-windows-msvc
-          - i686-pc-windows-msvc
+          # - i686-pc-windows-msvc
           - x86_64-apple-darwin
         version:
           - stable
@@ -21,9 +21,9 @@ jobs:
         - toolchain: x86_64-pc-windows-msvc
           os: windows-latest
           arch: x64
-        - toolchain: i686-pc-windows-msvc
-          os: windows-latest
-          arch: x86
+        # - toolchain: i686-pc-windows-msvc
+          # os: windows-latest
+          # arch: x86
         - toolchain: x86_64-apple-darwin
           os: macOS-latest
 

--- a/actix-files/CHANGES.md
+++ b/actix-files/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+## [0.2.1] - 2019-12-22
+
+* Use the same format for file URLs regardless of platforms
+
 ## [0.2.0] - 2019-12-20
 
 * Fix BodyEncoding trait import #1220

--- a/actix-files/Cargo.toml
+++ b/actix-files/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-files"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Nikolay Kim <fafhrd91@gmail.com>"]
 description = "Static files support for actix web."
 readme = "README.md"

--- a/actix-files/src/lib.rs
+++ b/actix-files/src/lib.rs
@@ -1222,7 +1222,10 @@ mod tests {
         );
 
         let bytes = test::read_body(resp).await;
+        #[cfg(unix)]
         assert!(format!("{:?}", bytes).contains("/tests/test.png"));
+        #[cfg(windows)]
+        assert!(format!("{:?}", bytes).contains("/tests\\\\test.png"));
     }
 
     #[actix_rt::test]

--- a/actix-files/src/lib.rs
+++ b/actix-files/src/lib.rs
@@ -155,7 +155,7 @@ impl Directory {
 // show file url as relative to static path
 macro_rules! encode_file_url {
     ($path:ident) => {
-        utf8_percent_encode(&$path.to_string_lossy(), CONTROLS)
+        utf8_percent_encode(&$path, CONTROLS)
     };
 }
 
@@ -178,7 +178,8 @@ fn directory_listing(
         if dir.is_visible(&entry) {
             let entry = entry.unwrap();
             let p = match entry.path().strip_prefix(&dir.path) {
-                Ok(p) => base.join(p),
+                Ok(p) if cfg!(windows) => base.join(p).to_string_lossy().replace("\\", "/"),
+                Ok(p) => base.join(p).to_string_lossy().into_owned(),
                 Err(_) => continue,
             };
 
@@ -1222,10 +1223,7 @@ mod tests {
         );
 
         let bytes = test::read_body(resp).await;
-        #[cfg(unix)]
         assert!(format!("{:?}", bytes).contains("/tests/test.png"));
-        #[cfg(windows)]
-        assert!(format!("{:?}", bytes).contains("/tests\\\\test.png"));
     }
 
     #[actix_rt::test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -3,15 +3,21 @@ use std::sync::{Arc, Mutex};
 use std::{fmt, io, net};
 
 use actix_http::{
-    body::MessageBody, Error, HttpService, KeepAlive, Protocol, Request, Response,
+    body::MessageBody, Error, HttpService, KeepAlive, Request, Response,
 };
 use actix_server::{Server, ServerBuilder};
 use actix_service::{
-    map_config, pipeline_factory, IntoServiceFactory, Service, ServiceFactory,
+    map_config, IntoServiceFactory, Service, ServiceFactory,
 };
-use futures::future::ok;
 
 use net2::TcpBuilder;
+
+#[cfg(unix)]
+use actix_http::Protocol;
+#[cfg(unix)]
+use actix_service::pipeline_factory;
+#[cfg(unix)]
+use futures::future::ok;
 
 #[cfg(feature = "openssl")]
 use actix_tls::openssl::{AlpnError, SslAcceptor, SslAcceptorBuilder};


### PR DESCRIPTION
Note that the current check suite is fragile due to frequent timeout.

`cargo check` and `cargo test` require OpenSSL so windows-gnu is removed.
Also, somehow i686-pc-windows-msvc is stuck on Actions frequently so it is disabled temporarily.

See the check suite: https://github.com/JohnTitor/actix-web/commit/a28d1d7778da317083a8f332ca8bd796d453d9d7/checks?check_suite_id=370125307