### PR TITLE
📝 Improve the code example for JsonConfig

### DIFF
--- a/src/types/json.rs
+++ b/src/types/json.rs
@@ -223,8 +223,6 @@ where
 ///     format!("Welcome {}!", info.username)
 /// }
 ///
-/// /// Create custom error response
-///
 /// /// Return either a 400 or 415, and include the error message from serde
 /// /// in the response body
 /// fn json_error_handler(err: error::JsonPayloadError, _req: &HttpRequest) -> error::Error {

--- a/src/types/json.rs
+++ b/src/types/json.rs
@@ -208,8 +208,10 @@ where
 
 /// Json extractor configuration
 ///
+/// # Examples
+///
 /// ```rust
-/// use actix_web::{error, web, App, FromRequest, HttpResponse};
+/// use actix_web::{error, web, App, FromRequest, HttpRequest, HttpResponse};
 /// use serde_derive::Deserialize;
 ///
 /// #[derive(Deserialize)]
@@ -222,6 +224,21 @@ where
 ///     format!("Welcome {}!", info.username)
 /// }
 ///
+/// /// Create custom error response
+///
+/// /// Return either a 400 or 415, and include the error message from serde
+/// /// in the response body
+/// fn json_error_handler(err: error::JsonPayloadError, _req: &HttpRequest) -> error::Error {
+///     let detail = err.to_string();
+///     let response = match &err {
+///         error::JsonPayloadError::ContentType => {
+///             HttpResponse::UnsupportedMediaType().content_type("text/plain").body(detail)
+///         }
+///         _ => HttpResponse::BadRequest().content_type("text/plain").body(detail),
+///     };
+///     error::InternalError::from_response(err, response).into()
+/// }
+///
 /// fn main() {
 ///     let app = App::new().service(
 ///         web::resource("/index.html")
@@ -232,10 +249,7 @@ where
 ///                        .content_type(|mime| {  // <- accept text/plain content type
 ///                            mime.type_() == mime::TEXT && mime.subtype() == mime::PLAIN
 ///                        })
-///                        .error_handler(|err, req| {  // <- create custom error response
-///                           error::InternalError::from_response(
-///                               err, HttpResponse::Conflict().finish()).into()
-///                        })
+///                        .error_handler(json_error_handler)  // Use our custom error response
 ///             }))
 ///             .route(web::post().to(index))
 ///     );


### PR DESCRIPTION
I initially submitted a new example in https://github.com/actix/examples/pull/268, and was recommended to add the example to the docstring in this repository.

This expands the JSON error handler to set a response code and return an error message in the body. It also 

I made a couple of changes compared to https://github.com/actix/examples/pull/268. I removed the 422 response, as I discovered that Serde sometimes gives an `is_data` type error even for malformed JSON. 422 is not supposed to be used if the request is syntactically incorrect. For example, `{"a": 5` will give an `is_data` error if `"a"` is expected to be a string, and not mention the missing closing curly bracket.

I could add the `curl` examples from the README in https://github.com/actix/examples/pull/268, but I'm not quite sure where they fit in best here. 

## Questions

- Should this example be in addition to, rather than replace, the current example?