### PR TITLE
clarify resource/scope app data overriding

### DIFF
--- a/actix-http/src/extensions.rs
+++ b/actix-http/src/extensions.rs
@@ -67,108 +67,113 @@ impl fmt::Debug for Extensions {
     }
 }
 
-#[test]
-fn test_remove() {
-    let mut map = Extensions::new();
+#[cfg(test)]
+mod tests {
+    use super::*;
+    
+    #[test]
+    fn test_remove() {
+        let mut map = Extensions::new();
 
-    map.insert::<i8>(123);
-    assert!(map.get::<i8>().is_some());
+        map.insert::<i8>(123);
+        assert!(map.get::<i8>().is_some());
 
-    map.remove::<i8>();
-    assert!(map.get::<i8>().is_none());
-}
-
-#[test]
-fn test_clear() {
-    let mut map = Extensions::new();
-
-    map.insert::<i8>(8);
-    map.insert::<i16>(16);
-    map.insert::<i32>(32);
-
-    assert!(map.contains::<i8>());
-    assert!(map.contains::<i16>());
-    assert!(map.contains::<i32>());
-
-    map.clear();
-
-    assert!(!map.contains::<i8>());
-    assert!(!map.contains::<i16>());
-    assert!(!map.contains::<i32>());
-
-    map.insert::<i8>(10);
-    assert_eq!(*map.get::<i8>().unwrap(), 10);
-}
-
-#[test]
-fn test_integers() {
-    let mut map = Extensions::new();
-
-    map.insert::<i8>(8);
-    map.insert::<i16>(16);
-    map.insert::<i32>(32);
-    map.insert::<i64>(64);
-    map.insert::<i128>(128);
-    map.insert::<u8>(8);
-    map.insert::<u16>(16);
-    map.insert::<u32>(32);
-    map.insert::<u64>(64);
-    map.insert::<u128>(128);
-    assert!(map.get::<i8>().is_some());
-    assert!(map.get::<i16>().is_some());
-    assert!(map.get::<i32>().is_some());
-    assert!(map.get::<i64>().is_some());
-    assert!(map.get::<i128>().is_some());
-    assert!(map.get::<u8>().is_some());
-    assert!(map.get::<u16>().is_some());
-    assert!(map.get::<u32>().is_some());
-    assert!(map.get::<u64>().is_some());
-    assert!(map.get::<u128>().is_some());
-}
-
-#[test]
-fn test_composition() {
-    struct Magi<T>(pub T);
-
-    struct Madoka {
-        pub god: bool,
+        map.remove::<i8>();
+        assert!(map.get::<i8>().is_none());
     }
 
-    struct Homura {
-        pub attempts: usize,
+    #[test]
+    fn test_clear() {
+        let mut map = Extensions::new();
+
+        map.insert::<i8>(8);
+        map.insert::<i16>(16);
+        map.insert::<i32>(32);
+
+        assert!(map.contains::<i8>());
+        assert!(map.contains::<i16>());
+        assert!(map.contains::<i32>());
+
+        map.clear();
+
+        assert!(!map.contains::<i8>());
+        assert!(!map.contains::<i16>());
+        assert!(!map.contains::<i32>());
+
+        map.insert::<i8>(10);
+        assert_eq!(*map.get::<i8>().unwrap(), 10);
     }
 
-    struct Mami {
-        pub guns: usize,
+    #[test]
+    fn test_integers() {
+        let mut map = Extensions::new();
+
+        map.insert::<i8>(8);
+        map.insert::<i16>(16);
+        map.insert::<i32>(32);
+        map.insert::<i64>(64);
+        map.insert::<i128>(128);
+        map.insert::<u8>(8);
+        map.insert::<u16>(16);
+        map.insert::<u32>(32);
+        map.insert::<u64>(64);
+        map.insert::<u128>(128);
+        assert!(map.get::<i8>().is_some());
+        assert!(map.get::<i16>().is_some());
+        assert!(map.get::<i32>().is_some());
+        assert!(map.get::<i64>().is_some());
+        assert!(map.get::<i128>().is_some());
+        assert!(map.get::<u8>().is_some());
+        assert!(map.get::<u16>().is_some());
+        assert!(map.get::<u32>().is_some());
+        assert!(map.get::<u64>().is_some());
+        assert!(map.get::<u128>().is_some());
     }
 
-    let mut map = Extensions::new();
+    #[test]
+    fn test_composition() {
+        struct Magi<T>(pub T);
 
-    map.insert(Magi(Madoka { god: false }));
-    map.insert(Magi(Homura { attempts: 0 }));
-    map.insert(Magi(Mami { guns: 999 }));
+        struct Madoka {
+            pub god: bool,
+        }
 
-    assert!(!map.get::<Magi<Madoka>>().unwrap().0.god);
-    assert_eq!(0, map.get::<Magi<Homura>>().unwrap().0.attempts);
-    assert_eq!(999, map.get::<Magi<Mami>>().unwrap().0.guns);
-}
+        struct Homura {
+            pub attempts: usize,
+        }
 
-#[test]
-fn test_extensions() {
-    #[derive(Debug, PartialEq)]
-    struct MyType(i32);
+        struct Mami {
+            pub guns: usize,
+        }
 
-    let mut extensions = Extensions::new();
+        let mut map = Extensions::new();
 
-    extensions.insert(5i32);
-    extensions.insert(MyType(10));
+        map.insert(Magi(Madoka { god: false }));
+        map.insert(Magi(Homura { attempts: 0 }));
+        map.insert(Magi(Mami { guns: 999 }));
 
-    assert_eq!(extensions.get(), Some(&5i32));
-    assert_eq!(extensions.get_mut(), Some(&mut 5i32));
+        assert!(!map.get::<Magi<Madoka>>().unwrap().0.god);
+        assert_eq!(0, map.get::<Magi<Homura>>().unwrap().0.attempts);
+        assert_eq!(999, map.get::<Magi<Mami>>().unwrap().0.guns);
+    }
 
-    assert_eq!(extensions.remove::<i32>(), Some(5i32));
-    assert!(extensions.get::<i32>().is_none());
+    #[test]
+    fn test_extensions() {
+        #[derive(Debug, PartialEq)]
+        struct MyType(i32);
 
-    assert_eq!(extensions.get::<bool>(), None);
-    assert_eq!(extensions.get(), Some(&MyType(10)));
+        let mut extensions = Extensions::new();
+
+        extensions.insert(5i32);
+        extensions.insert(MyType(10));
+
+        assert_eq!(extensions.get(), Some(&5i32));
+        assert_eq!(extensions.get_mut(), Some(&mut 5i32));
+
+        assert_eq!(extensions.remove::<i32>(), Some(5i32));
+        assert!(extensions.get::<i32>().is_none());
+
+        assert_eq!(extensions.get::<bool>(), None);
+        assert_eq!(extensions.get(), Some(&MyType(10)));
+    }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -10,11 +10,11 @@ use actix_service::boxed::{self, BoxServiceFactory};
 use actix_service::{
     apply, apply_fn_factory, IntoServiceFactory, ServiceFactory, Transform,
 };
-use futures::future::{FutureExt, LocalBoxFuture};
+use futures::future::FutureExt;
 
 use crate::app_service::{AppEntry, AppInit, AppRoutingFactory};
 use crate::config::ServiceConfig;
-use crate::data::{Data, DataFactory};
+use crate::data::{Data, DataFactory, FnDataFactory};
 use crate::dev::ResourceDef;
 use crate::error::Error;
 use crate::resource::Resource;
@@ -25,8 +25,6 @@ use crate::service::{
 };
 
 type HttpNewService = BoxServiceFactory<(), ServiceRequest, ServiceResponse, Error, ()>;
-type FnDataFactory =
-    Box<dyn Fn() -> LocalBoxFuture<'static, Result<Box<dyn DataFactory>, ()>>>;
 
 /// Application builder - structure that follows the builder pattern
 /// for building application instances.

--- a/src/app_service.rs
+++ b/src/app_service.rs
@@ -12,7 +12,7 @@ use actix_service::{fn_service, Service, ServiceFactory};
 use futures::future::{ok, FutureExt, LocalBoxFuture};
 
 use crate::config::{AppConfig, AppService};
-use crate::data::DataFactory;
+use crate::data::{FnDataFactory, DataFactory};
 use crate::error::Error;
 use crate::guard::Guard;
 use crate::request::{HttpRequest, HttpRequestPool};
@@ -23,8 +23,6 @@ type Guards = Vec<Box<dyn Guard>>;
 type HttpService = BoxService<ServiceRequest, ServiceResponse, Error>;
 type HttpNewService = BoxServiceFactory<(), ServiceRequest, ServiceResponse, Error, ()>;
 type BoxResponse = LocalBoxFuture<'static, Result<ServiceResponse, Error>>;
-type FnDataFactory =
-    Box<dyn Fn() -> LocalBoxFuture<'static, Result<Box<dyn DataFactory>, ()>>>;
 
 /// Service factory to convert `Request` to a `ServiceRequest<S>`.
 /// It also executes data factories.

--- a/src/data.rs
+++ b/src/data.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use actix_http::error::{Error, ErrorInternalServerError};
 use actix_http::Extensions;
-use futures::future::{err, ok, Ready};
+use futures::future::{err, ok, LocalBoxFuture, Ready};
 
 use crate::dev::Payload;
 use crate::extract::FromRequest;
@@ -13,6 +13,9 @@ use crate::request::HttpRequest;
 pub(crate) trait DataFactory {
     fn create(&self, extensions: &mut Extensions) -> bool;
 }
+
+pub(crate) type FnDataFactory =
+    Box<dyn Fn() -> LocalBoxFuture<'static, Result<Box<dyn DataFactory>, ()>>>;
 
 /// Application data.
 ///

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -151,9 +151,11 @@ where
         self.app_data(Data::new(data))
     }
 
-    /// Set or override application data.
+    /// Add scope data.
     ///
-    /// This method overrides data stored with [`App::app_data()`](#method.app_data)
+    /// If used, this method will create a new data context used for extracting
+    /// from requests. Data added here is *not* merged with data added on App
+    /// or containing scopes.
     pub fn app_data<U: 'static>(mut self, data: U) -> Self {
         if self.data.is_none() {
             self.data = Some(Extensions::new());


### PR DESCRIPTION
The current docs refer to "overriding" app data when using .app_data on Resource or Scope but it is not clear that this means overriding the entire parent app data container.

I would like to address this limitation but it seems tricky and will take some time to work out; I thought a docs update was called for, regardless.

Also centralizes the DataFactoryFn type alias and moves the tests for Extensions inside a conditional `mod test`.