### PR TITLE
Use #[pin_project] with `ConnectorPoolSupport`

### DIFF
--- a/actix-http/src/client/pool.rs
+++ b/actix-http/src/client/pool.rs
@@ -17,6 +17,7 @@ use h2::client::{handshake, Connection, SendRequest};
 use http::uri::Authority;
 use indexmap::IndexSet;
 use slab::Slab;
+use pin_project::pin_project;
 
 use super::connection::{ConnectionType, IoConnection};
 use super::error::ConnectError;
@@ -422,6 +423,7 @@ where
     }
 }
 
+#[pin_project]
 struct ConnectorPoolSupport<T, Io>
 where
     Io: AsyncRead + AsyncWrite + Unpin + 'static,
@@ -439,7 +441,7 @@ where
     type Output = ();
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let this = unsafe { self.get_unchecked_mut() };
+        let this = self.project();
 
         let mut inner = this.inner.as_ref().borrow_mut();
         inner.waker.register(cx.waker());


### PR DESCRIPTION
This removes a use of `Pin::get_unchecked_mut`