### PR TITLE
Http2 client configuration to improve performance

### DIFF
--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -12,7 +12,11 @@
 
 * MessageBody is not implemented for &'static [u8] anymore.
 
-* Change defaul initial window size and connection window size for HTTP2 to 5MB and 2MB respectively. This 7 times improves download speed for awc when downloading large objects.
+* Change default initial window size and connection window size for HTTP2 to 2MB and 1MB respectively to improve download speed for awc when downloading large objects.
+
+* client::Connector accepts initial_window_size and initial_connection_window_size HTTP2 configuration
+
+* client::Connector allowing to set max_http_version to limit HTTP version to be used
 
 ### Fixed
 

--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -12,6 +12,8 @@
 
 * MessageBody is not implemented for &'static [u8] anymore.
 
+* Change defaul initial window size and connection window size for HTTP2 to 5MB and 2MB respectively. This 7 times improves download speed for awc when downloading large objects.
+
 ### Fixed
 
 * Allow `SameSite=None` cookies to be sent in a response.

--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -1,5 +1,15 @@
 # Changes
 
+## [NEXT] - 2020-02-27
+
+### Changed
+
+* Change default initial window size and connection window size for HTTP2 to 2MB and 1MB respectively to improve download speed for awc when downloading large objects.
+
+* client::Connector accepts initial_window_size and initial_connection_window_size HTTP2 configuration
+
+* client::Connector allowing to set max_http_version to limit HTTP version to be used
+
 ## [2.0.0-alpha.1] - 2020-02-27
 
 ### Changed
@@ -11,12 +21,6 @@
 * Breaking change: trait MessageBody requires Unpin and accepting Pin<&mut Self> instead of &mut self in the poll_next().
 
 * MessageBody is not implemented for &'static [u8] anymore.
-
-* Change default initial window size and connection window size for HTTP2 to 2MB and 1MB respectively to improve download speed for awc when downloading large objects.
-
-* client::Connector accepts initial_window_size and initial_connection_window_size HTTP2 configuration
-
-* client::Connector allowing to set max_http_version to limit HTTP version to be used
 
 ### Fixed
 

--- a/actix-http/src/client/config.rs
+++ b/actix-http/src/client/config.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 // These values are taken from hyper/src/proto/h2/client.rs
 const DEFAULT_H2_CONN_WINDOW: u32 = 1024 * 1024 * 2; // 2mb
-const DEFAULT_H2_STREAM_WINDOW: u32 = 1024 * 1024 * 1; // 1mb
+const DEFAULT_H2_STREAM_WINDOW: u32 = 1024 * 1024; // 1mb
 
 /// Connector configuration
 #[derive(Clone)]

--- a/actix-http/src/client/config.rs
+++ b/actix-http/src/client/config.rs
@@ -1,0 +1,39 @@
+use std::time::Duration;
+
+// These values are taken from hyper/src/proto/h2/client.rs
+const DEFAULT_H2_CONN_WINDOW: u32 = 1024 * 1024 * 2; // 2mb
+const DEFAULT_H2_STREAM_WINDOW: u32 = 1024 * 1024 * 1; // 1mb
+
+/// Connector configuration
+#[derive(Clone)]
+pub(crate) struct ConnectorConfig {
+    pub(crate) timeout: Duration,
+    pub(crate) conn_lifetime: Duration,
+    pub(crate) conn_keep_alive: Duration,
+    pub(crate) disconnect_timeout: Option<Duration>,
+    pub(crate) limit: usize,
+    pub(crate) conn_window_size: u32,
+    pub(crate) stream_window_size: u32,
+}
+
+impl Default for ConnectorConfig {
+    fn default() -> Self {
+        Self {
+            timeout: Duration::from_secs(1),
+            conn_lifetime: Duration::from_secs(75),
+            conn_keep_alive: Duration::from_secs(15),
+            disconnect_timeout: Some(Duration::from_millis(3000)),
+            limit: 100,
+            conn_window_size: DEFAULT_H2_CONN_WINDOW,
+            stream_window_size: DEFAULT_H2_STREAM_WINDOW,
+        }
+    }
+}
+
+impl ConnectorConfig {
+    pub(crate) fn no_disconnect_timeout(&self) -> Self {
+        let mut res = self.clone();
+        res.disconnect_timeout = None;
+        res
+    }
+}

--- a/actix-http/src/client/connector.rs
+++ b/actix-http/src/client/connector.rs
@@ -50,13 +50,6 @@ type SslConnector = ();
 pub struct Connector<T, U> {
     connector: T,
     config: ConnectorConfig,
-    /*    timeout: Duration,
-    conn_lifetime: Duration,
-    conn_keep_alive: Duration,
-    disconnect_timeout: Duration,
-    limit: usize,
-    conn_window_size: u32,
-    stream_window_size: u32,*/
     #[allow(dead_code)]
     ssl: SslConnector,
     _t: PhantomData<U>,

--- a/actix-http/src/client/connector.rs
+++ b/actix-http/src/client/connector.rs
@@ -164,13 +164,14 @@ where
     }
 
     /// Maximum supported http major version
-    /// When supplied 1 both HTTP/1.0 and HTTP/1.1 will be allowed
-    pub fn max_http_version(mut self, val: u8) -> Self {
-        self.ssl = Connector::build_ssl(if val == 1 {
-            vec![b"http/1.1".to_vec()]
-        } else {
-            vec![b"h2".to_vec(), b"http/1.1".to_vec()]
-        });
+    /// Supported versions http/1.1, http/2
+    pub fn max_http_version(mut self, val: http::Version) -> Self {
+        let versions = match val {
+            http::Version::HTTP_11 => vec![b"http/1.1".to_vec()],
+            http::Version::HTTP_2 => vec![b"h2".to_vec(), b"http/1.1".to_vec()],
+            _ => unimplemented!("actix-http:client: supported versions http/1.1, http/2"),
+        };
+        self.ssl = Connector::build_ssl(versions);
         self
     }
 

--- a/actix-http/src/client/connector.rs
+++ b/actix-http/src/client/connector.rs
@@ -72,13 +72,6 @@ impl Connector<(), ()> {
             ssl: Self::build_ssl(vec![b"h2".to_vec(), b"http/1.1".to_vec()]),
             connector: default_connector(),
             config: ConnectorConfig::default(),
-            /*            timeout: Duration::from_secs(1),
-            conn_lifetime: Duration::from_secs(75),
-            conn_keep_alive: Duration::from_secs(15),
-            disconnect_timeout: Duration::from_millis(3000),
-            limit: 100,
-            conn_window_size: DEFAULT_H2_CONN_WINDOW,
-            stream_window_size: DEFAULT_H2_STREAM_WINDOW,*/
             _t: PhantomData,
         }
     }

--- a/actix-http/src/client/mod.rs
+++ b/actix-http/src/client/mod.rs
@@ -1,6 +1,7 @@
 //! Http client api
 use http::Uri;
 
+mod config;
 mod connection;
 mod connector;
 mod error;

--- a/actix-http/src/client/pool.rs
+++ b/actix-http/src/client/pool.rs
@@ -594,7 +594,7 @@ where
                         Some(Acquired(this.key.clone(), this.inner.take())),
                     )));
                     Poll::Ready(())
-                } else {            
+                } else {
                     *this.h2 = Some(handshake(io).boxed_local());
                     self.poll(cx)
                 }

--- a/actix-http/src/client/pool.rs
+++ b/actix-http/src/client/pool.rs
@@ -13,12 +13,13 @@ use actix_utils::{oneshot, task::LocalWaker};
 use bytes::Bytes;
 use futures_util::future::{poll_fn, FutureExt, LocalBoxFuture};
 use fxhash::FxHashMap;
-use h2::client::{handshake, Connection, SendRequest};
+use h2::client::{Connection, SendRequest};
 use http::uri::Authority;
 use indexmap::IndexSet;
 use pin_project::pin_project;
 use slab::Slab;
 
+use super::h2proto::handshake;
 use super::connection::{ConnectionType, IoConnection};
 use super::error::ConnectError;
 use super::Connect;
@@ -593,7 +594,7 @@ where
                         Some(Acquired(this.key.clone(), this.inner.take())),
                     )));
                     Poll::Ready(())
-                } else {
+                } else {            
                     *this.h2 = Some(handshake(io).boxed_local());
                     self.poll(cx)
                 }

--- a/actix-web-codegen/Cargo.toml
+++ b/actix-web-codegen/Cargo.toml
@@ -12,7 +12,7 @@ workspace = ".."
 proc-macro = true
 
 [dependencies]
-quote = "=1.0.2"
+quote = "^1"
 syn = { version = "^1", features = ["full", "parsing"] }
 proc-macro2 = "^1"
 

--- a/actix-web-codegen/Cargo.toml
+++ b/actix-web-codegen/Cargo.toml
@@ -12,7 +12,7 @@ workspace = ".."
 proc-macro = true
 
 [dependencies]
-quote = "^1"
+quote = "=1.0.2"
 syn = { version = "^1", features = ["full", "parsing"] }
 proc-macro2 = "^1"
 

--- a/awc/CHANGES.md
+++ b/awc/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## [NEXT]
+
+* ClientBuilder accepts initial_window_size and initial_connection_window_size HTTP2 configuration
+
+* ClientBuilder allowing to set max_http_version to limit HTTP version to be used
+
 ## [1.0.1] - 2019-12-15
 
 * Fix compilation with default features off

--- a/awc/src/builder.rs
+++ b/awc/src/builder.rs
@@ -169,8 +169,8 @@ impl ClientBuilder {
 
     /// Finish build process and create `Client` instance.
     pub fn finish(self) -> Client {
-        let connector = if self.connector.is_some() {
-            self.connector.unwrap()
+        let connector = if let Some(connector) = self.connector {
+            connector
         } else {
             let mut connector = Connector::new();
             if let Some(val) = self.max_http_version {

--- a/awc/src/builder.rs
+++ b/awc/src/builder.rs
@@ -5,7 +5,7 @@ use std::rc::Rc;
 use std::time::Duration;
 
 use actix_http::client::{Connect as HttpConnect, ConnectError, Connection, Connector};
-use actix_http::http::{header, Error as HttpError, HeaderMap, HeaderName};
+use actix_http::http::{header, Error as HttpError, HeaderMap, HeaderName, self};
 use actix_service::Service;
 
 use crate::connect::{ConnectorWrapper, Connect};
@@ -19,7 +19,7 @@ pub struct ClientBuilder {
     default_headers: bool,
     allow_redirects: bool,
     max_redirects: usize,
-    max_http_version: Option<u8>,
+    max_http_version: Option<http::Version>,
     stream_window_size: Option<u32>,
     conn_window_size: Option<u32>,
     headers: HeaderMap,
@@ -84,8 +84,8 @@ impl ClientBuilder {
     }
 
     /// Maximum supported http major version
-    /// When supplied 1 both HTTP/1.0 and HTTP/1.1 will be allowed
-    pub fn max_http_version(mut self, val: u8) -> Self {
+    /// Supported versions http/1.1, http/2
+    pub fn max_http_version(mut self, val: http::Version) -> Self {
         self.max_http_version = Some(val);
         self
     }

--- a/awc/src/builder.rs
+++ b/awc/src/builder.rs
@@ -4,11 +4,11 @@ use std::fmt;
 use std::rc::Rc;
 use std::time::Duration;
 
-use actix_http::client::{Connect, ConnectError, Connection, Connector};
+use actix_http::client::{Connect as HttpConnect, ConnectError, Connection, Connector};
 use actix_http::http::{header, Error as HttpError, HeaderMap, HeaderName};
 use actix_service::Service;
 
-use crate::connect::ConnectorWrapper;
+use crate::connect::{ConnectorWrapper, Connect};
 use crate::{Client, ClientConfig};
 
 /// An HTTP Client builder
@@ -16,10 +16,15 @@ use crate::{Client, ClientConfig};
 /// This type can be used to construct an instance of `Client` through a
 /// builder-like pattern.
 pub struct ClientBuilder {
-    config: ClientConfig,
     default_headers: bool,
     allow_redirects: bool,
     max_redirects: usize,
+    max_http_version: Option<u8>,
+    stream_window_size: Option<u32>,
+    conn_window_size: Option<u32>,
+    headers: HeaderMap,
+    timeout: Option<Duration>,
+    connector: Option<RefCell<Box<dyn Connect>>>,
 }
 
 impl Default for ClientBuilder {
@@ -34,25 +39,24 @@ impl ClientBuilder {
             default_headers: true,
             allow_redirects: true,
             max_redirects: 10,
-            config: ClientConfig {
-                headers: HeaderMap::new(),
-                timeout: Some(Duration::from_secs(5)),
-                connector: RefCell::new(Box::new(ConnectorWrapper(
-                    Connector::new().finish(),
-                ))),
-            },
+            headers: HeaderMap::new(),
+            timeout: Some(Duration::from_secs(5)),
+            connector: None,
+            max_http_version: None,
+            stream_window_size: None,
+            conn_window_size: None,
         }
     }
 
     /// Use custom connector service.
     pub fn connector<T>(mut self, connector: T) -> Self
     where
-        T: Service<Request = Connect, Error = ConnectError> + 'static,
+        T: Service<Request = HttpConnect, Error = ConnectError> + 'static,
         T::Response: Connection,
         <T::Response as Connection>::Future: 'static,
         T::Future: 'static,
     {
-        self.config.connector = RefCell::new(Box::new(ConnectorWrapper(connector)));
+        self.connector = Some(RefCell::new(Box::new(ConnectorWrapper(connector))));
         self
     }
 
@@ -61,13 +65,13 @@ impl ClientBuilder {
     /// Request timeout is the total time before a response must be received.
     /// Default value is 5 seconds.
     pub fn timeout(mut self, timeout: Duration) -> Self {
-        self.config.timeout = Some(timeout);
+        self.timeout = Some(timeout);
         self
     }
 
     /// Disable request timeout.
     pub fn disable_timeout(mut self) -> Self {
-        self.config.timeout = None;
+        self.timeout = None;
         self
     }
 
@@ -106,7 +110,7 @@ impl ClientBuilder {
         match HeaderName::try_from(key) {
             Ok(key) => match value.try_into() {
                 Ok(value) => {
-                    self.config.headers.append(key, value);
+                    self.headers.append(key, value);
                 }
                 Err(e) => log::error!("Header value error: {:?}", e),
             },
@@ -140,7 +144,27 @@ impl ClientBuilder {
 
     /// Finish build process and create `Client` instance.
     pub fn finish(self) -> Client {
-        Client(Rc::new(self.config))
+        let connector = if self.connector.is_some() {
+            self.connector.unwrap()
+        } else {
+            let mut connector = Connector::new();
+            if let Some(val) = self.max_http_version {
+                connector = connector.max_http_version(val)
+            };
+            if let Some(val) = self.conn_window_size {
+                connector = connector.initial_connection_window_size(val)
+            };
+            if let Some(val) = self.stream_window_size {
+                connector = connector.initial_window_size(val)
+            };
+            RefCell::new(Box::new(ConnectorWrapper(connector.finish())) as Box<dyn Connect>)
+        };
+        let config = ClientConfig {
+            headers: self.headers,
+            timeout: self.timeout,
+            connector,
+        };
+        Client(Rc::new(config))
     }
 }
 
@@ -153,7 +177,6 @@ mod tests {
         let client = ClientBuilder::new().basic_auth("username", Some("password"));
         assert_eq!(
             client
-                .config
                 .headers
                 .get(header::AUTHORIZATION)
                 .unwrap()
@@ -165,7 +188,6 @@ mod tests {
         let client = ClientBuilder::new().basic_auth("username", None);
         assert_eq!(
             client
-                .config
                 .headers
                 .get(header::AUTHORIZATION)
                 .unwrap()
@@ -180,7 +202,6 @@ mod tests {
         let client = ClientBuilder::new().bearer_auth("someS3cr3tAutht0k3n");
         assert_eq!(
             client
-                .config
                 .headers
                 .get(header::AUTHORIZATION)
                 .unwrap()

--- a/awc/src/builder.rs
+++ b/awc/src/builder.rs
@@ -83,6 +83,31 @@ impl ClientBuilder {
         self
     }
 
+    /// Maximum supported http major version
+    /// When supplied 1 both HTTP/1.0 and HTTP/1.1 will be allowed
+    pub fn max_http_version(mut self, val: u8) -> Self {
+        self.max_http_version = Some(val);
+        self
+    }
+
+    /// Indicates the initial window size (in octets) for
+    /// HTTP2 stream-level flow control for received data.
+    ///
+    /// The default value is 65,535 and is good for APIs, but not for big objects.
+    pub fn initial_window_size(mut self, size: u32) -> Self {
+        self.stream_window_size = Some(size);
+        self
+    }
+
+    /// Indicates the initial window size (in octets) for
+    /// HTTP2 connection-level flow control for received data.
+    ///
+    /// The default value is 65,535 and is good for APIs, but not for big objects.
+    pub fn initial_connection_window_size(mut self, size: u32) -> Self {
+        self.conn_window_size = Some(size);
+        self
+    }
+
     /// Set max number of redirects.
     ///
     /// Max redirects is set to 10 by default.

--- a/awc/tests/test_connector.rs
+++ b/awc/tests/test_connector.rs
@@ -1,0 +1,61 @@
+#![cfg(feature = "openssl")]
+use actix_http::HttpService;
+use actix_http_test::test_server;
+use actix_service::{map_config, ServiceFactory};
+use actix_web::http::Version;
+use actix_web::{dev::AppConfig, web, App, HttpResponse};
+use open_ssl::ssl::{SslAcceptor, SslConnector, SslFiletype, SslMethod, SslVerifyMode};
+
+fn ssl_acceptor() -> SslAcceptor {
+    // load ssl keys
+    let mut builder = SslAcceptor::mozilla_intermediate(SslMethod::tls()).unwrap();
+    builder
+        .set_private_key_file("../tests/key.pem", SslFiletype::PEM)
+        .unwrap();
+    builder
+        .set_certificate_chain_file("../tests/cert.pem")
+        .unwrap();
+    builder.set_alpn_select_callback(|_, protos| {
+        const H2: &[u8] = b"\x02h2";
+        if protos.windows(3).any(|window| window == H2) {
+            Ok(b"h2")
+        } else {
+            Err(open_ssl::ssl::AlpnError::NOACK)
+        }
+    });
+    builder.set_alpn_protos(b"\x02h2").unwrap();
+    builder.build()
+}
+
+#[actix_rt::test]
+async fn test_connection_window_size() {
+    let srv = test_server(move || {
+        HttpService::build()
+            .h2(map_config(
+                App::new().service(
+                    web::resource("/").route(web::to(|| HttpResponse::Ok())),
+                ),
+                |_| AppConfig::default(),
+            ))
+            .openssl(ssl_acceptor())
+            .map_err(|_| ())
+    });
+
+    // disable ssl verification
+    let mut builder = SslConnector::builder(SslMethod::tls()).unwrap();
+    builder.set_verify(SslVerifyMode::NONE);
+    let _ = builder
+        .set_alpn_protos(b"\x02h2\x08http/1.1")
+        .map_err(|e| log::error!("Can not set alpn protocol: {:?}", e));
+
+    let client = awc::Client::build()
+        .connector(awc::Connector::new().ssl(builder.build()).finish())
+        .initial_window_size(100)
+        .initial_connection_window_size(100)
+        .finish();
+
+    let request = client.get(srv.surl("/")).send();
+    let response = request.await.unwrap();
+    assert!(response.status().is_success());
+    assert_eq!(response.version(), Version::HTTP_2);
+}


### PR DESCRIPTION
This PR should be fixing https://github.com/actix/actix-web/issues/1393. 

Since implementation is using hardcoded const need your opinion (pls see question below). Implementation is pretty much based on [hyper's resolving similar problem](https://github.com/hyperium/hyper/blob/master/src/proto/h2/client.rs#L24-L28), though it sets initial buffer for quite large 5MB which gets some pressure off a task scheduler but requires more memory.

UPD: this PR also adding possibility to configure awc and Connector:
- initial_window_size
- initial_connection_window_size
- min_http_version

I have pointed awc_https example to this branch to show that it really helps:
https://github.com/dunnock/examples/tree/h2-speed-1393
Also it can be seen from benchmarks 
https://github.com/dunnock/awc_test/tree/benches

Speed with enabled alpn protocol:
```
	let mut builder = SslConnector::builder(SslMethod::tls()).unwrap();
	builder.set_alpn_protos(b"\x02h2\x08http/1.1").unwrap(); 
```
```
Benchmarking awc_test_openssl: 
Throughput 5994288B/s
Iters 10 total 101747060 elapsed 16974ms
awc_test_openssl        time:   [1.5834 s 1.6329 s 1.6794 s]                              
```
```
Benchmarking awc_test_default
Throughput 6327160B/s
Iters 10 total 101747060 elapsed 16081ms
awc_test_default        time:   [1.5967 s 1.7657 s 2.0360 s]                              
```
compared to reqwest
```
Benchmarking reqwest:
Throughput 6333067B/s
Iters 10 total 101747060 elapsed 16066ms
reqwest                 time:   [1.6207 s 1.7328 s 1.8409 s]                     
```
