### PR TITLE
actix-http: Remove `failure` support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,15 +42,13 @@ members = [
 ]
 
 [features]
-default = ["compress", "failure"]
+default = ["compress"]
 
 # content-encoding support
 compress = ["actix-http/compress", "awc/compress"]
 
 # sessions feature, session require "ring" crate and c compiler
 secure-cookies = ["actix-http/secure-cookies"]
-
-failure = ["actix-http/failure"]
 
 # openssl
 openssl = ["actix-tls/openssl", "awc/openssl", "open-ssl"]

--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -5,6 +5,8 @@
 ### Changed
 
 * Implement `std::error::Error` for our custom errors [#1422]
+* Remove `failure` support for `ResponseError` since that crate
+  will be deprecated in the near future.
 
 [#1422]: https://github.com/actix/actix-web/pull/1422
 

--- a/actix-http/Cargo.toml
+++ b/actix-http/Cargo.toml
@@ -15,7 +15,7 @@ license = "MIT/Apache-2.0"
 edition = "2018"
 
 [package.metadata.docs.rs]
-features = ["openssl", "rustls", "failure", "compress", "secure-cookies","actors"]
+features = ["openssl", "rustls", "compress", "secure-cookies", "actors"]
 
 [lib]
 name = "actix_http"
@@ -32,9 +32,6 @@ rustls = ["actix-tls/rustls", "actix-connect/rustls"]
 
 # enable compressison support
 compress = ["flate2", "brotli2"]
-
-# failure integration. actix does not use failure anymore
-failure = ["fail-ure"]
 
 # support for secure cookies
 secure-cookies = ["ring"]
@@ -88,9 +85,6 @@ ring = { version = "0.16.9", optional = true }
 # compression
 brotli2 = { version="0.3.2", optional = true }
 flate2 = { version = "1.0.13", optional = true }
-
-# optional deps
-fail-ure = { version = "0.1.5", package="failure", optional = true }
 
 [dev-dependencies]
 actix-server = "1.0.1"

--- a/actix-http/src/error.rs
+++ b/actix-http/src/error.rs
@@ -34,7 +34,7 @@ pub type Result<T, E = Error> = result::Result<T, E>;
 
 /// General purpose actix web error.
 ///
-/// An actix web error is used to carry errors from `failure` or `std::error`
+/// An actix web error is used to carry errors from `std::error`
 /// through actix in a convenient way.  It can be created through
 /// converting errors with `into()`.
 ///
@@ -949,10 +949,6 @@ where
 {
     InternalError::new(err, StatusCode::NETWORK_AUTHENTICATION_REQUIRED).into()
 }
-
-#[cfg(feature = "failure")]
-/// Compatibility for `failure::Error`
-impl ResponseError for fail_ure::Error {}
 
 #[cfg(feature = "actors")]
 /// `InternalServerError` for `actix::MailboxError`

--- a/test-server/Cargo.toml
+++ b/test-server/Cargo.toml
@@ -52,7 +52,7 @@ sha1 = "0.6"
 slab = "0.4"
 serde_urlencoded = "0.6.1"
 time = { version = "0.2.7", default-features = false, features = ["std"] }
-open-ssl = { version="0.10", package="openssl", optional = true }
+open-ssl = { version="0.10", package = "openssl", optional = true }
 
 [dev-dependencies]
 actix-web = "3.0.0-alpha.1"


### PR DESCRIPTION
The `failure` crate will be deprecated, see [current maintainer's post on IRLO](https://internals.rust-lang.org/t/failure-crate-maintenance/12087?u=johntitor) and [withoutboats' post](https://boats.gitlab.io/blog/post/failure-to-fehler/).
It's no rush but we should land this sooner or later.

Someone may want to support another ecosystem but I think it's out of scope here.