### PR TITLE
Backport to 1.0: allow explicit SameSite=None cookies (#1282)

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,3 +1,57 @@
+## Unreleased
+
+* Setting a cookie's SameSite property, explicitly, to `SameSite::None` will now
+  result in `SameSite=None` being sent with the response Set-Cookie header.
+  To create a cookie without a SameSite attribute, remove any calls setting same_site.
+
+## 2.0.0
+
+* `HttpServer::start()` renamed to `HttpServer::run()`. It also possible to
+  `.await` on `run` method result, in that case it awaits server exit.
+
+* `App::register_data()` renamed to `App::app_data()` and accepts any type `T: 'static`.
+  Stored data is available via `HttpRequest::app_data()` method at runtime.
+
+* Extractor configuration must be registered with `App::app_data()` instead of `App::data()`
+
+* Sync handlers has been removed. `.to_async()` method has been renamed to `.to()`
+  replace `fn` with `async fn` to convert sync handler to async
+
+* `actix_http_test::TestServer` moved to `actix_web::test` module. To start
+  test server use `test::start()` or `test_start_with_config()` methods
+
+* `ResponseError` trait has been reafctored. `ResponseError::error_response()` renders
+  http response.
+
+* Feature `rust-tls` renamed to `rustls`
+
+  instead of
+
+    ```rust
+    actix-web = { version = "2.0.0", features = ["rust-tls"] }
+    ```
+
+  use
+
+    ```rust
+    actix-web = { version = "2.0.0", features = ["rustls"] }
+    ```
+
+* Feature `ssl` renamed to `openssl`
+
+  instead of
+
+    ```rust
+    actix-web = { version = "2.0.0", features = ["ssl"] }
+    ```
+
+  use
+
+    ```rust
+    actix-web = { version = "2.0.0", features = ["openssl"] }
+    ```
+* `Cors` builder now requires that you call `.finish()` to construct the middleware
+
 ## 1.0.1
 
 * Cors middleware has been moved to `actix-cors` crate

--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -1,5 +1,60 @@
 # Changes
 
+# [Unreleased]
+
+### Fixed
+
+* Allow `SameSite=None` cookies to be sent in a response.
+
+## [1.0.1] - 2019-12-20
+
+### Fixed
+
+* Poll upgrade service's readiness from HTTP service handlers
+
+* Replace brotli with brotli2 #1224
+
+## [1.0.0] - 2019-12-13
+
+### Added
+
+* Add websockets continuation frame support
+
+### Changed
+
+* Replace `flate2-xxx` features with `compress`
+
+## [1.0.0-alpha.5] - 2019-12-09
+
+### Fixed
+
+* Check `Upgrade` service readiness before calling it
+
+* Fix buffer remaining capacity calcualtion
+
+### Changed
+
+* Websockets: Ping and Pong should have binary data #1049
+
+## [1.0.0-alpha.4] - 2019-12-08
+
+### Added
+
+* Add impl ResponseBuilder for Error
+
+### Changed
+
+* Use rust based brotli compression library
+
+## [1.0.0-alpha.3] - 2019-12-07
+
+### Changed
+
+* Migrate to tokio 0.2
+
+* Migrate to `std::future`
+
+
 ## [0.2.11] - 2019-11-06
 
 ### Added

--- a/actix-http/src/cookie/draft.rs
+++ b/actix-http/src/cookie/draft.rs
@@ -10,18 +10,26 @@ use std::fmt;
 /// attribute is "Strict", then the cookie is never sent in cross-site requests.
 /// If the `SameSite` attribute is "Lax", the cookie is only sent in cross-site
 /// requests with "safe" HTTP methods, i.e, `GET`, `HEAD`, `OPTIONS`, `TRACE`.
-/// If the `SameSite` attribute is not present (made explicit via the
-/// `SameSite::None` variant), then the cookie will be sent as normal.
+/// If the `SameSite` attribute is not present then the cookie will be sent as
+/// normal. In some browsers, this will implicitly handle the cookie as if "Lax"
+/// and in others, "None". It's best to explicitly set the `SameSite` attribute
+/// to avoid inconsistent behavior.
+/// 
+/// **Note:** Depending on browser, the `Secure` attribute may be required for
+/// `SameSite` "None" cookies to be accepted.
 ///
 /// **Note:** This cookie attribute is an HTTP draft! Its meaning and definition
 /// are subject to change.
+/// 
+/// More info about these draft changes can be found in the draft spec:
+/// - https://tools.ietf.org/html/draft-west-cookie-incrementalism-00
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum SameSite {
     /// The "Strict" `SameSite` attribute.
     Strict,
     /// The "Lax" `SameSite` attribute.
     Lax,
-    /// No `SameSite` attribute.
+    /// The "None" `SameSite` attribute.
     None,
 }
 
@@ -92,7 +100,7 @@ impl fmt::Display for SameSite {
         match *self {
             SameSite::Strict => write!(f, "Strict"),
             SameSite::Lax => write!(f, "Lax"),
-            SameSite::None => Ok(()),
+            SameSite::None => write!(f, "None"),
         }
     }
 }

--- a/actix-http/src/cookie/mod.rs
+++ b/actix-http/src/cookie/mod.rs
@@ -752,9 +752,7 @@ impl<'c> Cookie<'c> {
         }
 
         if let Some(same_site) = self.same_site() {
-            if !same_site.is_none() {
-                write!(f, "; SameSite={}", same_site)?;
-            }
+            write!(f, "; SameSite={}", same_site)?;
         }
 
         if let Some(path) = self.path() {
@@ -1043,7 +1041,7 @@ mod tests {
         let cookie = Cookie::build("foo", "bar")
             .same_site(SameSite::None)
             .finish();
-        assert_eq!(&cookie.to_string(), "foo=bar");
+        assert_eq!(&cookie.to_string(), "foo=bar; SameSite=None");
     }
 
     #[test]


### PR DESCRIPTION
fixes #1035
(cherry picked from commit a3287948d19bbdc9e7cf9957403961eeb2d8b94d)