### PR TITLE
Extensions module improvement and tests.

### DIFF
--- a/actix-http/src/extensions.rs
+++ b/actix-http/src/extensions.rs
@@ -119,11 +119,11 @@ fn test_integers() {
     assert!(map.get::<i32>().is_some());
     assert!(map.get::<i64>().is_some());
     assert!(map.get::<i128>().is_some());
-    assert!(map.get::<i8>().is_some());
-    assert!(map.get::<i16>().is_some());
-    assert!(map.get::<i32>().is_some());
-    assert!(map.get::<i64>().is_some());
-    assert!(map.get::<i128>().is_some());
+    assert!(map.get::<u8>().is_some());
+    assert!(map.get::<u16>().is_some());
+    assert!(map.get::<u32>().is_some());
+    assert!(map.get::<u64>().is_some());
+    assert!(map.get::<u128>().is_some());
 }
 
 #[test]

--- a/actix-http/src/extensions.rs
+++ b/actix-http/src/extensions.rs
@@ -71,6 +71,92 @@ impl fmt::Debug for Extensions {
 }
 
 #[test]
+fn test_remove() {
+    let mut map = Extensions::new();
+
+    map.insert::<i8>(123);
+    assert!(map.get::<i8>().is_some());
+
+    map.remove::<i8>();
+    assert!(!map.get::<i8>().is_some());
+}
+
+#[test]
+fn test_clear() {
+    let mut map = Extensions::new();
+
+    map.insert::<i8>(8);
+    map.insert::<i16>(16);
+    map.insert::<i32>(32);
+
+    assert!(map.contains::<i8>());
+    assert!(map.contains::<i16>());
+    assert!(map.contains::<i32>());
+
+    map.clear();
+
+    assert!(!map.contains::<i8>());
+    assert!(!map.contains::<i16>());
+    assert!(!map.contains::<i32>());
+
+    map.insert::<i8>(10);
+    assert_eq!(*map.get::<i8>().unwrap(), 10);
+}
+
+#[test]
+fn test_integers() {
+    let mut map = Extensions::new();
+
+    map.insert::<i8>(8);
+    map.insert::<i16>(16);
+    map.insert::<i32>(32);
+    map.insert::<i64>(64);
+    map.insert::<i128>(128);
+    map.insert::<u8>(8);
+    map.insert::<u16>(16);
+    map.insert::<u32>(32);
+    map.insert::<u64>(64);
+    map.insert::<u128>(128);
+    assert!(map.get::<i8>().is_some());
+    assert!(map.get::<i16>().is_some());
+    assert!(map.get::<i32>().is_some());
+    assert!(map.get::<i64>().is_some());
+    assert!(map.get::<i128>().is_some());
+    assert!(map.get::<i8>().is_some());
+    assert!(map.get::<i16>().is_some());
+    assert!(map.get::<i32>().is_some());
+    assert!(map.get::<i64>().is_some());
+    assert!(map.get::<i128>().is_some());
+}
+
+#[test]
+fn test_composition() {
+    struct Magi<T>(pub T);
+
+    struct Madoka {
+        pub god: bool,
+    }
+
+    struct Homura {
+        pub attempts: usize,
+    }
+
+    struct Mami {
+        pub guns: usize,
+    }
+
+    let mut map = Extensions::new();
+
+    map.insert(Magi(Madoka { god: false }));
+    map.insert(Magi(Homura { attempts: 0 }));
+    map.insert(Magi(Mami { guns: 999 }));
+
+    assert_eq!(false, map.get::<Magi<Madoka>>().unwrap().0.god);
+    assert_eq!(0, map.get::<Magi<Homura>>().unwrap().0.attempts);
+    assert_eq!(999, map.get::<Magi<Mami>>().unwrap().0.guns);
+}
+
+#[test]
 fn test_extensions() {
     #[derive(Debug, PartialEq)]
     struct MyType(i32);

--- a/actix-http/src/extensions.rs
+++ b/actix-http/src/extensions.rs
@@ -35,26 +35,23 @@ impl Extensions {
     pub fn get<T: 'static>(&self) -> Option<&T> {
         self.map
             .get(&TypeId::of::<T>())
-            .and_then(|boxed| (&**boxed as &(dyn Any + 'static)).downcast_ref())
+            .and_then(|boxed| boxed.downcast_ref())
     }
 
     /// Get a mutable reference to a type previously inserted on this `Extensions`.
     pub fn get_mut<T: 'static>(&mut self) -> Option<&mut T> {
         self.map
             .get_mut(&TypeId::of::<T>())
-            .and_then(|boxed| (&mut **boxed as &mut (dyn Any + 'static)).downcast_mut())
+            .and_then(|boxed| boxed.downcast_mut())
     }
 
     /// Remove a type from this `Extensions`.
     ///
     /// If a extension of this type existed, it will be returned.
     pub fn remove<T: 'static>(&mut self) -> Option<T> {
-        self.map.remove(&TypeId::of::<T>()).and_then(|boxed| {
-            (boxed as Box<dyn Any + 'static>)
-                .downcast()
-                .ok()
-                .map(|boxed| *boxed)
-        })
+        self.map
+            .remove(&TypeId::of::<T>())
+            .and_then(|boxed| boxed.downcast().ok().map(|boxed| *boxed))
     }
 
     /// Clear the `Extensions` of all inserted extensions.

--- a/actix-http/src/extensions.rs
+++ b/actix-http/src/extensions.rs
@@ -28,7 +28,7 @@ impl Extensions {
 
     /// Check if container contains entry
     pub fn contains<T: 'static>(&self) -> bool {
-        self.map.get(&TypeId::of::<T>()).is_some()
+        self.map.contains_key(&TypeId::of::<T>())
     }
 
     /// Get a reference to a type previously inserted on this `Extensions`.

--- a/actix-http/src/extensions.rs
+++ b/actix-http/src/extensions.rs
@@ -75,7 +75,7 @@ fn test_remove() {
     assert!(map.get::<i8>().is_some());
 
     map.remove::<i8>();
-    assert!(!map.get::<i8>().is_some());
+    assert!(map.get::<i8>().is_none());
 }
 
 #[test]
@@ -148,7 +148,7 @@ fn test_composition() {
     map.insert(Magi(Homura { attempts: 0 }));
     map.insert(Magi(Mami { guns: 999 }));
 
-    assert_eq!(false, map.get::<Magi<Madoka>>().unwrap().0.god);
+    assert!(!map.get::<Magi<Madoka>>().unwrap().0.god);
     assert_eq!(0, map.get::<Magi<Homura>>().unwrap().0.attempts);
     assert_eq!(999, map.get::<Magi<Mami>>().unwrap().0.guns);
 }


### PR DESCRIPTION
Firstly `contains` method of extensions module used `self.map.get(...).is_some()` and I changed it to `self.map.contains_key`.

Secondly I added some tests for different types and operations.

Thirdly I see than there is no need in box casting in some functions and removed casts.