### PR TITLE
Fix audit issue logging by default peer address

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,9 +7,11 @@
 * `{Resource,Scope}::default_service(f)` handlers now support app data extraction. [#1452]
 * Implement `std::error::Error` for our custom errors [#1422]
 * NormalizePath middleware now appends trailing / so that routes of form /example/ respond to /example requests.
+* Fix audit issue logging by default peer address [#1485]
 
 [#1422]: https://github.com/actix/actix-web/pull/1422
 [#1452]: https://github.com/actix/actix-web/pull/1452
+[#1485]: https://github.com/actix/actix-web/pull/1485
 
 ## [3.0.0-alpha.1] - 2020-03-11
 

--- a/src/info.rs
+++ b/src/info.rs
@@ -12,8 +12,8 @@ const X_FORWARDED_PROTO: &[u8] = b"x-forwarded-proto";
 pub struct ConnectionInfo {
     scheme: String,
     host: String,
-    remote: Option<String>,
-    peer: Option<String>,
+    realip_remote_addr: Option<String>,
+    remote_addr: Option<String>,
 }
 
 impl ConnectionInfo {
@@ -29,7 +29,7 @@ impl ConnectionInfo {
     fn new(req: &RequestHead, cfg: &AppConfig) -> ConnectionInfo {
         let mut host = None;
         let mut scheme = None;
-        let mut remote = None;
+        let mut realip_remote_addr = None;
 
         // load forwarded header
         for hdr in req.headers.get_all(&header::FORWARDED) {
@@ -41,8 +41,8 @@ impl ConnectionInfo {
                             if let Some(val) = items.next() {
                                 match &name.to_lowercase() as &str {
                                     "for" => {
-                                        if remote.is_none() {
-                                            remote = Some(val.trim());
+                                        if realip_remote_addr.is_none() {
+                                            realip_remote_addr = Some(val.trim());
                                         }
                                     }
                                     "proto" => {
@@ -105,26 +105,25 @@ impl ConnectionInfo {
             }
         }
 
-        // get peeraddr from socketaddr
-        let peer = req.peer_addr.map(|addr| format!("{}", addr));
+        // get remote_addraddr from socketaddr
+        let remote_addr = req.peer_addr.map(|addr| format!("{}", addr));
 
-        // remote addr
-        if remote.is_none() {
+        if realip_remote_addr.is_none() {
             if let Some(h) = req
                 .headers
                 .get(&HeaderName::from_lowercase(X_FORWARDED_FOR).unwrap())
             {
                 if let Ok(h) = h.to_str() {
-                    remote = h.split(',').next().map(|v| v.trim());
+                    realip_remote_addr = h.split(',').next().map(|v| v.trim());
                 }
             }
         }
 
         ConnectionInfo {
-            peer,
+            remote_addr,
             scheme: scheme.unwrap_or("http").to_owned(),
             host: host.unwrap_or("localhost").to_owned(),
-            remote: remote.map(|s| s.to_owned()),
+            realip_remote_addr: realip_remote_addr.map(|s| s.to_owned()),
         }
     }
 
@@ -153,23 +152,23 @@ impl ConnectionInfo {
         &self.host
     }
 
-    /// Peer address of the request.
+    /// remote_addr address of the request.
     ///
-    /// Get peer address from socket address
-    pub fn peer(&self) -> Option<&str> {
-        if let Some(ref peer) = self.peer {
-            Some(peer)
+    /// Get remote_addr address from socket address
+    pub fn remote_addr(&self) -> Option<&str> {
+        if let Some(ref remote_addr) = self.remote_addr {
+            Some(remote_addr)
         } else {
             None
         }
     }
-    /// Remote socket addr of client initiated HTTP request.
+    /// Real ip remote addr of client initiated HTTP request.
     ///
     /// The addr is resolved through the following headers, in this order:
     ///
     /// - Forwarded
     /// - X-Forwarded-For
-    /// - peer name of opened socket
+    /// - remote_addr name of opened socket
     ///
     /// # Security
     /// Do not use this function for security purposes, unless you can ensure the Forwarded and
@@ -177,11 +176,11 @@ impl ConnectionInfo {
     /// address explicitly, use
     /// [`HttpRequest::peer_addr()`](../web/struct.HttpRequest.html#method.peer_addr) instead.
     #[inline]
-    pub fn remote(&self) -> Option<&str> {
-        if let Some(ref r) = self.remote {
+    pub fn realip_remote_addr(&self) -> Option<&str> {
+        if let Some(ref r) = self.realip_remote_addr {
             Some(r)
-        } else if let Some(ref peer) = self.peer {
-            Some(peer)
+        } else if let Some(ref remote_addr) = self.remote_addr {
+            Some(remote_addr)
         } else {
             None
         }
@@ -210,7 +209,7 @@ mod tests {
         let info = req.connection_info();
         assert_eq!(info.scheme(), "https");
         assert_eq!(info.host(), "rust-lang.org");
-        assert_eq!(info.remote(), Some("192.0.2.60"));
+        assert_eq!(info.realip_remote_addr(), Some("192.0.2.60"));
 
         let req = TestRequest::default()
             .header(header::HOST, "rust-lang.org")
@@ -219,20 +218,20 @@ mod tests {
         let info = req.connection_info();
         assert_eq!(info.scheme(), "http");
         assert_eq!(info.host(), "rust-lang.org");
-        assert_eq!(info.remote(), None);
+        assert_eq!(info.realip_remote_addr(), None);
 
         let req = TestRequest::default()
             .header(X_FORWARDED_FOR, "192.0.2.60")
             .to_http_request();
         let info = req.connection_info();
-        assert_eq!(info.remote(), Some("192.0.2.60"));
+        assert_eq!(info.realip_remote_addr(), Some("192.0.2.60"));
 
         let req = TestRequest::default()
             .header(X_FORWARDED_HOST, "192.0.2.60")
             .to_http_request();
         let info = req.connection_info();
         assert_eq!(info.host(), "192.0.2.60");
-        assert_eq!(info.remote(), None);
+        assert_eq!(info.realip_remote_addr(), None);
 
         let req = TestRequest::default()
             .header(X_FORWARDED_PROTO, "https")

--- a/src/info.rs
+++ b/src/info.rs
@@ -30,7 +30,6 @@ impl ConnectionInfo {
         let mut host = None;
         let mut scheme = None;
         let mut remote = None;
-        let mut peer = None;
 
         // load forwarded header
         for hdr in req.headers.get_all(&header::FORWARDED) {
@@ -106,6 +105,9 @@ impl ConnectionInfo {
             }
         }
 
+        // get peeraddr from socketaddr
+        let peer = req.peer_addr.map(|addr| format!("{}", addr));
+
         // remote addr
         if remote.is_none() {
             if let Some(h) = req
@@ -115,10 +117,6 @@ impl ConnectionInfo {
                 if let Ok(h) = h.to_str() {
                     remote = h.split(',').next().map(|v| v.trim());
                 }
-            }
-            if remote.is_none() {
-                // get peeraddr from socketaddr
-                peer = req.peer_addr.map(|addr| format!("{}", addr));
             }
         }
 
@@ -155,6 +153,16 @@ impl ConnectionInfo {
         &self.host
     }
 
+    /// Peer address of the request.
+    ///
+    /// Get peer address from socket address
+    pub fn peer(&self) -> Option<&str> {
+        if let Some(ref peer) = self.peer {
+            Some(peer)
+        } else {
+            None
+        }
+    }
     /// Remote socket addr of client initiated HTTP request.
     ///
     /// The addr is resolved through the following headers, in this order:

--- a/src/middleware/logger.rs
+++ b/src/middleware/logger.rs
@@ -80,8 +80,8 @@ use crate::HttpResponse;
 ///
 /// `%{FOO}e`  os.environ['FOO']
 ///
-/// ### **\* security warning**
-///  It is calculated using
+/// # Security
+///  **\*** It is calculated using
 ///  [`ConnectionInfo::realip_remote_addr()`](../dev/struct.ConnectionInfo.html#method.realip_remote_addr)
 ///
 ///  If you use this value ensure that all requests come from trusted hosts, since it is trivial

--- a/src/middleware/logger.rs
+++ b/src/middleware/logger.rs
@@ -55,7 +55,7 @@ use crate::HttpResponse;
 ///
 /// `%%`  The percent sign
 ///
-/// `%a`  Remote IP-address (IP-address of proxy if using reverse proxy)
+/// `%a`  Client IP-address
 ///
 /// `%t`  Time when the request was started to process (in rfc3339 format)
 ///
@@ -72,11 +72,17 @@ use crate::HttpResponse;
 ///
 /// `%U`  Request URL
 ///
+/// `%{r}a`  Remote IP-address (IP-address of proxy if using reverse proxy) **\***
+///
 /// `%{FOO}i`  request.headers['FOO']
 ///
 /// `%{FOO}o`  response.headers['FOO']
 ///
 /// `%{FOO}e`  os.environ['FOO']
+///
+/// > **\* warning** It is critical to only use this value from intermediate
+/// > hosts(proxies, etc) which are trusted by this server, since it is trivial
+/// > for the remote client to simulate another client.
 ///
 pub struct Logger(Rc<Inner>);
 
@@ -301,7 +307,7 @@ impl Format {
     /// Returns `None` if the format string syntax is incorrect.
     pub fn new(s: &str) -> Format {
         log::trace!("Access log format: {}", s);
-        let fmt = Regex::new(r"%(\{([A-Za-z0-9\-_]+)\}([ioe])|[atPrUsbTD]?)").unwrap();
+        let fmt = Regex::new(r"%(\{([A-Za-z0-9\-_]+)\}([aioe])|[atPrUsbTD]?)").unwrap();
 
         let mut idx = 0;
         let mut results = Vec::new();
@@ -315,6 +321,11 @@ impl Format {
 
             if let Some(key) = cap.get(2) {
                 results.push(match cap.get(3).unwrap().as_str() {
+                    "a" => if key.as_str() == "r" {
+                        FormatText::RemoteAddr
+                    } else {
+                        unreachable!()
+                    },
                     "i" => FormatText::RequestHeader(
                         HeaderName::try_from(key.as_str()).unwrap(),
                     ),
@@ -328,7 +339,7 @@ impl Format {
                 let m = cap.get(1).unwrap();
                 results.push(match m.as_str() {
                     "%" => FormatText::Percent,
-                    "a" => FormatText::RemoteAddr,
+                    "a" => FormatText::ClientIP,
                     "t" => FormatText::RequestTime,
                     "r" => FormatText::RequestLine,
                     "s" => FormatText::ResponseStatus,
@@ -361,6 +372,7 @@ pub enum FormatText {
     ResponseSize,
     Time,
     TimeMillis,
+    ClientIP,
     RemoteAddr,
     UrlPath,
     RequestHeader(HeaderName),
@@ -457,6 +469,14 @@ impl FormatText {
                 };
                 *self = FormatText::Str(s.to_string());
             }
+            FormatText::ClientIP => {
+                let s = if let Some(ref peer) = req.connection_info().peer() {
+                    FormatText::Str(peer.to_string())
+                } else {
+                    FormatText::Str("-".to_string())
+                };
+                *self = s;
+            }
             FormatText::RemoteAddr => {
                 let s = if let Some(remote) = req.connection_info().remote() {
                     FormatText::Str(remote.to_string())
@@ -549,6 +569,7 @@ mod tests {
             header::USER_AGENT,
             header::HeaderValue::from_static("ACTIX-WEB"),
         )
+        .peer_addr("127.0.0.1:8081".parse().unwrap())
         .to_srv_request();
 
         let now = OffsetDateTime::now_utc();
@@ -570,6 +591,7 @@ mod tests {
         };
         let s = format!("{}", FormatDisplay(&render));
         assert!(s.contains("GET / HTTP/1.1"));
+        assert!(s.contains("127.0.0.1"));
         assert!(s.contains("200 1024"));
         assert!(s.contains("ACTIX-WEB"));
     }
@@ -597,5 +619,37 @@ mod tests {
         };
         let s = format!("{}", FormatDisplay(&render));
         assert!(s.contains(&format!("{}", now.format("%Y-%m-%dT%H:%M:%S"))));
+    }
+
+    #[actix_rt::test]
+    async fn test_remote_addr_format() {
+        let mut format = Format::new("%{r}a");
+
+        let req = TestRequest::with_header(
+            header::FORWARDED,
+            header::HeaderValue::from_static("for=192.0.2.60;proto=http;by=203.0.113.43"),
+        )
+        .to_srv_request();
+
+        let now = OffsetDateTime::now_utc();
+        for unit in &mut format.0 {
+            unit.render_request(now, &req);
+        }
+
+        let resp = HttpResponse::build(StatusCode::OK).force_close().finish();
+        for unit in &mut format.0 {
+            unit.render_response(&resp);
+        }
+
+        let entry_time = OffsetDateTime::now_utc();
+        let render = |fmt: &mut Formatter<'_>| {
+            for unit in &format.0 {
+                unit.render(fmt, 1024, entry_time)?;
+            }
+            Ok(())
+        };
+        let s = format!("{}", FormatDisplay(&render));
+        println!("{}", s);
+        assert!(s.contains("192.0.2.60"));
     }
 }


### PR DESCRIPTION
By default log format include remote address that is taken from headers.
This is very easy to replace making log untrusted.

Changing default log format value `%a` to peer address we are getting
this trusted data always. Also, remote address option is maintianed and
relegated to `%{r}a` value.

Related  kanidm/kanidm#191.