### PR TITLE
log message as error instead of debug

### DIFF
--- a/src/types/json.rs
+++ b/src/types/json.rs
@@ -188,7 +188,7 @@ where
             .limit(limit)
             .map(move |res| match res {
                 Err(e) => {
-                    log::debug!(
+                    log::error!(
                         "Failed to deserialize Json from payload. \
                          Request path: {}",
                         req2.path()


### PR DESCRIPTION
from_request implementation for Json should log the message as error instead of debug during error