### PR TITLE
Disable coverage for PRs

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -73,12 +73,12 @@ jobs:
           args: --package=awc --no-default-features --features=rustls -- --nocapture
 
       - name: Generate coverage file
-        if: matrix.version == 'stable' && (github.ref == 'master' || github.event_name == 'pull_request')
+        if: matrix.version == 'stable' && github.ref == 'refs/heads/master'
         run: |
           cargo install cargo-tarpaulin
           cargo tarpaulin --out Xml
       - name: Upload to Codecov
-        if: matrix.version == 'stable' && (github.ref == 'master' || github.event_name == 'pull_request')
+        if: matrix.version == 'stable' && github.ref == 'refs/heads/master'
         uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
It's meaningless _mostly_ since GHA disables secrets when PR comes from forks.