### PR TITLE
Remove codecoverage for tests and examples

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+ignore: # ignore codecoverage on following paths
+  - "**/tests"
+  - "test-server"
+  - "**/benches"
+  - "**/examples"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,5 @@
-codecov:
-  ignore: # ignore codecoverage on following paths
-    - "**/tests"
-    - "test-server"
-    - "**/benches"
-    - "**/examples"
+ignore: # ignore codecoverage on following paths
+  - "**/tests"
+  - "test-server"
+  - "**/benches"
+  - "**/examples"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,6 @@
-ignore: # ignore codecoverage on following paths
-  - "**/tests"
-  - "test-server"
-  - "**/benches"
-  - "**/examples"
+codecov:
+  ignore: # ignore codecoverage on following paths
+    - "**/tests"
+    - "test-server"
+    - "**/benches"
+    - "**/examples"


### PR DESCRIPTION
Codecov checks Codecoverage for bench and tests folders.
By excluding these files from codecoverage we show more correct codecoverage statistics. 