### PR TITLE
Convert from `derive_more` to `thiserror`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,6 @@ actix-http = "2.0.0-alpha.2"
 awc = { version = "2.0.0-alpha.1", default-features = false }
 
 bytes = "0.5.3"
-derive_more = "0.99.2"
 encoding_rs = "0.8"
 futures = "0.3.1"
 fxhash = "0.2.1"
@@ -88,6 +87,7 @@ serde = { version = "1.0", features=["derive"] }
 serde_json = "1.0"
 serde_urlencoded = "0.6.1"
 time = { version = "0.2.7", default-features = false, features = ["std"] }
+thiserror = "1.0.11"
 url = "2.1"
 open-ssl = { version="0.10", package = "openssl", optional = true }
 rust-tls = { version = "0.17.0", package = "rustls", optional = true }

--- a/actix-files/Cargo.toml
+++ b/actix-files/Cargo.toml
@@ -24,12 +24,12 @@ actix-service = "1.0.1"
 bitflags = "1"
 bytes = "0.5.3"
 futures = "0.3.1"
-derive_more = "0.99.2"
 log = "0.4"
 mime = "0.3"
 mime_guess = "2.0.1"
 percent-encoding = "2.1"
 v_htmlescape = "0.4"
+thiserror = "1.0.11"
 
 [dev-dependencies]
 actix-rt = "1.0.0"

--- a/actix-files/src/error.rs
+++ b/actix-files/src/error.rs
@@ -1,16 +1,16 @@
 use actix_web::{http::StatusCode, HttpResponse, ResponseError};
-use derive_more::Display;
+use thiserror::Error;
 
 /// Errors which can occur when serving static files.
-#[derive(Display, Debug, PartialEq)]
+#[derive(Error, Debug, PartialEq)]
 pub enum FilesError {
     /// Path is not a directory
     #[allow(dead_code)]
-    #[display(fmt = "Path is not a directory. Unable to serve static files")]
+    #[error("Path is not a directory. Unable to serve static files")]
     IsNotDirectory,
 
     /// Cannot render directory
-    #[display(fmt = "Unable to render directory without index file")]
+    #[error("Unable to render directory without index file")]
     IsDirectory,
 }
 
@@ -21,16 +21,16 @@ impl ResponseError for FilesError {
     }
 }
 
-#[derive(Display, Debug, PartialEq)]
+#[derive(Error, Debug, PartialEq)]
 pub enum UriSegmentError {
     /// The segment started with the wrapped invalid character.
-    #[display(fmt = "The segment started with the wrapped invalid character")]
+    #[error("The segment started with the wrapped invalid character")]
     BadStart(char),
     /// The segment contained the wrapped invalid character.
-    #[display(fmt = "The segment contained the wrapped invalid character")]
+    #[error("The segment contained the wrapped invalid character")]
     BadChar(char),
     /// The segment ended with the wrapped invalid character.
-    #[display(fmt = "The segment ended with the wrapped invalid character")]
+    #[error("The segment ended with the wrapped invalid character")]
     BadEnd(char),
 }
 

--- a/actix-http/Cargo.toml
+++ b/actix-http/Cargo.toml
@@ -56,7 +56,6 @@ base64 = "0.11"
 bitflags = "1.2"
 bytes = "0.5.3"
 copyless = "0.1.4"
-derive_more = "0.99.2"
 either = "1.5.3"
 encoding_rs = "0.8"
 futures-core = "0.3.1"
@@ -80,6 +79,7 @@ serde_json = "1.0"
 sha-1 = "0.8"
 slab = "0.4"
 serde_urlencoded = "0.6.1"
+thiserror = "1.0.11"
 time = { version = "0.2.7", default-features = false, features = ["std"] }
 
 # for secure cookie

--- a/actix-http/src/ws/mod.rs
+++ b/actix-http/src/ws/mod.rs
@@ -5,8 +5,8 @@
 //! communicate with the peer.
 use std::io;
 
-use derive_more::{Display, From};
 use http::{header, Method, StatusCode};
+use thiserror::Error;
 
 use crate::error::ResponseError;
 use crate::message::RequestHead;
@@ -24,62 +24,62 @@ pub use self::frame::Parser;
 pub use self::proto::{hash_key, CloseCode, CloseReason, OpCode};
 
 /// Websocket protocol errors
-#[derive(Debug, Display, From)]
+#[derive(Debug, Error)]
 pub enum ProtocolError {
     /// Received an unmasked frame from client
-    #[display(fmt = "Received an unmasked frame from client")]
+    #[error("Received an unmasked frame from client")]
     UnmaskedFrame,
     /// Received a masked frame from server
-    #[display(fmt = "Received a masked frame from server")]
+    #[error("Received a masked frame from server")]
     MaskedFrame,
     /// Encountered invalid opcode
-    #[display(fmt = "Invalid opcode: {}", _0)]
+    #[error("Invalid opcode: {0}")]
     InvalidOpcode(u8),
     /// Invalid control frame length
-    #[display(fmt = "Invalid control frame length: {}", _0)]
+    #[error("Invalid control frame length: {0}")]
     InvalidLength(usize),
     /// Bad web socket op code
-    #[display(fmt = "Bad web socket op code")]
+    #[error("Bad web socket op code")]
     BadOpCode,
     /// A payload reached size limit.
-    #[display(fmt = "A payload reached size limit.")]
+    #[error("A payload reached size limit.")]
     Overflow,
     /// Continuation is not started
-    #[display(fmt = "Continuation is not started.")]
+    #[error("Continuation is not started.")]
     ContinuationNotStarted,
     /// Received new continuation but it is already started
-    #[display(fmt = "Received new continuation but it is already started")]
+    #[error("Received new continuation but it is already started")]
     ContinuationStarted,
     /// Unknown continuation fragment
-    #[display(fmt = "Unknown continuation fragment.")]
+    #[error("Unknown continuation fragment.")]
     ContinuationFragment(OpCode),
     /// Io error
-    #[display(fmt = "io error: {}", _0)]
-    Io(io::Error),
+    #[error("io error: {0}")]
+    Io(#[from] io::Error),
 }
 
 impl ResponseError for ProtocolError {}
 
 /// Websocket handshake errors
-#[derive(PartialEq, Debug, Display)]
+#[derive(PartialEq, Debug, Error)]
 pub enum HandshakeError {
     /// Only get method is allowed
-    #[display(fmt = "Method not allowed")]
+    #[error("Method not allowed")]
     GetMethodRequired,
     /// Upgrade header if not set to websocket
-    #[display(fmt = "Websocket upgrade is expected")]
+    #[error("Websocket upgrade is expected")]
     NoWebsocketUpgrade,
     /// Connection header is not set to upgrade
-    #[display(fmt = "Connection upgrade is expected")]
+    #[error("Connection upgrade is expected")]
     NoConnectionUpgrade,
     /// Websocket version header is not set
-    #[display(fmt = "Websocket version header is required")]
+    #[error("Websocket version header is required")]
     NoVersionHeader,
     /// Unsupported websocket version
-    #[display(fmt = "Unsupported version")]
+    #[error("Unsupported version")]
     UnsupportedVersion,
     /// Websocket key is not set or wrong
-    #[display(fmt = "Unknown websocket key")]
+    #[error("Unknown websocket key")]
     BadWebsocketKey,
 }
 

--- a/actix-multipart/Cargo.toml
+++ b/actix-multipart/Cargo.toml
@@ -20,11 +20,11 @@ actix-web = { version = "3.0.0-alpha.1", default-features = false }
 actix-service = "1.0.1"
 actix-utils = "1.0.3"
 bytes = "0.5.3"
-derive_more = "0.99.2"
 httparse = "1.3"
 futures = "0.3.1"
 log = "0.4"
 mime = "0.3"
+thiserror = "1.0.11"
 twoway = "0.2"
 
 [dev-dependencies]

--- a/actix-multipart/src/error.rs
+++ b/actix-multipart/src/error.rs
@@ -2,38 +2,36 @@
 use actix_web::error::{ParseError, PayloadError};
 use actix_web::http::StatusCode;
 use actix_web::ResponseError;
-use derive_more::{Display, From};
+use thiserror::Error;
 
 /// A set of errors that can occur during parsing multipart streams
-#[derive(Debug, Display, From)]
+#[derive(Debug, Error)]
 pub enum MultipartError {
     /// Content-Type header is not found
-    #[display(fmt = "No Content-type header found")]
+    #[error("No Content-type header found")]
     NoContentType,
     /// Can not parse Content-Type header
-    #[display(fmt = "Can not parse Content-Type header")]
+    #[error("Can not parse Content-Type header")]
     ParseContentType,
     /// Multipart boundary is not found
-    #[display(fmt = "Multipart boundary is not found")]
+    #[error("Multipart boundary is not found")]
     Boundary,
     /// Nested multipart is not supported
-    #[display(fmt = "Nested multipart is not supported")]
+    #[error("Nested multipart is not supported")]
     Nested,
     /// Multipart stream is incomplete
-    #[display(fmt = "Multipart stream is incomplete")]
+    #[error("Multipart stream is incomplete")]
     Incomplete,
     /// Error during field parsing
-    #[display(fmt = "{}", _0)]
-    Parse(ParseError),
+    #[error(transparent)]
+    Parse(#[from] ParseError),
     /// Payload error
-    #[display(fmt = "{}", _0)]
-    Payload(PayloadError),
+    #[error(transparent)]
+    Payload(#[from] PayloadError),
     /// Not consumed
-    #[display(fmt = "Multipart stream is not consumed")]
+    #[error("Multipart stream is not consumed")]
     NotConsumed,
 }
-
-impl std::error::Error for MultipartError {}
 
 /// Return `BadRequest` for `MultipartError`
 impl ResponseError for MultipartError {

--- a/awc/Cargo.toml
+++ b/awc/Cargo.toml
@@ -41,7 +41,6 @@ actix-rt = "1.0.0"
 
 base64 = "0.11"
 bytes = "0.5.3"
-derive_more = "0.99.2"
 futures-core = "0.3.1"
 log =" 0.4"
 mime = "0.3"
@@ -52,6 +51,7 @@ serde_json = "1.0"
 serde_urlencoded = "0.6.1"
 open-ssl = { version="0.10", package="openssl", optional = true }
 rust-tls = { version = "0.17.0", package="rustls", optional = true, features = ["dangerous_configuration"]  }
+thiserror = "1.0.11"
 
 [dev-dependencies]
 actix-connect = { version = "2.0.0-alpha.2", features=["openssl"] }

--- a/awc/src/error.rs
+++ b/awc/src/error.rs
@@ -11,35 +11,35 @@ use actix_http::ResponseError;
 use serde_json::error::Error as JsonError;
 
 use actix_http::http::{header::HeaderValue, StatusCode};
-use derive_more::{Display, From};
+use thiserror::Error;
 
 /// Websocket client error
-#[derive(Debug, Display, From)]
+#[derive(Debug, Error)]
 pub enum WsClientError {
     /// Invalid response status
-    #[display(fmt = "Invalid response status")]
+    #[error("Invalid response status")]
     InvalidResponseStatus(StatusCode),
     /// Invalid upgrade header
-    #[display(fmt = "Invalid upgrade header")]
+    #[error("Invalid upgrade header")]
     InvalidUpgradeHeader,
     /// Invalid connection header
-    #[display(fmt = "Invalid connection header")]
+    #[error("Invalid connection header")]
     InvalidConnectionHeader(HeaderValue),
     /// Missing CONNECTION header
-    #[display(fmt = "Missing CONNECTION header")]
+    #[error("Missing CONNECTION header")]
     MissingConnectionHeader,
     /// Missing SEC-WEBSOCKET-ACCEPT header
-    #[display(fmt = "Missing SEC-WEBSOCKET-ACCEPT header")]
+    #[error("Missing SEC-WEBSOCKET-ACCEPT header")]
     MissingWebSocketAcceptHeader,
     /// Invalid challenge response
-    #[display(fmt = "Invalid challenge response")]
+    #[error("Invalid challenge response")]
     InvalidChallengeResponse(String, HeaderValue),
     /// Protocol error
-    #[display(fmt = "{}", _0)]
-    Protocol(WsProtocolError),
+    #[error(transparent)]
+    Protocol(#[from] WsProtocolError),
     /// Send request error
-    #[display(fmt = "{}", _0)]
-    SendRequest(SendRequestError),
+    #[error(transparent)]
+    SendRequest(#[from] SendRequestError),
 }
 
 impl From<InvalidUrl> for WsClientError {
@@ -55,17 +55,17 @@ impl From<HttpError> for WsClientError {
 }
 
 /// A set of errors that can occur during parsing json payloads
-#[derive(Debug, Display, From)]
+#[derive(Debug, Error)]
 pub enum JsonPayloadError {
     /// Content type error
-    #[display(fmt = "Content type error")]
+    #[error("Content type error")]
     ContentType,
     /// Deserialize error
-    #[display(fmt = "Json deserialize error: {}", _0)]
-    Deserialize(JsonError),
+    #[error("Json deserialize error: {0}")]
+    Deserialize(#[from] JsonError),
     /// Payload error
-    #[display(fmt = "Error that occur during reading payload: {}", _0)]
-    Payload(PayloadError),
+    #[error("Error that occur during reading payload: {0}")]
+    Payload(#[from] PayloadError),
 }
 
 /// Return `InternalServerError` for `JsonPayloadError`

--- a/awc/src/sender.rs
+++ b/awc/src/sender.rs
@@ -6,9 +6,9 @@ use std::time::Duration;
 
 use actix_rt::time::{delay_for, Delay};
 use bytes::Bytes;
-use derive_more::From;
 use futures_core::{Future, Stream};
 use serde::Serialize;
+use thiserror::Error;
 
 use actix_http::body::{Body, BodyStream};
 use actix_http::http::header::{self, IntoHeaderValue};
@@ -26,10 +26,12 @@ use crate::error::{FreezeRequestError, InvalidUrl, SendRequestError};
 use crate::response::ClientResponse;
 use crate::ClientConfig;
 
-#[derive(Debug, From)]
+#[derive(Debug, Error)]
 pub(crate) enum PrepForSendingError {
-    Url(InvalidUrl),
-    Http(HttpError),
+    #[error(transparent)]
+    Url(#[from] InvalidUrl),
+    #[error(transparent)]
+    Http(#[from] HttpError),
 }
 
 impl Into<FreezeRequestError> for PrepForSendingError {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,54 +1,50 @@
 //! Error and Result module
 pub use actix_http::error::*;
-use derive_more::{Display, From};
 use serde_json::error::Error as JsonError;
+use thiserror::Error;
 use url::ParseError as UrlParseError;
 
 use crate::http::StatusCode;
 use crate::HttpResponse;
 
 /// Errors which can occur when attempting to generate resource uri.
-#[derive(Debug, PartialEq, Display, From)]
+#[derive(Debug, PartialEq, Error)]
 pub enum UrlGenerationError {
     /// Resource not found
-    #[display(fmt = "Resource not found")]
+    #[error("Resource not found")]
     ResourceNotFound,
     /// Not all path pattern covered
-    #[display(fmt = "Not all path pattern covered")]
+    #[error("Not all path pattern covered")]
     NotEnoughElements,
     /// URL parse error
-    #[display(fmt = "{}", _0)]
-    ParseError(UrlParseError),
+    #[error(transparent)]
+    ParseError(#[from] UrlParseError),
 }
 
 /// `InternalServerError` for `UrlGeneratorError`
 impl ResponseError for UrlGenerationError {}
 
 /// A set of errors that can occur during parsing urlencoded payloads
-#[derive(Debug, Display, From)]
+#[derive(Debug, Error)]
 pub enum UrlencodedError {
     /// Can not decode chunked transfer encoding
-    #[display(fmt = "Can not decode chunked transfer encoding")]
+    #[error("Can not decode chunked transfer encoding")]
     Chunked,
     /// Payload size is bigger than allowed. (default: 256kB)
-    #[display(
-        fmt = "Urlencoded payload size is bigger ({} bytes) than allowed (default: {} bytes)",
-        size,
-        limit
-    )]
+    #[error("Urlencoded payload size is bigger ({size} bytes) than allowed (default: {limit} bytes)")]
     Overflow { size: usize, limit: usize },
     /// Payload size is now known
-    #[display(fmt = "Payload size is now known")]
+    #[error("Payload size is now known")]
     UnknownLength,
     /// Content type error
-    #[display(fmt = "Content type error")]
+    #[error("Content type error")]
     ContentType,
     /// Parse error
-    #[display(fmt = "Parse error")]
+    #[error("Parse error")]
     Parse,
     /// Payload error
-    #[display(fmt = "Error that occur during reading payload: {}", _0)]
-    Payload(PayloadError),
+    #[error("Error that occur during reading payload: {0}")]
+    Payload(#[from] PayloadError),
 }
 
 /// Return `BadRequest` for `UrlencodedError`
@@ -63,20 +59,20 @@ impl ResponseError for UrlencodedError {
 }
 
 /// A set of errors that can occur during parsing json payloads
-#[derive(Debug, Display, From)]
+#[derive(Debug, Error)]
 pub enum JsonPayloadError {
     /// Payload size is bigger than allowed. (default: 32kB)
-    #[display(fmt = "Json payload size is bigger than allowed")]
+    #[error("Json payload size is bigger than allowed")]
     Overflow,
     /// Content type error
-    #[display(fmt = "Content type error")]
+    #[error("Content type error")]
     ContentType,
     /// Deserialize error
-    #[display(fmt = "Json deserialize error: {}", _0)]
-    Deserialize(JsonError),
+    #[error("Json deserialize error: {0}")]
+    Deserialize(#[from] JsonError),
     /// Payload error
-    #[display(fmt = "Error that occur during reading payload: {}", _0)]
-    Payload(PayloadError),
+    #[error("Error that occur during reading payload: {0}")]
+    Payload(#[from] PayloadError),
 }
 
 /// Return `BadRequest` for `JsonPayloadError`
@@ -92,11 +88,11 @@ impl ResponseError for JsonPayloadError {
 }
 
 /// A set of errors that can occur during parsing request paths
-#[derive(Debug, Display, From)]
+#[derive(Debug, Error)]
 pub enum PathError {
     /// Deserialize error
-    #[display(fmt = "Path deserialize error: {}", _0)]
-    Deserialize(serde::de::value::Error),
+    #[error("Path deserialize error: {0}")]
+    Deserialize(#[from] serde::de::value::Error),
 }
 
 /// Return `BadRequest` for `PathError`
@@ -107,11 +103,11 @@ impl ResponseError for PathError {
 }
 
 /// A set of errors that can occur during parsing query strings
-#[derive(Debug, Display, From)]
+#[derive(Debug, Error)]
 pub enum QueryPayloadError {
     /// Deserialize error
-    #[display(fmt = "Query deserialize error: {}", _0)]
-    Deserialize(serde::de::value::Error),
+    #[error("Query deserialize error: {0}")]
+    Deserialize(#[from] serde::de::value::Error),
 }
 
 /// Return `BadRequest` for `QueryPayloadError`
@@ -122,21 +118,21 @@ impl ResponseError for QueryPayloadError {
 }
 
 /// Error type returned when reading body as lines.
-#[derive(From, Display, Debug)]
+#[derive(Error, Debug)]
 pub enum ReadlinesError {
     /// Error when decoding a line.
-    #[display(fmt = "Encoding error")]
+    #[error("Encoding error")]
     /// Payload size is bigger than allowed. (default: 256kB)
     EncodingError,
     /// Payload error.
-    #[display(fmt = "Error that occur during reading payload: {}", _0)]
-    Payload(PayloadError),
+    #[error("Error that occur during reading payload: {0}")]
+    Payload(#[from] PayloadError),
     /// Line limit exceeded.
-    #[display(fmt = "Line limit exceeded")]
+    #[error("Line limit exceeded")]
     LimitOverflow,
     /// ContentType error.
-    #[display(fmt = "Content-type error")]
-    ContentTypeError(ContentTypeError),
+    #[error("Content-type error")]
+    ContentTypeError(#[from] ContentTypeError),
 }
 
 /// Return `BadRequest` for `ReadlinesError`

--- a/src/types/path.rs
+++ b/src/types/path.rs
@@ -250,15 +250,15 @@ impl Default for PathConfig {
 #[cfg(test)]
 mod tests {
     use actix_router::ResourceDef;
-    use derive_more::Display;
     use serde_derive::Deserialize;
+    use thiserror::Error;
 
     use super::*;
     use crate::test::TestRequest;
     use crate::{error, http, HttpResponse};
 
-    #[derive(Deserialize, Debug, Display)]
-    #[display(fmt = "MyStruct({}, {})", key, value)]
+    #[derive(Deserialize, Debug, Error)]
+    #[error("MyStruct({key}, {value})")]
     struct MyStruct {
         key: String,
         value: String,

--- a/src/types/query.rs
+++ b/src/types/query.rs
@@ -224,15 +224,16 @@ impl Default for QueryConfig {
 #[cfg(test)]
 mod tests {
     use actix_http::http::StatusCode;
-    use derive_more::Display;
     use serde_derive::Deserialize;
+    use thiserror::Error;
 
     use super::*;
     use crate::error::InternalError;
     use crate::test::TestRequest;
     use crate::HttpResponse;
 
-    #[derive(Deserialize, Debug, Display)]
+    #[derive(Deserialize, Debug, Error)]
+    #[error("{id}")]
     struct Id {
         id: String,
     }


### PR DESCRIPTION
The thiserror has the advantage of implementing std::error::Error and it
integrates better with the Rust ecosystem.

Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>