### PR TITLE
Expose on_connect

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,9 @@ required-features = ["compress"]
 name = "test_server"
 required-features = ["compress"]
 
+[[example]]
+name = "on_connect"
+
 [dependencies]
 actix-codec = "0.2.0"
 actix-service = "1.0.2"

--- a/actix-http/src/builder.rs
+++ b/actix-http/src/builder.rs
@@ -184,6 +184,20 @@ where
         self
     }
 
+    /// Similar to `on_connect`, but takes optional callback.
+    /// If `f` is None, does nothing.
+    pub fn on_connect_optional<F, I>(self, f: Option<F>) -> Self
+    where 
+        F: Fn(&T) -> I + 'static,
+        I: Clone + 'static,
+    {
+        if let Some(f) = f {
+            self.on_connect(f)
+        } else {
+            self
+        }
+    }
+
     /// Finish service configuration and create *http service* for HTTP/1 protocol.
     pub fn h1<F, B>(self, service: F) -> H1Service<T, S, B, X, U>
     where

--- a/examples/on_connect.rs
+++ b/examples/on_connect.rs
@@ -1,0 +1,31 @@
+//! This example shows how to use `actix_web::HttpServer::on_connect`
+
+#[derive(Clone)]
+struct ConnectionInfo(String);
+
+async fn route_whoami(req: actix_web::HttpRequest) -> String {
+    let extensions = req.extensions();
+    let conn_info = extensions.get::<ConnectionInfo>().unwrap();
+    format!("Here is some info about you: {}", conn_info.0)
+}
+
+fn on_connect(connection: &dyn std::any::Any) -> ConnectionInfo {
+    let sock = connection.downcast_ref::<actix_rt::net::TcpStream>().unwrap();
+    let msg = format!("local_addr={:?}\npeer_addr={:?}", sock.local_addr(),sock.peer_addr());
+    ConnectionInfo(msg)
+}
+
+#[actix_rt::main]
+async fn main() -> std::io::Result<()> {
+    std::env::set_var("RUST_LOG", "actix_server=info,actix_web=info");
+    env_logger::init();
+
+    actix_web::HttpServer::new(|| {
+        actix_web::App::new().route("/", actix_web::web::get().to(route_whoami))
+    })
+    .on_connect(std::sync::Arc::new(on_connect))
+    .bind("127.0.0.1:8080")?
+    .workers(1)
+    .run()
+    .await
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -104,6 +104,7 @@ where
     /// - `actix_tls::openssl::SslStream<tokio::net::TcpStream>` when using openssl.
     /// - `actix_tls::rustls::TlsStream<tokio::net::TcpStream>` when using rustls.
     /// - `tokio::net::TcpStream` when no encryption is used.
+    /// See `on_connect` example for additional details.
     pub fn on_connect<C>(
         self,
         f: Arc<dyn Fn(&dyn std::any::Any) -> C + Send + Sync>,

--- a/src/server.rs
+++ b/src/server.rs
@@ -51,7 +51,7 @@ struct Config {
 ///         .await
 /// }
 /// ```
-pub struct HttpServer<F, I, S, B>
+pub struct HttpServer<F, I, S, B, C = ()>
 where
     F: Fn() -> I + Send + Clone + 'static,
     I: IntoServiceFactory<S>,
@@ -66,10 +66,10 @@ where
     backlog: i32,
     sockets: Vec<Socket>,
     builder: ServerBuilder,
-    _t: PhantomData<(S, B)>,
+    on_connect_fn: Option<Arc<dyn Fn(&dyn std::any::Any) -> C + Send + Sync>>,
+    _t: PhantomData<(S, B, C)>,
 }
-
-impl<F, I, S, B> HttpServer<F, I, S, B>
+impl<F, I, S, B> HttpServer<F, I, S, B, ()>
 where
     F: Fn() -> I + Send + Clone + 'static,
     I: IntoServiceFactory<S>,
@@ -93,10 +93,48 @@ where
             backlog: 1024,
             sockets: Vec::new(),
             builder: ServerBuilder::default(),
+            on_connect_fn: None,
             _t: PhantomData,
         }
     }
 
+    /// Sets function that will be called once for each connection.
+    /// It will receive &Any, which contains underlying connection type.
+    /// For example:
+    /// - `actix_tls::openssl::SslStream<tokio::net::TcpStream>` when using openssl.
+    /// - `actix_tls::rustls::TlsStream<tokio::net::TcpStream>` when using rustls.
+    /// - `tokio::net::TcpStream` when no encryption is used.
+    pub fn on_connect<C>(
+        self,
+        f: Arc<dyn Fn(&dyn std::any::Any) -> C + Send + Sync>,
+    ) -> HttpServer<F, I, S, B, C>
+    where
+        C: Clone + 'static,
+    {
+        HttpServer {
+            factory: self.factory,
+            config: self.config,
+            backlog: self.backlog,
+            sockets: self.sockets,
+            builder: self.builder,
+            on_connect_fn: Some(f),
+            _t: PhantomData,
+        }
+    }
+}
+
+impl<F, I, S, B, C> HttpServer<F, I, S, B, C>
+where
+    F: Fn() -> I + Send + Clone + 'static,
+    I: IntoServiceFactory<S>,
+    S: ServiceFactory<Config = AppConfig, Request = Request>,
+    S::Error: Into<Error> + 'static,
+    S::InitError: fmt::Debug,
+    S::Response: Into<Response<B>> + 'static,
+    <S::Service as Service>::Future: 'static,
+    B: MessageBody + 'static,
+    C: Clone + 'static,
+{
     /// Set number of workers to start.
     ///
     /// By default http server uses number of available logical cpu as threads
@@ -242,6 +280,7 @@ where
             addr,
             scheme: "http",
         });
+        let on_connect_fn = self.on_connect_fn.clone();
 
         self.builder = self.builder.listen(
             format!("actix-web-service-{}", addr),
@@ -258,6 +297,9 @@ where
                     .keep_alive(c.keep_alive)
                     .client_timeout(c.client_timeout)
                     .local_addr(addr)
+                    .on_connect_optional(on_connect_fn.clone().map(|handler| {
+                        move |arg: &_| (&*handler)(arg as &dyn std::any::Any)
+                    }))
                     .finish(map_config(factory(), move |_| cfg.clone()))
                     .tcp()
             },
@@ -291,6 +333,8 @@ where
             scheme: "https",
         });
 
+        let on_connect_fn = self.on_connect_fn.clone();
+
         self.builder = self.builder.listen(
             format!("actix-web-service-{}", addr),
             lst,
@@ -305,6 +349,9 @@ where
                     .keep_alive(c.keep_alive)
                     .client_timeout(c.client_timeout)
                     .client_disconnect(c.client_shutdown)
+                    .on_connect_optional(on_connect_fn.clone().map(|handler| {
+                        move |arg: &_| (&*handler)(arg as &dyn std::any::Any)
+                    }))
                     .finish(map_config(factory(), move |_| cfg.clone()))
                     .openssl(acceptor.clone())
             },
@@ -338,6 +385,8 @@ where
             scheme: "https",
         });
 
+        let on_connect_fn = self.on_connect_fn.clone();
+
         self.builder = self.builder.listen(
             format!("actix-web-service-{}", addr),
             lst,
@@ -352,6 +401,9 @@ where
                     .keep_alive(c.keep_alive)
                     .client_timeout(c.client_timeout)
                     .client_disconnect(c.client_shutdown)
+                    .on_connect_optional(on_connect_fn.clone().map(|handler| {
+                        move |arg: &_| (&*handler)(arg as &dyn std::any::Any)
+                    }))
                     .finish(map_config(factory(), move |_| cfg.clone()))
                     .rustls(config.clone())
             },
@@ -461,7 +513,7 @@ where
         });
 
         let addr = format!("actix-web-service-{:?}", lst.local_addr()?);
-
+        let on_connect_fn = self.on_connect_fn.clone();
         self.builder = self.builder.listen_uds(addr, lst, move || {
             let c = cfg.lock().unwrap();
             let config = AppConfig::new(
@@ -473,6 +525,9 @@ where
                 HttpService::build()
                     .keep_alive(c.keep_alive)
                     .client_timeout(c.client_timeout)
+                    .on_connect_optional(on_connect_fn.clone().map(|handler| {
+                        move |arg: &_| (&*handler)(arg as &dyn std::any::Any)
+                    }))
                     .finish(map_config(factory(), move |_| config.clone())),
             )
         })?;
@@ -521,7 +576,7 @@ where
     }
 }
 
-impl<F, I, S, B> HttpServer<F, I, S, B>
+impl<F, I, S, B, C> HttpServer<F, I, S, B, C>
 where
     F: Fn() -> I + Send + Clone + 'static,
     I: IntoServiceFactory<S>,


### PR DESCRIPTION
Since I don't know actix-web internals well enough, it is very possible that I selected wrong implementaion plan. Also, I have not written neither tests nor example yet.
# Motivation
Custom `on_connect` handler provides user with useful capabilities. For example, it can be used to obtain CN or SAN from client TLS certificate and save it in request's data, which is major step of TLS mutual authentication.
Currently, to write on_connect handler user has to manually build server, using `actix_server`, `actix_service`, `actix_http` and probably other completely undocumented actix-web internals. Also, user has to copy-paste some actix-web code, e.g. [this function](https://github.com/actix/actix-web/blob/c27d3fad8ece1e1440153f0abb47b96927c66f97/src/server.rs#L576).
This PR should not have any performance impact on those who do not use `on_connect`.