### PR TITLE
actix-web: Bump up to 3.0.0-alpha.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,12 +1,13 @@
 # Changes
 
-## [Unreleased]
+## [3.0.0-alpha.2] - 2020-05-08
 
 ### Changed
 
 * `{Resource,Scope}::default_service(f)` handlers now support app data extraction. [#1452]
 * Implement `std::error::Error` for our custom errors [#1422]
 * NormalizePath middleware now appends trailing / so that routes of form /example/ respond to /example requests.
+* Remove the `failure` feature and support.
 
 [#1422]: https://github.com/actix/actix-web/pull/1422
 [#1452]: https://github.com/actix/actix-web/pull/1452

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-web"
-version = "3.0.0-alpha.1"
+version = "3.0.0-alpha.2"
 authors = ["Nikolay Kim <fafhrd91@gmail.com>"]
 description = "Actix web is a simple, pragmatic and extremely fast web framework for Rust."
 readme = "README.md"

--- a/actix-files/Cargo.toml
+++ b/actix-files/Cargo.toml
@@ -18,7 +18,7 @@ name = "actix_files"
 path = "src/lib.rs"
 
 [dependencies]
-actix-web = { version = "3.0.0-alpha.1", default-features = false }
+actix-web = { version = "3.0.0-alpha.2", default-features = false }
 actix-http = "2.0.0-alpha.3"
 actix-service = "1.0.1"
 bitflags = "1"
@@ -33,4 +33,4 @@ v_htmlescape = "0.4"
 
 [dev-dependencies]
 actix-rt = "1.0.0"
-actix-web = { version = "3.0.0-alpha.1", features=["openssl"] }
+actix-web = { version = "3.0.0-alpha.2", features = ["openssl"] }

--- a/actix-multipart/Cargo.toml
+++ b/actix-multipart/Cargo.toml
@@ -16,7 +16,7 @@ name = "actix_multipart"
 path = "src/lib.rs"
 
 [dependencies]
-actix-web = { version = "3.0.0-alpha.1", default-features = false }
+actix-web = { version = "3.0.0-alpha.2", default-features = false }
 actix-service = "1.0.1"
 actix-utils = "1.0.3"
 bytes = "0.5.3"

--- a/actix-web-actors/Cargo.toml
+++ b/actix-web-actors/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/lib.rs"
 
 [dependencies]
 actix = "0.10.0-alpha.2"
-actix-web = "3.0.0-alpha.1"
+actix-web = "3.0.0-alpha.2"
 actix-http = "2.0.0-alpha.3"
 actix-codec = "0.2.0"
 bytes = "0.5.2"

--- a/actix-web-codegen/Cargo.toml
+++ b/actix-web-codegen/Cargo.toml
@@ -18,5 +18,5 @@ proc-macro2 = "^1"
 
 [dev-dependencies]
 actix-rt = "1.0.0"
-actix-web = "3.0.0-alpha.1"
+actix-web = "3.0.0-alpha.2"
 futures = "0.3.1"

--- a/awc/Cargo.toml
+++ b/awc/Cargo.toml
@@ -50,17 +50,17 @@ rand = "0.7"
 serde = "1.0"
 serde_json = "1.0"
 serde_urlencoded = "0.6.1"
-open-ssl = { version="0.10", package="openssl", optional = true }
-rust-tls = { version = "0.17.0", package="rustls", optional = true, features = ["dangerous_configuration"]  }
+open-ssl = { version = "0.10", package = "openssl", optional = true }
+rust-tls = { version = "0.17.0", package = "rustls", optional = true, features = ["dangerous_configuration"] }
 
 [dev-dependencies]
-actix-connect = { version = "2.0.0-alpha.2", features=["openssl"] }
-actix-web = { version = "3.0.0-alpha.1", features=["openssl"] }
-actix-http = { version = "2.0.0-alpha.3", features=["openssl"] }
-actix-http-test = { version = "1.0.0", features=["openssl"] }
+actix-connect = { version = "2.0.0-alpha.2", features = ["openssl"] }
+actix-web = { version = "3.0.0-alpha.2", features = ["openssl"] }
+actix-http = { version = "2.0.0-alpha.3", features = ["openssl"] }
+actix-http-test = { version = "1.0.0", features = ["openssl"] }
 actix-utils = "1.0.3"
 actix-server = "1.0.0"
-actix-tls = { version = "2.0.0-alpha.1", features=["openssl", "rustls"] }
+actix-tls = { version = "2.0.0-alpha.1", features = ["openssl", "rustls"] }
 brotli2 = "0.3.2"
 flate2 = "1.0.13"
 futures = "0.3.1"

--- a/test-server/Cargo.toml
+++ b/test-server/Cargo.toml
@@ -52,8 +52,8 @@ sha1 = "0.6"
 slab = "0.4"
 serde_urlencoded = "0.6.1"
 time = { version = "0.2.7", default-features = false, features = ["std"] }
-open-ssl = { version="0.10", package = "openssl", optional = true }
+open-ssl = { version = "0.10", package = "openssl", optional = true }
 
 [dev-dependencies]
-actix-web = "3.0.0-alpha.1"
+actix-web = "3.0.0-alpha.2"
 actix-http = "2.0.0-alpha.3"


### PR DESCRIPTION
We need the next actix-web version that removes failure support to use new actix-http (this blocks to release actix-web-actors).