### PR TITLE
Update `v_htmlescape` to 0.10

### DIFF
--- a/actix-files/CHANGES.md
+++ b/actix-files/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+## [unreleased] - xxx
+
+* Update `v_htmlescape` to 0.10
+
 ## [0.3.0-alpha.1] - 2020-05-23
 
 * Update `actix-web` and `actix-http` dependencies to alpha

--- a/actix-files/Cargo.toml
+++ b/actix-files/Cargo.toml
@@ -29,7 +29,7 @@ log = "0.4"
 mime = "0.3"
 mime_guess = "2.0.1"
 percent-encoding = "2.1"
-v_htmlescape = "0.4"
+v_htmlescape = "0.10"
 
 [dev-dependencies]
 actix-rt = "1.0.0"


### PR DESCRIPTION
It bumps six minor versions but most of changes are cleaning-up things AFAIK.
ref: https://github.com/botika/v_escape