### PR TITLE
add method to extract matched resource name

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,7 @@
 * Re-export `actix_rt::main` as `actix_web::main`.
 * `HttpRequest::match_pattern` and `ServiceRequest::match_pattern` for extracting the matched
   resource pattern.
-* `HttpRequest::match_name` for matching a path to a route.
+* `HttpRequest::match_name` for matching a path to a named route.
 
 ### Changed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,7 @@
 * Re-export `actix_rt::main` as `actix_web::main`.
 * `HttpRequest::match_pattern` and `ServiceRequest::match_pattern` for extracting the matched
   resource pattern.
-* `HttpRequest::match_name` for matching a path to a named route.
+* `HttpRequest::match_name` and `ServiceRequest::match_name` for extracting matched resource name.
 
 ### Changed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 * Re-export `actix_rt::main` as `actix_web::main`.
 * `HttpRequest::match_pattern` and `ServiceRequest::match_pattern` for extracting the matched
   resource pattern.
+* `HttpRequest::match_name` for matching a path to a route.
 
 ### Changed
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -135,6 +135,7 @@ impl HttpRequest {
     #[inline]
     pub fn match_pattern(&self) -> Option<String> {
         self.0.rmap.match_pattern(self.path())
+    }
 
     /// Checks if a given path matches a route
     #[inline]
@@ -645,14 +646,14 @@ mod tests {
                         move |req: HttpRequest| {
                             assert_eq!(
                                 req.match_name(),
-                                Some("/user/{id}/profile".to_owned())
+                                Some(&ResourceDef::new("/profile"))
                             );
 
                             HttpResponse::Ok().finish()
                         },
                     )))
                     .default_service(web::to(move |req: HttpRequest| {
-                        assert!(req.match_pattern().is_none());
+                        assert!(req.match_name().is_none());
                         HttpResponse::Ok().finish()
                     })),
             ),

--- a/src/request.rs
+++ b/src/request.rs
@@ -480,9 +480,12 @@ mod tests {
 
         assert!(rmap.has_resource("/index.html"));
 
-        let req = TestRequest::default().rmap(rmap).to_http_request();
-        let route_name = req.0.rmap.match_name("/index.html");
-        assert_eq!(route_name.unwrap(), "index".to_owned());
+        let req = TestRequest::default()
+            .uri("/index.html")
+            .rmap(rmap)
+            .to_http_request();
+
+        assert_eq!(req.match_name(), Some("index"));
     }
 
     #[test]

--- a/src/request.rs
+++ b/src/request.rs
@@ -137,9 +137,11 @@ impl HttpRequest {
         self.0.rmap.match_pattern(self.path())
     }
 
-    /// Checks if a given path matches a route
+    /// The resource name that matched the path. Useful for logging and metrics.
+    ///
+    /// Returns a None when no resource is fully matched, including default services.
     #[inline]
-    pub fn match_name(&self) -> Option<String> {
+    pub fn match_name(&self) -> Option<&str> {
         self.0.rmap.match_name(self.path())
     }
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -4,7 +4,7 @@ use std::{fmt, net};
 
 use actix_http::http::{HeaderMap, Method, Uri, Version};
 use actix_http::{Error, Extensions, HttpMessage, Message, Payload, RequestHead};
-use actix_router::{Path, Url, ResourceDef};
+use actix_router::{Path, Url};
 use futures_util::future::{ok, Ready};
 use tinyvec::TinyVec;
 
@@ -139,7 +139,7 @@ impl HttpRequest {
 
     /// Checks if a given path matches a route
     #[inline]
-    pub fn match_name(&self) -> Option<&ResourceDef> {
+    pub fn match_name(&self) -> Option<String> {
         self.0.rmap.match_name(&self.path())
     }
 
@@ -482,10 +482,10 @@ mod tests {
             .header(header::HOST, "www.rust-lang.org")
             .rmap(rmap)
             .to_http_request();
-        let route_name = req.resource_map().match_name("index").unwrap().name();
+        let route_name = req.0.rmap.match_name("index");
         assert_eq!(
-            route_name,
-            rdef.name()
+            route_name.unwrap(),
+            rdef.name().to_owned()
         );
     }
 
@@ -645,8 +645,8 @@ mod tests {
                     .service(web::resource("/profile").route(web::get().to(
                         move |req: HttpRequest| {
                             assert_eq!(
-                                req.match_name(),
-                                Some(&ResourceDef::new("/profile"))
+                                req.0.rmap.match_name("/user/22/profile"),
+                                Some(ResourceDef::new("/profile").name().to_owned())
                             );
 
                             HttpResponse::Ok().finish()

--- a/src/request.rs
+++ b/src/request.rs
@@ -482,10 +482,7 @@ mod tests {
 
         let req = TestRequest::default().rmap(rmap).to_http_request();
         let route_name = req.0.rmap.match_name("/index.html");
-        assert_eq!(
-            route_name.unwrap(),
-            "index".to_owned()
-        );
+        assert_eq!(route_name.unwrap(), "index".to_owned());
     }
 
     #[test]

--- a/src/rmap.rs
+++ b/src/rmap.rs
@@ -94,9 +94,14 @@ impl ResourceMap {
     }
     /// Returns the full resource pattern matched against a route or None if no match is
     /// found.
-    pub fn match_name(&self, path: &str) -> Option<&ResourceDef> {
+    pub fn match_name(&self, path: &str) -> Option<String> {
         let path = if path.is_empty() { "/" } else { path };
-        self.named.get(path)
+        let route = self.named.get(path);
+
+        match route {
+            Some(route) => Some(route.name().to_string()),
+            None => None,
+        }
     }
 
     /// Returns the full resource pattern matched against a path or None if no full match

--- a/src/rmap.rs
+++ b/src/rmap.rs
@@ -92,14 +92,22 @@ impl ResourceMap {
         }
         false
     }
-    /// Returns the name of the route that matches the given path or None if no match is
-    /// found.
-    pub fn match_name(&self, path: &str) -> Option<String> {
+
+    /// Returns the name of the route that matches the given path or None if no full match
+    /// is possible.
+    pub fn match_name(&self, path: &str) -> Option<&str> {
         let path = if path.is_empty() { "/" } else { path };
 
-        for (pattern, _) in &self.patterns {
-            if pattern.pattern() == path {
-                return Some(pattern.name().to_string());
+        for (pattern, rmap) in &self.patterns {
+            if let Some(ref rmap) = rmap {
+                if let Some(plen) = pattern.is_prefix_match(path) {
+                    return rmap.match_name(&path[plen..]);
+                }
+            } else if pattern.is_match(path) {
+                return match pattern.name() {
+                    "" => None,
+                    s => Some(s),
+                };
             }
         }
 
@@ -314,5 +322,49 @@ mod tests {
             root.match_pattern("/user/22/post/other-post/comment/42"),
             Some("/user/{id}/post/{post_id}/comment/{comment_id}".to_owned())
         );
+    }
+
+    #[test]
+    fn extract_matched_name() {
+        let mut root = ResourceMap::new(ResourceDef::root_prefix(""));
+
+        let mut rdef = ResourceDef::new("/info");
+        *rdef.name_mut() = "root_info".to_owned();
+        root.add(&mut rdef, None);
+
+        let mut user_map = ResourceMap::new(ResourceDef::root_prefix(""));
+        let mut rdef = ResourceDef::new("/");
+        user_map.add(&mut rdef, None);
+
+        let mut rdef = ResourceDef::new("/post/{post_id}");
+        *rdef.name_mut() = "user_post".to_owned();
+        user_map.add(&mut rdef, None);
+
+        root.add(
+            &mut ResourceDef::root_prefix("/user/{id}"),
+            Some(Rc::new(user_map)),
+        );
+
+        let root = Rc::new(root);
+        root.finish(Rc::clone(&root));
+
+        // sanity check resource map setup
+
+        assert!(root.has_resource("/info"));
+        assert!(!root.has_resource("/bar"));
+
+        assert!(root.has_resource("/user/22"));
+        assert!(root.has_resource("/user/22/"));
+        assert!(root.has_resource("/user/22/post/55"));
+
+        // extract patterns from paths
+
+        assert!(root.match_name("/bar").is_none());
+        assert!(root.match_name("/v44").is_none());
+
+        assert_eq!(root.match_name("/info"), Some("root_info"));
+        assert_eq!(root.match_name("/user/22"), None);
+        assert_eq!(root.match_name("/user/22/"), None);
+        assert_eq!(root.match_name("/user/22/post/55"), Some("user_post"));
     }
 }

--- a/src/rmap.rs
+++ b/src/rmap.rs
@@ -92,16 +92,18 @@ impl ResourceMap {
         }
         false
     }
-    /// Returns the full resource pattern matched against a route or None if no match is
+    /// Returns the name of the route that matches the given path or None if no match is
     /// found.
     pub fn match_name(&self, path: &str) -> Option<String> {
         let path = if path.is_empty() { "/" } else { path };
-        let route = self.named.get(path);
 
-        match route {
-            Some(route) => Some(route.name().to_string()),
-            None => None,
+        for (pattern, _) in &self.patterns {
+            if pattern.pattern() == path {
+                return Some(pattern.name().to_string());
+            }
         }
+
+        None
     }
 
     /// Returns the full resource pattern matched against a path or None if no full match

--- a/src/rmap.rs
+++ b/src/rmap.rs
@@ -92,6 +92,12 @@ impl ResourceMap {
         }
         false
     }
+    /// Returns the full resource pattern matched against a route or None if no match is
+    /// found.
+    pub fn match_name(&self, path: &str) -> Option<&ResourceDef> {
+        let path = if path.is_empty() { "/" } else { path };
+        self.named.get(path)
+    }
 
     /// Returns the full resource pattern matched against a path or None if no full match
     /// is possible.

--- a/src/service.rs
+++ b/src/service.rs
@@ -195,7 +195,13 @@ impl ServiceRequest {
     pub fn match_info(&self) -> &Path<Url> {
         self.0.match_info()
     }
-    
+
+    /// Counterpart to [`HttpRequest::match_name`](../struct.HttpRequest.html#method.match_name).
+    #[inline]
+    pub fn match_name(&self) -> Option<&ResourceDef> {
+        self.0.match_name()
+    }
+
     /// Counterpart to [`HttpRequest::match_pattern`](../struct.HttpRequest.html#method.match_pattern).
     #[inline]
     pub fn match_pattern(&self) -> Option<String> {

--- a/src/service.rs
+++ b/src/service.rs
@@ -198,7 +198,7 @@ impl ServiceRequest {
 
     /// Counterpart to [`HttpRequest::match_name`](../struct.HttpRequest.html#method.match_name).
     #[inline]
-    pub fn match_name(&self) -> Option<String> {
+    pub fn match_name(&self) -> Option<&str> {
         self.0.match_name()
     }
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -198,7 +198,7 @@ impl ServiceRequest {
 
     /// Counterpart to [`HttpRequest::match_name`](../struct.HttpRequest.html#method.match_name).
     #[inline]
-    pub fn match_name(&self) -> Option<&ResourceDef> {
+    pub fn match_name(&self) -> Option<String> {
         self.0.match_name()
     }
 


### PR DESCRIPTION
This PR adds a method to match a path to a route.
This PR is for issue #1568.
Fixes #1568

I've given it a shot @robjtede, looking for your feedback, guidance, and corrections.