### PR TITLE
Incorrect handling of errors in data factory

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -89,7 +89,7 @@ where
     S::InitError: std::fmt::Debug,
 {
     let srv = app.into_factory();
-    srv.new_service(AppConfig::default()).await.unwrap()
+    srv.new_service(AppConfig::default()).await.expect("test::init_service failure")
 }
 
 /// Calls service and waits for response future completion.


### PR DESCRIPTION
This originates from #1304. 

When data_factory produces Error server is interrupting connection which is incorrect by web standard. It should return `StatusCode::INTERNAL_SERVER_ERROR` instead.

- [X] Add test case for #1304.
- [ ] Fix the issue