### PR TITLE
Add links to Gitter on the issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Gitter channel (actix-web)
+    url: https://gitter.im/actix/actix-web
+    about: Please ask and answer questions about the actix-web here.
+  - name: Gitter channel (actix)
+    url: https://gitter.im/actix/actix
+    about: Please ask and answer questions about the actix here.


### PR DESCRIPTION
I don't know if there's a big difference between these channels, but it's better to have them both listed.

r? @robjtede since you're active on Gitter than me.