### PR TITLE
[actix-session] Long lasting auto-prolonged session

### DIFF
--- a/actix-session/CHANGES.md
+++ b/actix-session/CHANGES.md
@@ -3,6 +3,7 @@
 ## [Unreleased] - 2020-01-xx
 
 * Update the `time` dependency to 0.2.5
+* [#1292](https://github.com/actix/actix-web/pull/1292) Long lasting auto-prolonged session
 
 ## [0.3.0] - 2019-12-20
 


### PR DESCRIPTION
This PR adds option to have persistent sessions (which last after restarting a browser). Expiration date is automatically prolonged with each response.

Prior art:
- [Django](https://github.com/django/django/blob/master/django/contrib/sessions/middleware.py#L50-L53)
- [RoR](https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/middleware/cookies.rb#L435-L437).