### PR TITLE
correct spelling of ConnectError::Unresolved

### DIFF
--- a/actix-http/src/client/error.rs
+++ b/actix-http/src/client/error.rs
@@ -48,7 +48,7 @@ pub enum ConnectError {
 
     /// Unresolved host name
     #[display(fmt = "Connector received `Connect` method with unresolved host")]
-    Unresolverd,
+    Unresolved,
 
     /// Connection io error
     #[display(fmt = "{}", _0)]
@@ -63,7 +63,7 @@ impl From<actix_connect::ConnectError> for ConnectError {
             actix_connect::ConnectError::Resolver(e) => ConnectError::Resolver(e),
             actix_connect::ConnectError::NoRecords => ConnectError::NoRecords,
             actix_connect::ConnectError::InvalidInput => panic!(),
-            actix_connect::ConnectError::Unresolverd => ConnectError::Unresolverd,
+            actix_connect::ConnectError::Unresolved => ConnectError::Unresolved,
             actix_connect::ConnectError::Io(e) => ConnectError::Io(e),
         }
     }

--- a/actix-http/src/client/pool.rs
+++ b/actix-http/src/client/pool.rs
@@ -105,7 +105,7 @@ where
             let key = if let Some(authority) = req.uri.authority() {
                 authority.clone().into()
             } else {
-                return Err(ConnectError::Unresolverd);
+                return Err(ConnectError::Unresolved);
             };
 
             // acquire connection
@@ -195,7 +195,7 @@ where
         if let Some(i) = self.inner.take() {
             let mut inner = i.as_ref().borrow_mut();
             inner.release_waiter(&self.key, self.token);
-            inner.check_availibility();
+            inner.check_availability();
         }
     }
 }
@@ -232,7 +232,7 @@ where
         if let Some(i) = self.inner.take() {
             let mut inner = i.as_ref().borrow_mut();
             inner.release();
-            inner.check_availibility();
+            inner.check_availability();
         }
     }
 }
@@ -359,7 +359,7 @@ where
                 created,
                 used: Instant::now(),
             });
-        self.check_availibility();
+        self.check_availability();
     }
 
     fn release_close(&mut self, io: ConnectionType<Io>) {
@@ -369,10 +369,10 @@ where
                 actix_rt::spawn(CloseConnection::new(io, timeout))
             }
         }
-        self.check_availibility();
+        self.check_availability();
     }
 
-    fn check_availibility(&self) {
+    fn check_availability(&self) {
         if !self.waiters_queue.is_empty() && self.acquired < self.config.limit {
             self.waker.wake();
         }
@@ -534,7 +534,7 @@ where
         if let Some(inner) = self.project().inner.take() {
             let mut inner = inner.as_ref().borrow_mut();
             inner.release();
-            inner.check_availibility();
+            inner.check_availability();
         }
     }
 }


### PR DESCRIPTION
blocked on actix/actix-net#135

also corrects spelling of internal method in actix_http `Inner::check_availability`.