### PR TITLE
Added 2.0.0 rustls feature name change

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -17,6 +17,20 @@
 * `ResponseError` trait has been reafctored. `ResponseError::error_response()` renders
   http response.
 
+* Feature `rust-tls` renamed to `rustls`
+
+  instead of
+  
+    ```rust
+    actix-web = { version = "2.0.0", features = ["rust-tls"] }
+    ```
+
+  use
+
+    ```rust
+    actix-web = { version = "2.0.0", features = ["rustls"] }
+    ```
+
 
 ## 1.0.1
 


### PR DESCRIPTION
Added comment to MIGRATION.md to reflect the feature name change from `rust-tls` to `rustls`.