### PR TITLE
Skip empty chucks for BodyStream and SizedStream

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,9 @@
 
 ### Changed
 
-*  Use `sha-1` crate instead of unmaintained `sha1` crate
+* Use `sha-1` crate instead of unmaintained `sha1` crate
+
+* Skip empty chunks when returning response from a `Stream` #1308
 
 ## [2.0.0] - 2019-12-25
 


### PR DESCRIPTION
Fixes #1267

This PR makes `BodyStream` and `SizedStream` in `actix-http` crate to skip empty chunks whicl streaming HTTP response, so omit unexpected termination.