### PR TITLE
Fix NormalizePath trailing slash behavior

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@
 
 * Fix actix_http::h1::dispatcher so it returns when HW_BUFFER_SIZE is reached. Should reduce peak memory consumption during large uploads. [#1550]
 
+### Fixed
+
+* `NormalizePath` improved consistency when path needs slashes added _and_ removed.
+
 ## [3.0.0-alpha.3] - 2020-05-21
 
 ### Added

--- a/src/middleware/normalize.rs
+++ b/src/middleware/normalize.rs
@@ -16,6 +16,7 @@ use crate::Error;
 /// Performs following:
 ///
 /// - Merges multiple slashes into one.
+/// - Appends a trailing slash if one is not present.
 ///
 /// ```rust
 /// use actix_web::{web, http, middleware, App, HttpResponse};

--- a/src/middleware/normalize.rs
+++ b/src/middleware/normalize.rs
@@ -144,6 +144,10 @@ mod tests {
         let req3 = TestRequest::with_uri("//v1//////something").to_request();
         let res3 = call_service(&mut app, req3).await;
         assert!(res3.status().is_success());
+
+        let req4 = TestRequest::with_uri("/v1//something").to_request();
+        let res4 = call_service(&mut app, req4).await;
+        assert!(res4.status().is_success());
     }
 
     #[actix_rt::test]
@@ -169,6 +173,10 @@ mod tests {
         let req3 = TestRequest::with_uri("//v1///something").to_srv_request();
         let res3 = normalize.call(req3).await.unwrap();
         assert!(res3.status().is_success());
+
+        let req4 = TestRequest::with_uri("/v1//something").to_srv_request();
+        let res4 = normalize.call(req4).await.unwrap();
+        assert!(res4.status().is_success());
     }
 
     #[actix_rt::test]


### PR DESCRIPTION
Fixes #1536

NormalizePath would append a trailing slash if and only if it would
merge multiple slashes into one. For example, the following path would
not get a trailing slash appended:

```"/sample/path"```

On the other hand, this path would get a trailing slash appended:

```"/sample//path"```

After this commit, the trailing slash is appended for both the paths.

Also, the documentation for NormalizePath is updated to inform the user of the trailing slash behavior.