### PR TITLE
allow parent data containers to be accessed from child scopes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,16 +1,24 @@
 # Changes
 
+## [Unreleased]
+
+### Changed
+
+* Resources and Scopes can now access non-overridden data types set on App (or containing scopes) when setting their own data. [#1486]
+
 ## [3.0.0-alpha.2] - 2020-05-08
 
 ### Changed
 
 * `{Resource,Scope}::default_service(f)` handlers now support app data extraction. [#1452]
 * Implement `std::error::Error` for our custom errors [#1422]
-* NormalizePath middleware now appends trailing / so that routes of form /example/ respond to /example requests.
+* NormalizePath middleware now appends trailing / so that routes of form /example/ respond to /example requests. [#1433]
 * Remove the `failure` feature and support.
 
 [#1422]: https://github.com/actix/actix-web/pull/1422
+[#1433]: https://github.com/actix/actix-web/pull/1433
 [#1452]: https://github.com/actix/actix-web/pull/1452
+[#1486]: https://github.com/actix/actix-web/pull/1486
 
 ## [3.0.0-alpha.1] - 2020-03-11
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,6 +101,7 @@ time = { version = "0.2.7", default-features = false, features = ["std"] }
 url = "2.1"
 open-ssl = { version="0.10", package = "openssl", optional = true }
 rust-tls = { version = "0.17.0", package = "rustls", optional = true }
+tinyvec = { version = "0.3", features = ["alloc"] }
 
 [dev-dependencies]
 actix = "0.10.0-alpha.1"

--- a/src/app_service.rs
+++ b/src/app_service.rs
@@ -245,7 +245,7 @@ where
             inner.path.reset();
             inner.head = head;
             inner.payload = payload;
-            inner.app_data = self.data.clone();
+            inner.app_data.push(self.data.clone());
             req
         } else {
             HttpRequest::new(

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -198,9 +198,7 @@ where
 
     /// Add resource data.
     ///
-    /// If used, this method will create a new data context used for extracting
-    /// from requests. Data added here is *not* merged with data added on App 
-    /// or containing scopes.
+    /// Data of different types from parent contexts will still be accessible.
     pub fn app_data<U: 'static>(mut self, data: U) -> Self {
         if self.data.is_none() {
             self.data = Some(Extensions::new());
@@ -539,14 +537,14 @@ impl Service for ResourceService {
         for route in self.routes.iter_mut() {
             if route.check(&mut req) {
                 if let Some(ref data) = self.data {
-                    req.set_data_container(data.clone());
+                    req.add_data_container(data.clone());
                 }
                 return Either::Right(route.call(req));
             }
         }
         if let Some(ref mut default) = self.default {
             if let Some(ref data) = self.data {
-                req.set_data_container(data.clone());
+                req.add_data_container(data.clone());
             }
             Either::Right(default.call(req))
         } else {
@@ -590,14 +588,13 @@ mod tests {
 
     use actix_rt::time::delay_for;
     use actix_service::Service;
-    use bytes::Bytes;
     use futures::future::ok;
 
     use crate::http::{header, HeaderValue, Method, StatusCode};
     use crate::middleware::DefaultHeaders;
     use crate::service::ServiceRequest;
-    use crate::test::{call_service, init_service, read_body, TestRequest};
-    use crate::{guard, web, App, Error, HttpRequest, HttpResponse};
+    use crate::test::{call_service, init_service, TestRequest};
+    use crate::{guard, web, App, Error, HttpResponse};
 
     #[actix_rt::test]
     async fn test_middleware() {
@@ -621,79 +618,6 @@ mod tests {
             resp.headers().get(header::CONTENT_TYPE).unwrap(),
             HeaderValue::from_static("0001")
         );
-    }
-
-    #[actix_rt::test]
-    async fn test_overwritten_data() {
-        #[allow(dead_code)]
-        fn echo_usize(req: HttpRequest) -> HttpResponse {
-            let num = req.app_data::<usize>().unwrap();
-            HttpResponse::Ok().body(format!("{}", num))
-        }
-
-        #[allow(dead_code)]
-        fn echo_u32(req: HttpRequest) -> HttpResponse {
-            let num = req.app_data::<u32>().unwrap();
-            HttpResponse::Ok().body(format!("{}", num))
-        }
-
-        #[allow(dead_code)]
-        fn echo_both(req: HttpRequest) -> HttpResponse {
-            let num = req.app_data::<usize>().unwrap();
-            let num2 = req.app_data::<u32>().unwrap();
-            HttpResponse::Ok().body(format!("{}-{}", num, num2))
-        }
-
-        let mut srv = init_service(
-            App::new()
-                .app_data(88usize)
-                .service(web::resource("/").route(web::get().to(echo_usize)))
-                .service(
-                    web::resource("/one")
-                        .app_data(1usize)
-                        .route(web::get().to(echo_usize)),
-                )
-                .service(
-                    web::resource("/two")
-                        .app_data(2usize)
-                        .route(web::get().to(echo_usize)),
-                )
-                .service(
-                    web::resource("/three")
-                        .app_data(3u32)
-                        // this doesnt work because app_data "overrides" the
-                        // entire data field potentially passed down
-                        // .route(web::get().to(echo_both)),
-                        .route(web::get().to(echo_u32)),
-                )
-                .service(web::resource("/eight").route(web::get().to(echo_usize))),
-        )
-        .await;
-
-        let req = TestRequest::get().uri("/").to_request();
-        let resp = srv.call(req).await.unwrap();
-        let body = read_body(resp).await;
-        assert_eq!(body, Bytes::from_static(b"88"));
-
-        let req = TestRequest::get().uri("/one").to_request();
-        let resp = srv.call(req).await.unwrap();
-        let body = read_body(resp).await;
-        assert_eq!(body, Bytes::from_static(b"1"));
-
-        let req = TestRequest::get().uri("/two").to_request();
-        let resp = srv.call(req).await.unwrap();
-        let body = read_body(resp).await;
-        assert_eq!(body, Bytes::from_static(b"2"));
-
-        // let req = TestRequest::get().uri("/three").to_request();
-        // let resp = srv.call(req).await.unwrap();
-        // let body = read_body(resp).await;
-        // assert_eq!(body, Bytes::from_static(b"88-3"));
-
-        let req = TestRequest::get().uri("/eight").to_request();
-        let resp = srv.call(req).await.unwrap();
-        let body = read_body(resp).await;
-        assert_eq!(body, Bytes::from_static(b"88"));
     }
 
     #[actix_rt::test]

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -153,9 +153,7 @@ where
 
     /// Add scope data.
     ///
-    /// If used, this method will create a new data context used for extracting
-    /// from requests. Data added here is *not* merged with data added on App
-    /// or containing scopes.
+    /// Data of different types from parent contexts will still be accessible.
     pub fn app_data<U: 'static>(mut self, data: U) -> Self {
         if self.data.is_none() {
             self.data = Some(Extensions::new());
@@ -624,12 +622,12 @@ impl Service for ScopeService {
 
         if let Some((srv, _info)) = res {
             if let Some(ref data) = self.data {
-                req.set_data_container(data.clone());
+                req.add_data_container(data.clone());
             }
             Either::Left(srv.call(req))
         } else if let Some(ref mut default) = self.default {
             if let Some(ref data) = self.data {
-                req.set_data_container(data.clone());
+                req.add_data_container(data.clone());
             }
             Either::Left(default.call(req))
         } else {


### PR DESCRIPTION
`ServiceRequest::set_data_container` now adds to an array of `Rc<Extensions>`s and lookups reverse iterate to find the closest app data of that type.

Adds the `tinyvec` dependency to keep a small set of references to data containers on the stack, up to 4 data containers, which should cover most use cases optimally.