### PR TITLE
Hide continuation frames from application layer.

### DIFF
--- a/actix-http/src/ws/dispatcher.rs
+++ b/actix-http/src/ws/dispatcher.rs
@@ -6,11 +6,11 @@ use actix_codec::{AsyncRead, AsyncWrite, Framed};
 use actix_service::{IntoService, Service};
 use actix_utils::framed;
 
-use super::{Codec, Frame, Message};
+use super::{Codec, Frame};
 
 pub struct Dispatcher<S, T>
 where
-    S: Service<Request = Frame, Response = Message> + 'static,
+    S: Service<Request = Frame, Response = Frame> + 'static,
     T: AsyncRead + AsyncWrite,
 {
     inner: framed::Dispatcher<S, T, Codec>,
@@ -19,7 +19,7 @@ where
 impl<S, T> Dispatcher<S, T>
 where
     T: AsyncRead + AsyncWrite,
-    S: Service<Request = Frame, Response = Message>,
+    S: Service<Request = Frame, Response = Frame>,
     S::Future: 'static,
     S::Error: 'static,
 {
@@ -39,7 +39,7 @@ where
 impl<S, T> Future for Dispatcher<S, T>
 where
     T: AsyncRead + AsyncWrite,
-    S: Service<Request = Frame, Response = Message>,
+    S: Service<Request = Frame, Response = Frame>,
     S::Future: 'static,
     S::Error: 'static,
 {

--- a/actix-http/src/ws/frame.rs
+++ b/actix-http/src/ws/frame.rs
@@ -153,7 +153,7 @@ impl Parser {
     }
 
     /// Generate binary representation
-    pub fn write_message<B: AsRef<[u8]>>(
+    pub fn write_frame<B: AsRef<[u8]>>(
         dst: &mut BytesMut,
         pl: B,
         op: OpCode,
@@ -211,7 +211,7 @@ impl Parser {
             }
         };
 
-        Parser::write_message(dst, payload, OpCode::Close, true, mask)
+        Parser::write_frame(dst, payload, OpCode::Close, true, mask)
     }
 }
 
@@ -346,7 +346,7 @@ mod tests {
     #[test]
     fn test_ping_frame() {
         let mut buf = BytesMut::new();
-        Parser::write_message(&mut buf, Vec::from("data"), OpCode::Ping, true, false);
+        Parser::write_frame(&mut buf, Vec::from("data"), OpCode::Ping, true, false);
 
         let mut v = vec![137u8, 4u8];
         v.extend(b"data");
@@ -356,7 +356,7 @@ mod tests {
     #[test]
     fn test_pong_frame() {
         let mut buf = BytesMut::new();
-        Parser::write_message(&mut buf, Vec::from("data"), OpCode::Pong, true, false);
+        Parser::write_frame(&mut buf, Vec::from("data"), OpCode::Pong, true, false);
 
         let mut v = vec![138u8, 4u8];
         v.extend(b"data");

--- a/actix-http/src/ws/frame_iters.rs
+++ b/actix-http/src/ws/frame_iters.rs
@@ -1,0 +1,221 @@
+use super::{Frame, Item};
+
+use bytes::Bytes;
+use std::str::Chars;
+
+/// Convert binary message content into Frame::Continuation types
+///
+/// This struct is an iterator over websocket frames
+/// with a configurable maximum content size.
+/// Original messages that are already within the size
+/// limit will be rendered as an iterator over one single
+/// binary frame.
+/// Original messages that are larger than the size threshold
+/// will be converted into an iterator over continuation
+/// messages, where the first is a FirstBinary message.
+pub struct ContinuationBins<'a> {
+    original: &'a [u8],
+    step: usize,
+    bs_i: usize,
+    bs_tot: usize,
+    max_frame_content_bytes: usize,
+}
+
+impl<'a> ContinuationBins<'a> {
+    pub fn new(original: &'a [u8], max_frame_content_bytes: usize) -> Self {
+        let bs_tot = original.len();
+
+        Self {
+            original,
+            step: 0,
+            bs_i: 0,
+            bs_tot,
+            max_frame_content_bytes,
+        }
+    }
+}
+
+impl<'a> Iterator for ContinuationBins<'a> {
+    type Item = Frame;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.bs_i >= self.bs_tot {
+            None
+        } else if self.bs_tot - self.bs_i <= self.max_frame_content_bytes {
+            if self.step == 0 {
+                // if there are fewer than max bytes remaining to send and
+                // we haven't sent anything yet, no continuation frame needed
+                self.bs_i += self.max_frame_content_bytes;
+                Some(Frame::Binary(Bytes::copy_from_slice(&self.original)))
+            } else {
+                // otherwise if there are fewer than max bytes remaining to send and
+                // we've already sent something, we send a final frame
+                let here = self.bs_i;
+                self.bs_i += self.max_frame_content_bytes;
+                Some(Frame::Continuation(Item::Last(Bytes::copy_from_slice(
+                    &self.original[here..self.bs_tot],
+                ))))
+            }
+        } else {
+            let item = if self.step == 0 {
+                Item::FirstBinary(Bytes::copy_from_slice(
+                    &self.original[self.bs_i..self.bs_i + self.max_frame_content_bytes],
+                ))
+            } else {
+                Item::Continue(Bytes::copy_from_slice(
+                    &self.original[self.bs_i..self.bs_i + self.max_frame_content_bytes],
+                ))
+            };
+            self.step += 1;
+            self.bs_i += self.max_frame_content_bytes;
+
+            Some(Frame::Continuation(item))
+        }
+    }
+}
+
+/// Convert text message content into Frame::Continuation types
+///
+/// This struct is an iterator over websocket frames
+/// with a configurable maximum content size.
+/// Original messages that are already within the size
+/// limit will be rendered as an iterator over one single
+/// text frame.
+/// Original messages that are larger than the size threshold
+/// will be converted into an iterator over continuation
+/// frames, where the first is a FirstText message.
+/// Note that for text frames, the maximum content size is
+/// fuzzy -- the actual content size may exceed the configured
+/// maximum content size by up to 7 bytes, depending on UTF-8
+/// encoding of the text string.
+pub struct ContinuationTexts<'a> {
+    original: Chars<'a>,
+    step: usize,
+    bs_i: usize,
+    bs_tot: usize,
+    max_frame_content_bytes: usize,
+}
+
+impl<'a> ContinuationTexts<'a> {
+    pub fn new(original: Chars<'a>, max_frame_content_bytes: usize) -> Self {
+        let bs_tot = original.as_str().len();
+
+        Self {
+            original,
+            step: 0,
+            bs_i: 0,
+            bs_tot,
+            max_frame_content_bytes,
+        }
+    }
+}
+
+impl<'a> Iterator for ContinuationTexts<'a> {
+    type Item = Frame;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.bs_i >= self.bs_tot {
+            None
+        } else if self.bs_tot - self.bs_i <= self.max_frame_content_bytes {
+            let bs = Bytes::copy_from_slice(self.original.as_str().as_bytes());
+            self.bs_i += self.max_frame_content_bytes;
+            let frm = if self.step == 0 {
+                // if there are fewer than max bytes remaining to send and
+                // we haven't sent anything yet, no continuation frame needed
+                Frame::Text(bs)
+            } else {
+                // otherwise if there are fewer than max bytes remaining to send and
+                // we've already sent something, we send a final frame
+                Frame::Continuation(Item::Last(bs))
+            };
+            Some(frm)
+        } else {
+            let mut s = String::new();
+            let mut temp_i: usize = 0;
+            while temp_i < self.max_frame_content_bytes {
+                let c = self.original.next();
+                if let Some(c) = c {
+                    temp_i += c.len_utf8();
+                    self.bs_i += c.len_utf8();
+                    s.push(c);
+                } else {
+                    self.bs_i = self.bs_tot;
+                    break;
+                }
+            }
+            let item = if self.step == 0 {
+                Item::FirstText(Bytes::copy_from_slice(s.as_bytes()))
+            } else {
+                Item::Continue(Bytes::copy_from_slice(s.as_bytes()))
+            };
+            self.step += 1;
+
+            Some(Frame::Continuation(item))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_continuation_bins() {
+        // render a single Frame::Binary when max size is greater than the payload len
+        let mut bins = ContinuationBins::new(b"one two three", 100);
+        assert_eq!(bins.next(), Some(Frame::Binary("one two three".into())));
+
+        let mut bins = ContinuationBins::new(b"one two three", 4);
+        assert_eq!(
+            bins.next(),
+            Some(Frame::Continuation(Item::FirstBinary("one ".into())))
+        );
+        assert_eq!(
+            bins.next(),
+            Some(Frame::Continuation(Item::Continue("two ".into())))
+        );
+        assert_eq!(
+            bins.next(),
+            Some(Frame::Continuation(Item::Continue("thre".into())))
+        );
+        assert_eq!(
+            bins.next(),
+            Some(Frame::Continuation(Item::Last("e".into())))
+        );
+    }
+
+    #[test]
+    fn test_continuation_texts() {
+        // render a single Frame::Binary when max size is greater than the payload len
+        let mut texts = ContinuationTexts::new("one two three".chars(), 100);
+        assert_eq!(texts.next(), Some(Frame::Text("one two three".into())));
+
+        let mut texts = ContinuationTexts::new("one two three".chars(), 4);
+        assert_eq!(
+            texts.next(),
+            Some(Frame::Continuation(Item::FirstText("one ".into())))
+        );
+        assert_eq!(
+            texts.next(),
+            Some(Frame::Continuation(Item::Continue("two ".into())))
+        );
+        assert_eq!(
+            texts.next(),
+            Some(Frame::Continuation(Item::Continue("thre".into())))
+        );
+        assert_eq!(
+            texts.next(),
+            Some(Frame::Continuation(Item::Last("e".into())))
+        );
+
+        let mut snowmen = ContinuationTexts::new("⛄⛄⛄".chars(), 5);
+        assert_eq!(
+            snowmen.next(),
+            Some(Frame::Continuation(Item::FirstText("⛄⛄".into())))
+        );
+        assert_eq!(
+            snowmen.next(),
+            Some(Frame::Continuation(Item::Last("⛄".into())))
+        );
+    }
+}

--- a/actix-http/src/ws/mod.rs
+++ b/actix-http/src/ws/mod.rs
@@ -15,12 +15,14 @@ use crate::response::{Response, ResponseBuilder};
 mod codec;
 mod dispatcher;
 mod frame;
+mod frame_iters;
 mod mask;
 mod proto;
 
 pub use self::codec::{Codec, Frame, Item, Message};
 pub use self::dispatcher::Dispatcher;
 pub use self::frame::Parser;
+pub use self::frame_iters::{ContinuationBins, ContinuationTexts};
 pub use self::proto::{hash_key, CloseCode, CloseReason, OpCode};
 
 /// Websocket protocol errors


### PR DESCRIPTION
Greeting `actix_web` maintainers.  Please find attached a suggestion floated by way of a pull request.  I try to explain my reasoning in the commit message that follows, and would be interested to read your reactions...

This commit asserts that continuation frames are an implementation
detail of the websocket layer, and should remain hidden from the
application layer.  That is:
  - a codec should write only frames to the wire, and read only frames from the wire
  - when sending messages, the websocket implementation should break large
    text and binary messages into continuation frames -- the application should
    not have to be aware of this.
  - when receiving messages, the websocket implementation should reconstitute
    continuation frames into their original messages -- the application should
    not have to handle this.
  - the application should only have to send and receive complete websocket messages

Here, the reconstitution of continuation frames into their original messages is
done by the `Stream` implementation of `actix_web_actors::ws::WsStream`, by adding
a continuation frame buffer and not issuing a `Poll::Ready(Some(Ok))` result until
a complete message has been buffered.  A test in `actix_web_actors::tests::test_ws.rs`
checks this.

The breaking of large message payloads into sequential continuation frames is
done by the addition of an `actix_http::ws::frame_iters` module, which introduces
two structs `ContinuationBins` and `ContinuationTexts`.  These are iterators over
either single `Frame::Binary` or `Frame::Text` frames, if the payloads are small,
or over sequences of `Frame::Continuation`'s with appropriate Items `FirstBinary/FirstText`,
`Continue`, and `Last`.  New tests in `actix_http::ws::frame_iters` verify this
functionality.