### PR TITLE
Add actix-http support for actix error messages

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -3,6 +3,8 @@
 * Setting a cookie's SameSite property, explicitly, to `SameSite::None` will now
   result in `SameSite=None` being sent with the response Set-Cookie header.
   To create a cookie without a SameSite attribute, remove any calls setting same_site.
+* actix-http support for Actors messages was moved to actix-http crate and is enabled 
+  with feature `actors`
 
 ## 2.0.0
 

--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -6,6 +6,8 @@
 
 * Update the `time` dependency to 0.2.7
 
+* Moved actors messages support from actix crate, enabled with feature `actors`.
+
 ### Fixed
 
 * Allow `SameSite=None` cookies to be sent in a response.

--- a/actix-http/Cargo.toml
+++ b/actix-http/Cargo.toml
@@ -15,7 +15,7 @@ license = "MIT/Apache-2.0"
 edition = "2018"
 
 [package.metadata.docs.rs]
-features = ["openssl", "rustls", "failure", "compress", "secure-cookies","actix"]
+features = ["openssl", "rustls", "failure", "compress", "secure-cookies","actors"]
 
 [lib]
 name = "actix_http"

--- a/actix-http/Cargo.toml
+++ b/actix-http/Cargo.toml
@@ -15,7 +15,7 @@ license = "MIT/Apache-2.0"
 edition = "2018"
 
 [package.metadata.docs.rs]
-features = ["openssl", "rustls", "failure", "compress", "secure-cookies"]
+features = ["openssl", "rustls", "failure", "compress", "secure-cookies","actix"]
 
 [lib]
 name = "actix_http"
@@ -39,6 +39,10 @@ failure = ["fail-ure"]
 # support for secure cookies
 secure-cookies = ["ring"]
 
+# support for actix Actor messages
+actix = ["actix"]
+resolver = ["actix/resolver"]
+
 [dependencies]
 actix-service = "1.0.1"
 actix-codec = "0.2.0"
@@ -47,6 +51,7 @@ actix-utils = "1.0.3"
 actix-rt = "1.0.0"
 actix-threadpool = "0.3.1"
 actix-tls = { version = "1.0.0", optional = true }
+actix = { version = "0.10.0-alpha.1", default_features = false, optional = true }
 
 base64 = "0.11"
 bitflags = "1.2"

--- a/actix-http/Cargo.toml
+++ b/actix-http/Cargo.toml
@@ -41,7 +41,6 @@ secure-cookies = ["ring"]
 
 # support for actix Actor messages
 actix = ["actix"]
-resolver = ["actix/resolver"]
 
 [dependencies]
 actix-service = "1.0.1"
@@ -51,7 +50,7 @@ actix-utils = "1.0.3"
 actix-rt = "1.0.0"
 actix-threadpool = "0.3.1"
 actix-tls = { version = "1.0.0", optional = true }
-actix = { version = "0.10.0-alpha.1", default_features = false, optional = true }
+actix = { version = "0.10.0-alpha.1", optional = true }
 
 base64 = "0.11"
 bitflags = "1.2"

--- a/actix-http/Cargo.toml
+++ b/actix-http/Cargo.toml
@@ -40,7 +40,7 @@ failure = ["fail-ure"]
 secure-cookies = ["ring"]
 
 # support for actix Actor messages
-actix = ["actix"]
+actors = ["actix"]
 
 [dependencies]
 actix-service = "1.0.1"

--- a/actix-http/src/error.rs
+++ b/actix-http/src/error.rs
@@ -955,7 +955,7 @@ impl ResponseError for fail_ure::Error {}
 /// `InternalServerError` for `actix::MailboxError`
 impl ResponseError for actix::MailboxError {} 
 
-#[cfg(all(feature = "actix", feature = "resolver"))]
+#[cfg(feature = "actix")]
 /// `InternalServerError` for `actix::ResolverError`
 impl ResponseError for actix::actors::resolver::ResolverError {} 
 

--- a/actix-http/src/error.rs
+++ b/actix-http/src/error.rs
@@ -951,11 +951,11 @@ where
 /// Compatibility for `failure::Error`
 impl ResponseError for fail_ure::Error {}
 
-#[cfg(feature = "actix")]
+#[cfg(feature = "actors")]
 /// `InternalServerError` for `actix::MailboxError`
 impl ResponseError for actix::MailboxError {} 
 
-#[cfg(feature = "actix")]
+#[cfg(feature = "actors")]
 /// `InternalServerError` for `actix::ResolverError`
 impl ResponseError for actix::actors::resolver::ResolverError {} 
 

--- a/actix-http/src/error.rs
+++ b/actix-http/src/error.rs
@@ -951,6 +951,14 @@ where
 /// Compatibility for `failure::Error`
 impl ResponseError for fail_ure::Error {}
 
+#[cfg(feature = "actix")]
+/// `InternalServerError` for `actix::MailboxError`
+impl ResponseError for actix::MailboxError {} 
+
+#[cfg(all(feature = "actix", feature = "resolver"))]
+/// `InternalServerError` for `actix::ResolverError`
+impl ResponseError for actix::actors::resolver::ResolverError {} 
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/actix-http/src/error.rs
+++ b/actix-http/src/error.rs
@@ -953,10 +953,12 @@ impl ResponseError for fail_ure::Error {}
 
 #[cfg(feature = "actors")]
 /// `InternalServerError` for `actix::MailboxError`
+/// This is supported on feature=`actors` only
 impl ResponseError for actix::MailboxError {} 
 
 #[cfg(feature = "actors")]
 /// `InternalServerError` for `actix::ResolverError`
+/// This is supported on feature=`actors` only
 impl ResponseError for actix::actors::resolver::ResolverError {} 
 
 #[cfg(test)]


### PR DESCRIPTION
As part of actix:0.10 release actix will not have "http" feature flag https://github.com/actix/actix/issues/321 which allowed to break circular dependency. Though actix does not support handling of actor's error messages via ResponseError anymore. 

This PR introduces "actors" feature flags which would re-add support for handling of MailboxError and ResolverError (with "resolver" flag).
