### PR TITLE
Remove limitation that prohibits segments from starting with '.'

### DIFF
--- a/actix-files/src/lib.rs
+++ b/actix-files/src/lib.rs
@@ -605,8 +605,6 @@ impl PathBufWrp {
         for segment in path.split('/') {
             if segment == ".." {
                 buf.pop();
-            } else if segment.starts_with('.') {
-                return Err(UriSegmentError::BadStart('.'));
             } else if segment.starts_with('*') {
                 return Err(UriSegmentError::BadStart('*'));
             } else if segment.ends_with(':') {
@@ -1397,10 +1395,6 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_path_buf() {
-        assert_eq!(
-            PathBufWrp::get_pathbuf("/test/.tt").map(|t| t.0),
-            Err(UriSegmentError::BadStart('.'))
-        );
         assert_eq!(
             PathBufWrp::get_pathbuf("/test/*tt").map(|t| t.0),
             Err(UriSegmentError::BadStart('*'))


### PR DESCRIPTION
The path "/.well-known", can be handy to use with Let's Encrypt, due to the requirements of https://tools.ietf.org/html/rfc8555 which inherits that name from https://tools.ietf.org/html/rfc5785

This commit removes the restriction that prevents actix-files::Files from serving files from paths that contain a segment that starts with a leading '.'

Without this commit I was unsuccessful getting [acme-lib](https://github.com/algesten/acme-lib) to work, but with it (and a [commit to acme-lib](https://github.com/algesten/acme-lib/pull/12)), I was successful.