### PR TITLE
Enforce HW_BUFFER_SIZE inside h1::dispatcher

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## [Unreleased]
+
+### Changed
+
+* Fix actix_http::h1::dispatcher so it returns when HW_BUFFER_SIZE is reached. Should reduce peak memory consumption during large uploads. [#1550]
+
 ## [3.0.0-alpha.3] - 2020-05-21
 
 ### Added

--- a/actix-http/src/h1/dispatcher.rs
+++ b/actix-http/src/h1/dispatcher.rs
@@ -861,7 +861,14 @@ where
     T: AsyncRead + Unpin,
 {
     let mut read_some = false;
+
     loop {
+        // If buf is full return but do not disconnect since
+        // there is more reading to be done
+        if buf.len() >= HW_BUFFER_SIZE {
+            return Ok(Some(false));
+        }
+
         let remaining = buf.capacity() - buf.len();
         if remaining < LW_BUFFER_SIZE {
             buf.reserve(HW_BUFFER_SIZE - remaining);


### PR DESCRIPTION
This fixes what I presume to be a bug in the `actix-http` http1 protocol body reading where a large amount of bytes being available to be read from the underlying TCP socket can cause `read_buf` to be resized far beyond `HW_BUFFER_SIZE`.

The end result before this patch was `read_buf` more or less becoming the size of the entire payload--defeating any streaming the user might be trying to in their view and causing a very large memory foot print. In my test environment a 512mb file could easily cause the server process to balloon out to 10gb fairly quickly. After this fix it stays at a nice constant.

From what I can tell this was probably caused by a misunderstanding of how `BufMut` is implemented for a `BytesMut`. I only discovered it while debugging that the `BufMut` impl for `BytesMut` effectively does not have an upper bound in side because it can just resize the underlying BytesMut. See https://docs.rs/bytes/0.5.4/src/bytes/bytes_mut.rs.html#965 This is why I have added a `MaxBuf`.

Not super happy with the MaxBuf wrapper but it seemed like continuing to use `BufMut` +`AsyncRead::poll_read_buf` is the right call--otherwise we would have to introduce a bunch of unsafe buffering code ourselves that probably would end up being just as messy.

closes #1551