### PR TITLE
Update `time` to 0.2.7

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,7 @@
 
 * Skip empty chunks when returning response from a `Stream` #1308
 
-* Update the `time` dependency to 0.2.5
+* Update the `time` dependency to 0.2.7
 
 ## [2.0.0] - 2019-12-25
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ regex = "1.3"
 serde = { version = "1.0", features=["derive"] }
 serde_json = "1.0"
 serde_urlencoded = "0.6.1"
-time = { version = "0.2.5", default-features = false, features = ["std"] }
+time = { version = "0.2.7", default-features = false, features = ["std"] }
 url = "2.1"
 open-ssl = { version="0.10", package = "openssl", optional = true }
 rust-tls = { version = "0.16.0", package = "rustls", optional = true }

--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-* Update the `time` dependency to 0.2.5
+* Update the `time` dependency to 0.2.7
 
 ### Fixed
 

--- a/actix-http/Cargo.toml
+++ b/actix-http/Cargo.toml
@@ -76,7 +76,7 @@ serde_json = "1.0"
 sha-1 = "0.8"
 slab = "0.4"
 serde_urlencoded = "0.6.1"
-time = { version = "0.2.5", default-features = false, features = ["std"] }
+time = { version = "0.2.7", default-features = false, features = ["std"] }
 
 # for secure cookie
 ring = { version = "0.16.9", optional = true }

--- a/actix-http/src/cookie/mod.rs
+++ b/actix-http/src/cookie/mod.rs
@@ -990,7 +990,7 @@ impl<'a, 'b> PartialEq<Cookie<'b>> for Cookie<'a> {
 #[cfg(test)]
 mod tests {
     use super::{Cookie, SameSite};
-    use time::{offset, PrimitiveDateTime};
+    use time::PrimitiveDateTime;
 
     #[test]
     fn format() {
@@ -1015,7 +1015,7 @@ mod tests {
         assert_eq!(&cookie.to_string(), "foo=bar; Domain=www.rust-lang.org");
 
         let time_str = "Wed, 21 Oct 2015 07:28:00 GMT";
-        let expires = PrimitiveDateTime::parse(time_str, "%a, %d %b %Y %H:%M:%S").unwrap().using_offset(offset!(UTC));
+        let expires = PrimitiveDateTime::parse(time_str, "%a, %d %b %Y %H:%M:%S").unwrap().assume_utc();
         let cookie = Cookie::build("foo", "bar").expires(expires).finish();
         assert_eq!(
             &cookie.to_string(),

--- a/actix-http/src/cookie/parse.rs
+++ b/actix-http/src/cookie/parse.rs
@@ -6,7 +6,7 @@ use std::fmt;
 use std::str::Utf8Error;
 
 use percent_encoding::percent_decode;
-use time::{Duration, offset};
+use time::Duration;
 
 use super::{Cookie, CookieStr, SameSite};
 
@@ -188,7 +188,7 @@ fn parse_inner<'c>(s: &str, decode: bool) -> Result<Cookie<'c>, ParseError> {
                     .or_else(|| time::parse(v, "%a, %d-%b-%Y %H:%M:%S").ok());
 
                 if let Some(time) = tm {
-                    cookie.expires = Some(time.using_offset(offset!(UTC)))
+                    cookie.expires = Some(time.assume_utc())
                 }
             }
             _ => {
@@ -216,7 +216,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::{Cookie, SameSite};
-    use time::{offset, Duration, PrimitiveDateTime};
+    use time::{Duration, PrimitiveDateTime};
 
     macro_rules! assert_eq_parse {
         ($string:expr, $expected:expr) => {
@@ -376,7 +376,7 @@ mod tests {
         );
 
         let time_str = "Wed, 21 Oct 2015 07:28:00 GMT";
-        let expires = PrimitiveDateTime::parse(time_str, "%a, %d %b %Y %H:%M:%S").unwrap().using_offset(offset!(UTC));
+        let expires = PrimitiveDateTime::parse(time_str, "%a, %d %b %Y %H:%M:%S").unwrap().assume_utc();
         expected.set_expires(expires);
         assert_eq_parse!(
             " foo=bar ;HttpOnly; Secure; Max-Age=4; Path=/foo; \
@@ -385,7 +385,7 @@ mod tests {
         );
 
         unexpected.set_domain("foo.com");
-        let bad_expires = PrimitiveDateTime::parse(time_str, "%a, %d %b %Y %H:%S:%M").unwrap().using_offset(offset!(UTC));
+        let bad_expires = PrimitiveDateTime::parse(time_str, "%a, %d %b %Y %H:%S:%M").unwrap().assume_utc();
         expected.set_expires(bad_expires);
         assert_ne_parse!(
             " foo=bar ;HttpOnly; Secure; Max-Age=4; Path=/foo; \

--- a/actix-http/src/header/shared/httpdate.rs
+++ b/actix-http/src/header/shared/httpdate.rs
@@ -20,7 +20,7 @@ impl FromStr for HttpDate {
 
     fn from_str(s: &str) -> Result<HttpDate, ParseError> {
         match time_parser::parse_http_date(s) {
-            Some(t) => Ok(HttpDate(t.using_offset(offset!(UTC)))),
+            Some(t) => Ok(HttpDate(t.assume_utc())),
             None => Err(ParseError::Header)
         }
     }
@@ -40,7 +40,7 @@ impl From<OffsetDateTime> for HttpDate {
 
 impl From<SystemTime> for HttpDate {
     fn from(sys: SystemTime) -> HttpDate {
-        HttpDate(PrimitiveDateTime::from(sys).using_offset(offset!(UTC)))
+        HttpDate(PrimitiveDateTime::from(sys).assume_utc())
     }
 }
 
@@ -66,14 +66,14 @@ impl From<HttpDate> for SystemTime {
 #[cfg(test)]
 mod tests {
     use super::HttpDate;
-    use time::{PrimitiveDateTime, date, time, offset};
+    use time::{PrimitiveDateTime, date, time};
 
     #[test]
     fn test_date() {
         let nov_07 = HttpDate(PrimitiveDateTime::new(
             date!(1994-11-07),
             time!(8:48:37)
-        ).using_offset(offset!(UTC)));
+        ).assume_utc());
 
         assert_eq!(
             "Sun, 07 Nov 1994 08:48:37 GMT".parse::<HttpDate>().unwrap(),

--- a/actix-http/src/time_parser.rs
+++ b/actix-http/src/time_parser.rs
@@ -1,4 +1,4 @@
-use time::{PrimitiveDateTime, Date};
+use time::{OffsetDateTime, PrimitiveDateTime, Date};
 
 /// Attempt to parse a `time` string as one of either RFC 1123, RFC 850, or asctime.
 pub fn parse_http_date(time: &str) -> Option<PrimitiveDateTime> {
@@ -19,7 +19,7 @@ fn try_parse_rfc_850(time: &str) -> Option<PrimitiveDateTime> {
             // If the `time` string contains a two-digit year, then as per RFC 2616 § 19.3,
             // we consider the year as part of this century if it's within the next 50 years,
             // otherwise we consider as part of the previous century.
-            let now = PrimitiveDateTime::now();
+            let now = OffsetDateTime::now();
             let century_start_year = (now.year() / 100) * 100;
             let mut expanded_year = century_start_year + dt.year();
 

--- a/test-server/CHANGES.md
+++ b/test-server/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased] - 2020-xx-xx
 
-* Update the `time` dependency to 0.2.5
+* Update the `time` dependency to 0.2.7
 
 
 ## [1.0.0] - 2019-12-13

--- a/test-server/Cargo.toml
+++ b/test-server/Cargo.toml
@@ -51,7 +51,7 @@ serde_json = "1.0"
 sha1 = "0.6"
 slab = "0.4"
 serde_urlencoded = "0.6.1"
-time = { version = "0.2.5", default-features = false, features = ["std"] }
+time = { version = "0.2.7", default-features = false, features = ["std"] }
 open-ssl = { version="0.10", package="openssl", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
`time` v0.2.7 has deprecated some methods, therefore our CI complains that and won't build.