### PR TITLE
Create helper function for HTTP Trace Method

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@
 
 ## [2.0.NEXT] - 2020-01-xx
 
+### Added
+
+* Add helper function for creating routes with `TRACE` method guard `web::trace()`
+
 ### Changed
 
 * Use `sha-1` crate instead of unmaintained `sha1` crate

--- a/src/web.rs
+++ b/src/web.rs
@@ -193,6 +193,24 @@ pub fn head() -> Route {
     method(Method::HEAD)
 }
 
+/// Create *route* with `TRACE` method guard.
+///
+/// ```rust
+/// use actix_web::{web, App, HttpResponse};
+///
+/// let app = App::new().service(
+///     web::resource("/{project_id}")
+///         .route(web::trace().to(|| HttpResponse::Ok()))
+/// );
+/// ```
+///
+/// In the above example, one `HEAD` route gets added:
+///  * /{project_id}
+///
+pub fn trace() -> Route {
+    method(Method::TRACE)
+}
+
 /// Create *route* and add method guard.
 ///
 /// ```rust


### PR DESCRIPTION
What
--
Add a helper method to create a route with `TRACE` method guard.

Why
--
Provide a helper function and have symmetry between the attribute macros from the `codegen` crate and the helper functions fro the `web` module. (_there's a trace macro already_)

Closes #1371 
