### PR TITLE
Add support for anyhow::Error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ members = [
 ]
 
 [features]
-default = ["compress", "failure"]
+default = ["compress", "failure", "anyhow"]
 
 # content-encoding support
 compress = ["actix-http/compress", "awc/compress"]
@@ -51,6 +51,7 @@ compress = ["actix-http/compress", "awc/compress"]
 secure-cookies = ["actix-http/secure-cookies"]
 
 failure = ["actix-http/failure"]
+anyhow = ["actix-http/anyhow"]
 
 # openssl
 openssl = ["actix-tls/openssl", "awc/openssl", "open-ssl"]

--- a/actix-http/Cargo.toml
+++ b/actix-http/Cargo.toml
@@ -15,7 +15,7 @@ license = "MIT/Apache-2.0"
 edition = "2018"
 
 [package.metadata.docs.rs]
-features = ["openssl", "rustls", "failure", "compress", "secure-cookies"]
+features = ["openssl", "rustls", "failure", "compress", "secure-cookies", "anyhow"]
 
 [lib]
 name = "actix_http"
@@ -35,6 +35,8 @@ compress = ["flate2", "brotli2"]
 
 # failure integration. actix does not use failure anymore
 failure = ["fail-ure"]
+
+anyhow = ["any-how"]
 
 # support for secure cookies
 secure-cookies = ["ring"]
@@ -88,6 +90,7 @@ flate2 = { version = "1.0.13", optional = true }
 
 # optional deps
 fail-ure = { version = "0.1.5", package="failure", optional = true }
+any-how = { version="1.0", package="anyhow", optional = true }
 
 [dev-dependencies]
 actix-server = "1.0.0"

--- a/actix-http/src/error.rs
+++ b/actix-http/src/error.rs
@@ -36,8 +36,8 @@ pub type Result<T, E = Error> = result::Result<T, E>;
 
 /// General purpose actix web error.
 ///
-/// An actix web error is used to carry errors from `failure` or `std::error`
-/// through actix in a convenient way.  It can be created through
+/// An actix web error is used to carry errors from `anyhow`, `failure`, or
+/// `std::error` through actix in a convenient way.  It can be created through
 /// converting errors with `into()`.
 ///
 /// Whenever it is created from an external object a response error is created
@@ -966,6 +966,10 @@ where
 #[cfg(feature = "failure")]
 /// Compatibility for `failure::Error`
 impl ResponseError for fail_ure::Error {}
+
+#[cfg(feature = "anyhow")]
+/// Compatibility for `anyhow::Error`
+impl ResponseError for any_how::Error {}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
anyhow is an error handling crate like failure. It seems to be better supported and more popular now as it uses std::error::Error and not a custom trait. This PR adds the same sort of support failure has, also behind a feature flag. 