### PR TITLE
Adapt workspace crates to MessageBody::poll with Pin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,7 @@ codegen-units = 1
 
 [patch.crates-io]
 actix-web = { path = "." }
-#actix-http = { path = "actix-http" }
+actix-http = { path = "actix-http" }
 actix-http-test = { path = "test-server" }
 actix-web-codegen = { path = "actix-web-codegen" }
 actix-cors = { path = "actix-cors" }

--- a/actix-http/tests/test_ws.rs
+++ b/actix-http/tests/test_ws.rs
@@ -81,9 +81,6 @@ async fn service(msg: ws::Frame) -> Result<ws::Message, Error> {
     Ok(msg)
 }
 
-/*
-Temporarily commented out due to dependency on actix-http-test
-
 #[actix_rt::test]
 async fn test_simple() {
     let ws_service = WsService::new();
@@ -195,5 +192,3 @@ async fn test_simple() {
 
     assert!(ws_service.was_polled());
 }
-
-*/

--- a/src/test.rs
+++ b/src/test.rs
@@ -150,7 +150,7 @@ where
 pub async fn read_response<S, B>(app: &mut S, req: Request) -> Bytes
 where
     S: Service<Request = Request, Response = ServiceResponse<B>, Error = Error>,
-    B: MessageBody,
+    B: MessageBody + Unpin,
 {
     let mut resp = app
         .call(req)
@@ -193,7 +193,7 @@ where
 /// ```
 pub async fn read_body<B>(mut res: ServiceResponse<B>) -> Bytes
 where
-    B: MessageBody,
+    B: MessageBody + Unpin,
 {
     let mut body = res.take_body();
     let mut bytes = BytesMut::new();
@@ -251,7 +251,7 @@ where
 pub async fn read_response_json<S, B, T>(app: &mut S, req: Request) -> T
 where
     S: Service<Request = Request, Response = ServiceResponse<B>, Error = Error>,
-    B: MessageBody,
+    B: MessageBody + Unpin,
     T: DeserializeOwned,
 {
     let body = read_response(app, req).await;


### PR DESCRIPTION
After https://github.com/actix/actix-web/pull/1332 there are incompatibility issues in actix-web logger left as well as some tests need to be reenabled.

This PR is resolving incompatibility issues so that whole workspace would compile and run tests with local actix-http version. PR is still placed against msg-body branch.