### PR TITLE
Implement `std::error::Error` for our custom errors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Changes
 
+## [Unreleased]
+
+### Changed
+
+* Implement `std::error::Error` for our custom errors [#1422]
+
+[#1422]: https://github.com/actix/actix-web/pull/1422
+
 ## [3.0.0-alpha.1] - 2020-03-11
 
 ### Added

--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -1,5 +1,13 @@
 # Changes
 
+## [Unreleased]
+
+### Changed
+
+* Implement `std::error::Error` for our custom errors [#1422]
+
+[#1422]: https://github.com/actix/actix-web/pull/1422
+
 ## [2.0.0-alpha.2] - 2020-03-07
 
 ### Changed

--- a/actix-http/src/client/error.rs
+++ b/actix-http/src/client/error.rs
@@ -55,6 +55,8 @@ pub enum ConnectError {
     Io(io::Error),
 }
 
+impl std::error::Error for ConnectError {}
+
 impl From<actix_connect::ConnectError> for ConnectError {
     fn from(err: actix_connect::ConnectError) -> ConnectError {
         match err {
@@ -86,6 +88,8 @@ pub enum InvalidUrl {
     HttpError(http::Error),
 }
 
+impl std::error::Error for InvalidUrl {}
+
 /// A set of errors that can occur during request sending and response reading
 #[derive(Debug, Display, From)]
 pub enum SendRequestError {
@@ -115,6 +119,8 @@ pub enum SendRequestError {
     Body(Error),
 }
 
+impl std::error::Error for SendRequestError {}
+
 /// Convert `SendRequestError` to a server `Response`
 impl ResponseError for SendRequestError {
     fn status_code(&self) -> StatusCode {
@@ -138,6 +144,8 @@ pub enum FreezeRequestError {
     #[display(fmt = "{}", _0)]
     Http(HttpError),
 }
+
+impl std::error::Error for FreezeRequestError {}
 
 impl From<FreezeRequestError> for SendRequestError {
     fn from(e: FreezeRequestError) -> Self {

--- a/actix-http/src/error.rs
+++ b/actix-http/src/error.rs
@@ -333,6 +333,8 @@ pub enum PayloadError {
     Io(io::Error),
 }
 
+impl std::error::Error for PayloadError {}
+
 impl From<h2::Error> for PayloadError {
     fn from(err: h2::Error) -> Self {
         PayloadError::Http2Payload(err)
@@ -440,6 +442,8 @@ pub enum ContentTypeError {
     #[display(fmt = "Unknown content encoding")]
     UnknownEncoding,
 }
+
+impl std::error::Error for ContentTypeError {}
 
 /// Return `BadRequest` for `ContentTypeError`
 impl ResponseError for ContentTypeError {

--- a/actix-http/src/ws/mod.rs
+++ b/actix-http/src/ws/mod.rs
@@ -58,6 +58,8 @@ pub enum ProtocolError {
     Io(io::Error),
 }
 
+impl std::error::Error for ProtocolError {}
+
 impl ResponseError for ProtocolError {}
 
 /// Websocket handshake errors

--- a/awc/CHANGES.md
+++ b/awc/CHANGES.md
@@ -1,5 +1,13 @@
 # Changes
 
+## [Unreleased]
+
+### Changed
+
+* Implement `std::error::Error` for our custom errors [#1422]
+
+[#1422]: https://github.com/actix/actix-web/pull/1422
+
 ## [2.0.0-alpha.1] - 2020-03-11
 
 * Update `actix-http` dependency to 2.0.0-alpha.2

--- a/awc/src/error.rs
+++ b/awc/src/error.rs
@@ -42,6 +42,8 @@ pub enum WsClientError {
     SendRequest(SendRequestError),
 }
 
+impl std::error::Error for WsClientError {}
+
 impl From<InvalidUrl> for WsClientError {
     fn from(err: InvalidUrl) -> Self {
         WsClientError::SendRequest(err.into())
@@ -67,6 +69,8 @@ pub enum JsonPayloadError {
     #[display(fmt = "Error that occur during reading payload: {}", _0)]
     Payload(PayloadError),
 }
+
+impl std::error::Error for JsonPayloadError {}
 
 /// Return `InternalServerError` for `JsonPayloadError`
 impl ResponseError for JsonPayloadError {}

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,6 +21,8 @@ pub enum UrlGenerationError {
     ParseError(UrlParseError),
 }
 
+impl std::error::Error for UrlGenerationError {}
+
 /// `InternalServerError` for `UrlGeneratorError`
 impl ResponseError for UrlGenerationError {}
 
@@ -51,6 +53,8 @@ pub enum UrlencodedError {
     Payload(PayloadError),
 }
 
+impl std::error::Error for UrlencodedError {}
+
 /// Return `BadRequest` for `UrlencodedError`
 impl ResponseError for UrlencodedError {
     fn status_code(&self) -> StatusCode {
@@ -79,6 +83,8 @@ pub enum JsonPayloadError {
     Payload(PayloadError),
 }
 
+impl std::error::Error for JsonPayloadError {}
+
 /// Return `BadRequest` for `JsonPayloadError`
 impl ResponseError for JsonPayloadError {
     fn error_response(&self) -> HttpResponse {
@@ -99,6 +105,8 @@ pub enum PathError {
     Deserialize(serde::de::value::Error),
 }
 
+impl std::error::Error for PathError {}
+
 /// Return `BadRequest` for `PathError`
 impl ResponseError for PathError {
     fn status_code(&self) -> StatusCode {
@@ -113,6 +121,8 @@ pub enum QueryPayloadError {
     #[display(fmt = "Query deserialize error: {}", _0)]
     Deserialize(serde::de::value::Error),
 }
+
+impl std::error::Error for QueryPayloadError {}
 
 /// Return `BadRequest` for `QueryPayloadError`
 impl ResponseError for QueryPayloadError {
@@ -138,6 +148,8 @@ pub enum ReadlinesError {
     #[display(fmt = "Content-type error")]
     ContentTypeError(ContentTypeError),
 }
+
+impl std::error::Error for ReadlinesError {}
 
 /// Return `BadRequest` for `ReadlinesError`
 impl ResponseError for ReadlinesError {


### PR DESCRIPTION
For allowing a more ergonomic use and better integration on the
ecosystem, this adds the `std::error::Error` `impl` for our custom
errors.

We intent to drop this hand made code once `derive_more` finishes the
addition of the Error derive support[1]. Until that is available, we
need to live with that.

1. https://github.com/JelteF/derive_more/issues/92