### PR TITLE
enable guards to access get_identity()

### DIFF
--- a/actix-identity/src/lib.rs
+++ b/actix-identity/src/lib.rs
@@ -116,7 +116,7 @@ impl Identity {
         }
     }
 
-    fn get_identity(extensions: &Extensions) -> Option<String> {
+    pub fn get_identity(extensions: &Extensions) -> Option<String> {
         if let Some(id) = extensions.get::<IdentityItem>() {
             id.id.clone()
         } else {


### PR DESCRIPTION
This change is intended to allow one to create an actix-web guard that determines whether a given scope is exposed, restricting to, for instance, only identified users.  With this change the following code is allowed.

```
struct AuthGuard();

impl actix_web::guard::Guard for AuthGuard {
    fn check(&self, request: &RequestHead) -> bool {
        actix_identity::Identity::get_identity(&*request.extensions()).is_some()
    }
}
....
            .service(
                web::scope("/api")
                    .guard(AuthGuard())
```

This is not intended to be a complete protection but rather an additional mitigation.
For other use cases, the guard could perform additional access control using the identity.
```
impl actix_web::guard::Guard for AuthGuard {
    fn check(&self, request: &RequestHead) -> bool {
        if let Some(id) = actix_identity::Identity::get_identity(&*request.extensions()) {
            User::from(id).has_permission()
        }
        false
    }
}
```
Again, this isn't intended to authenticate individual endpoints but to provide additional protection to certain scopes.