### PR TITLE
move pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,3 @@
----
-name: Bug / Feature
-about: Submit a bug fix or feature.
----
-
 ## PR Type
 What kind of change does this PR make?
 


### PR DESCRIPTION
Turns out this doesnt follow the same format as the issue templates, only one is allowed and the front-matter isnt interpreted.

Tested on my fork.