### PR TITLE
add method to extract matched resource pattern

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@
 ### Added
 
 * Re-export `actix_rt::main` as `actix_web::main`.
+* `HttpRequest::match_pattern` and `ServiceRequest::match_pattern` for extracting the matched
+  resource pattern.
 
 ### Changed
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -195,6 +195,12 @@ impl ServiceRequest {
     pub fn match_info(&self) -> &Path<Url> {
         self.0.match_info()
     }
+    
+    /// Counterpart to [`HttpRequest::match_pattern`](../struct.HttpRequest.html#method.match_pattern).
+    #[inline]
+    pub fn match_pattern(&self) -> Option<String> {
+        self.0.match_pattern()
+    }
 
     #[inline]
     /// Get a mutable reference to the Path parameters.


### PR DESCRIPTION
A commonly requested feature for logging and metrics reasons. Not possible to do with existing methods.

Closes #1565