### PR TITLE
CI: Only run the server benchmark to avoid SIGKILL

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -20,3 +20,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: bench
+          args: --bench=server


### PR DESCRIPTION
Don't run service benchmark since the async_service_direct benchmark causes SIGKILL on CI. For example:
- https://github.com/actix/actix-web/runs/687294657
- https://github.com/actix/actix-web/runs/687170532
- https://github.com/actix/actix-web/runs/687421955