### PR TITLE
allow explicit SameSite=None cookies

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+* Setting a cookie's SameSite property, explicitly, to `SameSite::None` will now
+  result in `SameSite=None` being sent with the response Set-Cookie header.
+  To create a cookie without a SameSite attribute, remove any calls setting same_site.
+
 ## 2.0.0
 
 * `HttpServer::start()` renamed to `HttpServer::run()`. It also possible to

--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+# [Unreleased]
+
+### Fixed
+
+* Allow `SameSite=None` cookies to be sent in a response.
+
 ## [1.0.1] - 2019-12-20
 
 ### Fixed

--- a/actix-http/src/cookie/draft.rs
+++ b/actix-http/src/cookie/draft.rs
@@ -10,18 +10,26 @@ use std::fmt;
 /// attribute is "Strict", then the cookie is never sent in cross-site requests.
 /// If the `SameSite` attribute is "Lax", the cookie is only sent in cross-site
 /// requests with "safe" HTTP methods, i.e, `GET`, `HEAD`, `OPTIONS`, `TRACE`.
-/// If the `SameSite` attribute is not present (made explicit via the
-/// `SameSite::None` variant), then the cookie will be sent as normal.
+/// If the `SameSite` attribute is not present then the cookie will be sent as
+/// normal. In some browsers, this will implicitly handle the cookie as if "Lax"
+/// and in others, "None". It's best to explicitly set the `SameSite` attribute
+/// to avoid inconsistent behavior.
+/// 
+/// **Note:** Depending on browser, the `Secure` attribute may be required for
+/// `SameSite` "None" cookies to be accepted.
 ///
 /// **Note:** This cookie attribute is an HTTP draft! Its meaning and definition
 /// are subject to change.
+/// 
+/// More info about these draft changes can be found in the draft spec:
+/// - https://tools.ietf.org/html/draft-west-cookie-incrementalism-00
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum SameSite {
     /// The "Strict" `SameSite` attribute.
     Strict,
     /// The "Lax" `SameSite` attribute.
     Lax,
-    /// No `SameSite` attribute.
+    /// The "None" `SameSite` attribute.
     None,
 }
 
@@ -92,7 +100,7 @@ impl fmt::Display for SameSite {
         match *self {
             SameSite::Strict => write!(f, "Strict"),
             SameSite::Lax => write!(f, "Lax"),
-            SameSite::None => Ok(()),
+            SameSite::None => write!(f, "None"),
         }
     }
 }

--- a/actix-http/src/cookie/mod.rs
+++ b/actix-http/src/cookie/mod.rs
@@ -746,9 +746,7 @@ impl<'c> Cookie<'c> {
         }
 
         if let Some(same_site) = self.same_site() {
-            if !same_site.is_none() {
-                write!(f, "; SameSite={}", same_site)?;
-            }
+            write!(f, "; SameSite={}", same_site)?;
         }
 
         if let Some(path) = self.path() {
@@ -1037,7 +1035,7 @@ mod tests {
         let cookie = Cookie::build("foo", "bar")
             .same_site(SameSite::None)
             .finish();
-        assert_eq!(&cookie.to_string(), "foo=bar");
+        assert_eq!(&cookie.to_string(), "foo=bar; SameSite=None");
     }
 
     #[test]


### PR DESCRIPTION
Given the upcoming changes in Chrome to default SameSite-less cookies to Lax, we should allow the option to explicity set None cookies.

This could be considered non-breaking while Chrome's changes are still in beta.

It's also possible this change should be packported to 0.x and 1.x branches.

fixes #1035 
