### PR TITLE
Fixed documentation typo for actix-files

### DIFF
--- a/actix-files/src/lib.rs
+++ b/actix-files/src/lib.rs
@@ -275,7 +275,7 @@ impl Files {
     ///
     /// `File` uses `ThreadPool` for blocking filesystem operations.
     /// By default pool with 5x threads of available cpus is used.
-    /// Pool size can be changed by setting ACTIX_CPU_POOL environment variable.
+    /// Pool size can be changed by setting ACTIX_THREADPOOL environment variable.
     pub fn new<T: Into<PathBuf>>(path: &str, dir: T) -> Files {
         let orig_dir = dir.into();
         let dir = match orig_dir.canonicalize() {


### PR DESCRIPTION
Found when I was optimizing an application for memory usage. Setting the documented env var (`ACTIX_CPU_POOL`) essentially did nothing. I found the fixed env var in `actix-net/actix_threadpool`:

https://github.com/actix/actix-net/blob/master/actix-threadpool/src/lib.rs#L14

Which seemed to fix my problem.