### PR TITLE
fix spelling errors in doc comments

### DIFF
--- a/actix-files/src/lib.rs
+++ b/actix-files/src/lib.rs
@@ -521,7 +521,7 @@ impl Service for FilesService {
             Err(e) => return Either::Left(ok(req.error_response(e))),
         };
 
-        // full filepath
+        // full file path
         let path = match self.directory.join(&real_path.0).canonicalize() {
             Ok(path) => path,
             Err(e) => return self.handle_err(e, req),

--- a/actix-framed/src/lib.rs
+++ b/actix-framed/src/lib.rs
@@ -7,7 +7,7 @@ mod service;
 mod state;
 pub mod test;
 
-// re-export for convinience
+// re-export for convenience
 pub use actix_http::{http, Error, HttpMessage, Response, ResponseError};
 
 pub use self::app::{FramedApp, FramedAppService};

--- a/actix-framed/src/request.rs
+++ b/actix-framed/src/request.rs
@@ -42,7 +42,7 @@ impl<Io, S> FramedRequest<Io, S> {
         self.req.head()
     }
 
-    /// This method returns muttable reference to the request head.
+    /// This method returns mutable reference to the request head.
     /// panics if multiple references of http request exists.
     #[inline]
     pub fn head_mut(&mut self) -> &mut RequestHead {
@@ -131,7 +131,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_reqest() {
+    fn test_request() {
         let buf = TestBuffer::empty();
         let framed = Framed::new(buf, Codec::default());
         let req = TestRequest::with_uri("/index.html?q=1")

--- a/actix-http/src/config.rs
+++ b/actix-http/src/config.rs
@@ -114,7 +114,7 @@ impl ServiceConfig {
     }
 
     #[inline]
-    /// Return state of connection keep-alive funcitonality
+    /// Return state of connection keep-alive functionality
     pub fn keep_alive_enabled(&self) -> bool {
         self.0.ka_enabled
     }

--- a/actix-http/src/cookie/jar.rs
+++ b/actix-http/src/cookie/jar.rs
@@ -13,7 +13,7 @@ use super::secure::{Key, PrivateJar, SignedJar};
 ///
 /// A `CookieJar` provides storage for any number of cookies. Any changes made
 /// to the jar are tracked; the changes can be retrieved via the
-/// [delta](#method.delta) method which returns an interator over the changes.
+/// [delta](#method.delta) method which returns an iterator over the changes.
 ///
 /// # Usage
 ///

--- a/actix-http/src/cookie/mod.rs
+++ b/actix-http/src/cookie/mod.rs
@@ -103,7 +103,7 @@ enum CookieStr {
 
 impl CookieStr {
     /// Retrieves the string `self` corresponds to. If `self` is derived from
-    /// indexes, the corresponding subslice of `string` is returned. Otherwise,
+    /// indexes, the corresponding sub-slice of `string` is returned. Otherwise,
     /// the concrete string is returned.
     ///
     /// # Panics

--- a/actix-http/src/cookie/secure/key.rs
+++ b/actix-http/src/cookie/secure/key.rs
@@ -84,7 +84,7 @@ impl Key {
     }
 
     /// Generates signing/encryption keys from a secure, random source. Keys are
-    /// generated nondeterministically.
+    /// generated non-deterministically.
     ///
     /// # Panics
     ///
@@ -103,7 +103,7 @@ impl Key {
     }
 
     /// Attempts to generate signing/encryption keys from a secure, random
-    /// source. Keys are generated nondeterministically. If randomness cannot be
+    /// source. Keys are generated non-deterministically. If randomness cannot be
     /// retrieved from the underlying operating system, returns `None`.
     ///
     /// # Example

--- a/actix-http/src/error.rs
+++ b/actix-http/src/error.rs
@@ -18,7 +18,7 @@ use serde::de::value::Error as DeError;
 use serde_json::error::Error as JsonError;
 use serde_urlencoded::ser::Error as FormError;
 
-// re-export for convinience
+// re-export for convenience
 use crate::body::Body;
 pub use crate::cookie::ParseError as CookieParseError;
 use crate::helpers::Writer;
@@ -432,7 +432,7 @@ pub enum DispatchError {
     Unknown,
 }
 
-/// A set of error that can occure during parsing content type
+/// A set of error that can occur during parsing content type
 #[derive(PartialEq, Debug, Display)]
 pub enum ContentTypeError {
     /// Can not parse content type

--- a/actix-http/src/h1/decoder.rs
+++ b/actix-http/src/h1/decoder.rs
@@ -18,7 +18,7 @@ use crate::request::Request;
 const MAX_BUFFER_SIZE: usize = 131_072;
 const MAX_HEADERS: usize = 96;
 
-/// Incoming messagd decoder
+/// Incoming message decoder
 pub(crate) struct MessageDecoder<T: MessageType>(PhantomData<T>);
 
 #[derive(Debug)]

--- a/actix-http/src/h1/dispatcher.rs
+++ b/actix-http/src/h1/dispatcher.rs
@@ -297,8 +297,8 @@ where
 
     /// Flush stream
     ///
-    /// true - got whouldblock
-    /// false - didnt get whouldblock
+    /// true - got WouldBlock
+    /// false - didn't get WouldBlock
     #[pin_project::project]
     fn poll_flush(
         self: Pin<&mut Self>,
@@ -812,7 +812,7 @@ where
                             return self.poll(cx);
                         }
 
-                        // we didnt get WouldBlock from write operation,
+                        // we didn't get WouldBlock from write operation,
                         // so data get written to kernel completely (OSX)
                         // and we have to write again otherwise response can get stuck
                         if inner.as_mut().poll_flush(cx)? || !drain {

--- a/actix-http/src/header/common/content_disposition.rs
+++ b/actix-http/src/header/common/content_disposition.rs
@@ -90,40 +90,40 @@ pub enum DispositionParam {
     /// [RFC6266](https://tools.ietf.org/html/rfc6266) as *token "=" value*. Recipients should
     /// ignore unrecognizable parameters.
     Unknown(String, String),
-    /// An unrecognized extended paramater as defined in
+    /// An unrecognized extended parameter as defined in
     /// [RFC5987](https://tools.ietf.org/html/rfc5987) as *ext-parameter*, in
     /// [RFC6266](https://tools.ietf.org/html/rfc6266) as *ext-token "=" ext-value*. The single
-    /// trailling asterisk is not included. Recipients should ignore unrecognizable parameters.
+    /// trailing asterisk is not included. Recipients should ignore unrecognizable parameters.
     UnknownExt(String, ExtendedValue),
 }
 
 impl DispositionParam {
-    /// Returns `true` if the paramater is [`Name`](DispositionParam::Name).
+    /// Returns `true` if the parameter is [`Name`](DispositionParam::Name).
     #[inline]
     pub fn is_name(&self) -> bool {
         self.as_name().is_some()
     }
 
-    /// Returns `true` if the paramater is [`Filename`](DispositionParam::Filename).
+    /// Returns `true` if the parameter is [`Filename`](DispositionParam::Filename).
     #[inline]
     pub fn is_filename(&self) -> bool {
         self.as_filename().is_some()
     }
 
-    /// Returns `true` if the paramater is [`FilenameExt`](DispositionParam::FilenameExt).
+    /// Returns `true` if the parameter is [`FilenameExt`](DispositionParam::FilenameExt).
     #[inline]
     pub fn is_filename_ext(&self) -> bool {
         self.as_filename_ext().is_some()
     }
 
-    /// Returns `true` if the paramater is [`Unknown`](DispositionParam::Unknown) and the `name`
+    /// Returns `true` if the parameter is [`Unknown`](DispositionParam::Unknown) and the `name`
     #[inline]
     /// matches.
     pub fn is_unknown<T: AsRef<str>>(&self, name: T) -> bool {
         self.as_unknown(name).is_some()
     }
 
-    /// Returns `true` if the paramater is [`UnknownExt`](DispositionParam::UnknownExt) and the
+    /// Returns `true` if the parameter is [`UnknownExt`](DispositionParam::UnknownExt) and the
     /// `name` matches.
     #[inline]
     pub fn is_unknown_ext<T: AsRef<str>>(&self, name: T) -> bool {
@@ -373,7 +373,7 @@ impl ContentDisposition {
                 let param = if param_name.eq_ignore_ascii_case("name") {
                     DispositionParam::Name(value)
                 } else if param_name.eq_ignore_ascii_case("filename") {
-                    // See also comments in test_from_raw_uncessary_percent_decode.
+                    // See also comments in test_from_raw_unnecessary_percent_decode.
                     DispositionParam::Filename(value)
                 } else {
                     DispositionParam::Unknown(param_name.to_owned(), value)
@@ -529,7 +529,7 @@ impl fmt::Display for DispositionParam {
         //               ; to use within parameter values
         //
         //
-        // See also comments in test_from_raw_uncessary_percent_decode.
+        // See also comments in test_from_raw_unnecessary_percent_decode.
         lazy_static! {
             static ref RE: Regex = Regex::new("[\x00-\x08\x10-\x1F\x7F\"\\\\]").unwrap();
         }
@@ -676,7 +676,7 @@ mod tests {
     fn test_from_raw_unordered() {
         let a = HeaderValue::from_static(
             "form-data; dummy=3; filename=\"sample.png\" ; name=upload;",
-            // Actually, a trailling semolocon is not compliant. But it is fine to accept.
+            // Actually, a trailing semicolon is not compliant. But it is fine to accept.
         );
         let a: ContentDisposition = ContentDisposition::from_raw(&a).unwrap();
         let b = ContentDisposition {
@@ -833,7 +833,7 @@ mod tests {
     }
 
     #[test]
-    fn test_from_raw_uncessary_percent_decode() {
+    fn test_from_raw_unnecessary_percent_decode() {
         // In fact, RFC7578 (multipart/form-data) Section 2 and 4.2 suggests that filename with
         // non-ASCII characters MAY be percent-encoded.
         // On the contrary, RFC6266 or other RFCs related to Content-Disposition response header

--- a/actix-http/src/header/common/range.rs
+++ b/actix-http/src/header/common/range.rs
@@ -7,7 +7,7 @@ use header::{Header, Raw};
 /// `Range` header, defined in [RFC7233](https://tools.ietf.org/html/rfc7233#section-3.1)
 ///
 /// The "Range" header field on a GET request modifies the method
-/// semantics to request transfer of only one or more subranges of the
+/// semantics to request transfer of only one or more sub-ranges of the
 /// selected representation data, rather than the entire selected
 /// representation data.
 ///

--- a/actix-http/src/header/map.rs
+++ b/actix-http/src/header/map.rs
@@ -7,7 +7,7 @@ use http::header::{HeaderName, HeaderValue};
 
 /// A set of HTTP headers
 ///
-/// `HeaderMap` is an multimap of [`HeaderName`] to values.
+/// `HeaderMap` is an multi-map of [`HeaderName`] to values.
 ///
 /// [`HeaderName`]: struct.HeaderName.html
 #[derive(Debug, Clone)]

--- a/actix-http/src/message.rs
+++ b/actix-http/src/message.rs
@@ -99,13 +99,13 @@ impl RequestHead {
     }
 
     /// Is to uppercase headers with Camel-Case.
-    /// Befault is `false`
+    /// Default is `false`
     #[inline]
     pub fn camel_case_headers(&self) -> bool {
         self.flags.contains(Flags::CAMEL_CASE)
     }
 
-    /// Set `true` to send headers which are uppercased with Camel-Case.
+    /// Set `true` to send headers which are formatted as Camel-Case.
     #[inline]
     pub fn set_camel_case_headers(&mut self, val: bool) {
         if val {

--- a/actix-http/src/ws/mod.rs
+++ b/actix-http/src/ws/mod.rs
@@ -110,7 +110,7 @@ impl ResponseError for HandshakeError {
     }
 }
 
-/// Verify `WebSocket` handshake request and create handshake reponse.
+/// Verify `WebSocket` handshake request and create handshake response.
 // /// `protocols` is a sequence of known protocols. On successful handshake,
 // /// the returned response headers contain the first protocol in this list
 // /// which the server also knows.
@@ -170,7 +170,7 @@ pub fn verify_handshake(req: &RequestHead) -> Result<(), HandshakeError> {
     Ok(())
 }
 
-/// Create websocket's handshake response
+/// Create websocket handshake response
 ///
 /// This function returns handshake `Response`, ready to send to peer.
 pub fn handshake_response(req: &RequestHead) -> ResponseBuilder {

--- a/actix-http/src/ws/proto.rs
+++ b/actix-http/src/ws/proto.rs
@@ -203,7 +203,7 @@ impl<T: Into<String>> From<(CloseCode, T)> for CloseReason {
 
 static WS_GUID: &str = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
 
-// TODO: hash is always same size, we dont need String
+// TODO: hash is always same size, we don't need String
 pub fn hash_key(key: &[u8]) -> String {
     use sha1::Digest;
     let mut hasher = sha1::Sha1::new();

--- a/src/app.rs
+++ b/src/app.rs
@@ -320,7 +320,7 @@ where
 
     /// Registers middleware, in the form of a middleware component (type),
     /// that runs during inbound and/or outbound processing in the request
-    /// lifecycle (request -> response), modifying request/response as
+    /// life-cycle (request -> response), modifying request/response as
     /// necessary, across all requests managed by the *Application*.
     ///
     /// Use middleware when you need to read or modify *every* request or
@@ -385,7 +385,7 @@ where
     }
 
     /// Registers middleware, in the form of a closure, that runs during inbound
-    /// and/or outbound processing in the request lifecycle (request -> response),
+    /// and/or outbound processing in the request life-cycle (request -> response),
     /// modifying request/response as necessary, across all requests managed by
     /// the *Application*.
     ///

--- a/src/config.rs
+++ b/src/config.rs
@@ -50,7 +50,7 @@ impl AppService {
         }
     }
 
-    /// Check if root is beeing configured
+    /// Check if root is being configured
     pub fn is_root(&self) -> bool {
         self.root
     }

--- a/src/guard.rs
+++ b/src/guard.rs
@@ -6,7 +6,7 @@
 //! It is possible to add guards to *scopes*, *resources*
 //! and *routes*. Actix provide several guards by default, like various
 //! http methods, header, etc. To become a guard, type must implement `Guard`
-//! trait. Simple functions coulds guards as well.
+//! trait. Simple functions could be guards as well.
 //!
 //! Guards can not modify the request object. But it is possible
 //! to store extra attributes on a request by using the `Extensions` container.
@@ -100,7 +100,7 @@ pub fn Any<F: Guard + 'static>(guard: F) -> AnyGuard {
     AnyGuard(vec![Box::new(guard)])
 }
 
-/// Matches if any of supplied guards matche.
+/// Matches any of supplied guards.
 pub struct AnyGuard(Vec<Box<dyn Guard>>);
 
 impl AnyGuard {

--- a/src/middleware/condition.rs
+++ b/src/middleware/condition.rs
@@ -5,7 +5,7 @@ use actix_service::{Service, Transform};
 use futures::future::{ok, Either, FutureExt, LocalBoxFuture};
 
 /// `Middleware` for conditionally enables another middleware.
-/// The controled middleware must not change the `Service` interfaces.
+/// The controlled middleware must not change the `Service` interfaces.
 /// This means you cannot control such middlewares like `Logger` or `Compress`.
 ///
 /// ## Usage

--- a/src/request.rs
+++ b/src/request.rs
@@ -57,7 +57,7 @@ impl HttpRequest {
         &self.0.head
     }
 
-    /// This method returns muttable reference to the request head.
+    /// This method returns mutable reference to the request head.
     /// panics if multiple references of http request exists.
     #[inline]
     pub(crate) fn head_mut(&mut self) -> &mut RequestHead {

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -46,7 +46,7 @@ type HttpNewService = BoxServiceFactory<(), ServiceRequest, ServiceResponse, Err
 /// ```
 ///
 /// If no matching route could be found, *405* response code get returned.
-/// Default behavior could be overriden with `default_resource()` method.
+/// Default behavior could be overridden with `default_resource()` method.
 pub struct Resource<T = ResourceEndpoint> {
     endpoint: T,
     rdef: Vec<String>,

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -303,7 +303,7 @@ where
 
     /// Registers middleware, in the form of a middleware component (type),
     /// that runs during inbound processing in the request
-    /// lifecycle (request -> response), modifying request as
+    /// life-cycle (request -> response), modifying request as
     /// necessary, across all requests managed by the *Scope*.  Scope-level
     /// middleware is more limited in what it can modify, relative to Route or
     /// Application level middleware, in that Scope-level middleware can not modify
@@ -344,7 +344,7 @@ where
     }
 
     /// Registers middleware, in the form of a closure, that runs during inbound
-    /// processing in the request lifecycle (request -> response), modifying
+    /// processing in the request life-cycle (request -> response), modifying
     /// request as necessary, across all requests managed by the *Scope*.
     /// Scope-level middleware is more limited in what it can modify, relative
     /// to Route or Application level middleware, in that Scope-level middleware

--- a/src/service.rs
+++ b/src/service.rs
@@ -69,7 +69,7 @@ impl ServiceRequest {
 
     /// Construct request from parts.
     ///
-    /// `ServiceRequest` can be re-constructed only if `req` hasnt been cloned.
+    /// `ServiceRequest` can be re-constructed only if `req` hasn't been cloned.
     pub fn from_parts(
         mut req: HttpRequest,
         pl: Payload,


### PR DESCRIPTION
Run over docs with a code spell checker.

Left in the relevant `.vscode` file with allow list but can remove if anyone has strong opinions.

Future fixes:
`ConnectError::Unresolverd` => `ConnectError::Unresolved` (breaking)