### PR TITLE
Replace deprecated `net2` crate with `socket2`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,8 @@
 
 * Bump minimum supported Rust version to 1.40
 
+* Replace deprecated `net2` crate with `socket2`
+
 [#1485]: https://github.com/actix/actix-web/pull/1485
 [#1509]: https://github.com/actix/actix-web/pull/1509
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,7 @@ futures-util = { version = "0.3.5", default-features = false }
 fxhash = "0.2.1"
 log = "0.4"
 mime = "0.3"
-net2 = "0.2.33"
+socket2 = "0.3"
 pin-project = "0.4.6"
 regex = "1.3"
 serde = { version = "1.0", features=["derive"] }

--- a/src/test.rs
+++ b/src/test.rs
@@ -21,10 +21,10 @@ use bytes::{Bytes, BytesMut};
 use futures_core::Stream;
 use futures_util::future::ok;
 use futures_util::StreamExt;
-use net2::TcpBuilder;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use serde_json;
+use socket2::{Domain, Protocol, Socket, Type};
 
 pub use actix_http::test::TestBuffer;
 
@@ -913,10 +913,10 @@ impl TestServerConfig {
 /// Get first available unused address
 pub fn unused_addr() -> net::SocketAddr {
     let addr: net::SocketAddr = "127.0.0.1:0".parse().unwrap();
-    let socket = TcpBuilder::new_v4().unwrap();
-    socket.bind(&addr).unwrap();
-    socket.reuse_address(true).unwrap();
-    let tcp = socket.to_tcp_listener().unwrap();
+    let socket = Socket::new(Domain::ipv4(), Type::stream(), Some(Protocol::tcp())).unwrap();
+    socket.bind(&addr.into()).unwrap();
+    socket.set_reuse_address(true).unwrap();
+    let tcp = socket.into_tcp_listener();
     tcp.local_addr().unwrap()
 }
 

--- a/test-server/CHANGES.md
+++ b/test-server/CHANGES.md
@@ -6,6 +6,7 @@
 * Update `actix-connect` dependency to 2.0.0-alpha.2
 * Make `test_server` `async` fn.
 * Bump minimum supported Rust version to 1.40
+* Replace deprecated `net2` crate with `socket2`
 
 ## [1.0.0] - 2019-12-13
 

--- a/test-server/Cargo.toml
+++ b/test-server/Cargo.toml
@@ -45,7 +45,7 @@ futures-core = { version = "0.3.5", default-features = false }
 http = "0.2.0"
 log = "0.4"
 env_logger = "0.6"
-net2 = "0.2"
+socket2 = "0.3"
 serde = "1.0"
 serde_json = "1.0"
 sha1 = "0.6"

--- a/test-server/src/lib.rs
+++ b/test-server/src/lib.rs
@@ -9,7 +9,7 @@ use awc::{error::PayloadError, ws, Client, ClientRequest, ClientResponse, Connec
 use bytes::Bytes;
 use futures_core::stream::Stream;
 use http::Method;
-use net2::TcpBuilder;
+use socket2::{Domain, Protocol, Socket, Type};
 
 pub use actix_testing::*;
 
@@ -104,10 +104,10 @@ pub async fn test_server<F: ServiceFactory<TcpStream>>(factory: F) -> TestServer
 /// Get first available unused address
 pub fn unused_addr() -> net::SocketAddr {
     let addr: net::SocketAddr = "127.0.0.1:0".parse().unwrap();
-    let socket = TcpBuilder::new_v4().unwrap();
-    socket.bind(&addr).unwrap();
-    socket.reuse_address(true).unwrap();
-    let tcp = socket.to_tcp_listener().unwrap();
+    let socket = Socket::new(Domain::ipv4(), Type::stream(), Some(Protocol::tcp())).unwrap();
+    socket.bind(&addr.into()).unwrap();
+    socket.set_reuse_address(true).unwrap();
+    let tcp = socket.into_tcp_listener();
     tcp.local_addr().unwrap()
 }
 

--- a/tests/test_httpserver.rs
+++ b/tests/test_httpserver.rs
@@ -1,25 +1,15 @@
-use net2::TcpBuilder;
 use std::sync::mpsc;
-use std::{net, thread, time::Duration};
+use std::{thread, time::Duration};
 
 #[cfg(feature = "openssl")]
 use open_ssl::ssl::SslAcceptorBuilder;
 
-use actix_web::{web, App, HttpResponse, HttpServer};
-
-fn unused_addr() -> net::SocketAddr {
-    let addr: net::SocketAddr = "127.0.0.1:0".parse().unwrap();
-    let socket = TcpBuilder::new_v4().unwrap();
-    socket.bind(&addr).unwrap();
-    socket.reuse_address(true).unwrap();
-    let tcp = socket.to_tcp_listener().unwrap();
-    tcp.local_addr().unwrap()
-}
+use actix_web::{test, web, App, HttpResponse, HttpServer};
 
 #[cfg(unix)]
 #[actix_rt::test]
 async fn test_start() {
-    let addr = unused_addr();
+    let addr = test::unused_addr();
     let (tx, rx) = mpsc::channel();
 
     thread::spawn(move || {
@@ -92,7 +82,7 @@ fn ssl_acceptor() -> std::io::Result<SslAcceptorBuilder> {
 async fn test_start_ssl() {
     use actix_web::HttpRequest;
 
-    let addr = unused_addr();
+    let addr = test::unused_addr();
     let (tx, rx) = mpsc::channel();
 
     thread::spawn(move || {


### PR DESCRIPTION
Fixes #1516