### PR TITLE
Make web::Path a tuple struct with a public inner value

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,8 @@
 * Fix actix_http::h1::dispatcher so it returns when HW_BUFFER_SIZE is reached. Should reduce peak memory consumption during large uploads. [#1550]
 * Migrate cookie handling to `cookie` crate. Actix-web no longer requires `ring` dependency.
 * MSRV is now 1.41.1
+* `web::Path` now has a public representation: `web::Path(pub T)`
+  * This means it can now be destructured the same way as `web::Json`: `async fn some_route(web::Path(s): web::Path<String>)`
 
 ### Fixed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,10 +4,13 @@
 ### Changed
 * `PayloadConfig` is now also considered in `Bytes` and `String` extractors when set
   using `App::data`. [#1610]
+* `web::Path` now has a public representation: `web::Path(pub T)` that enables
+  destructuring. [#1594]
 
 ### Fixed
 * Memory leak of app data in pooled requests. [#1609]
 
+[#1594]: https://github.com/actix/actix-web/pull/1594
 [#1609]: https://github.com/actix/actix-web/pull/1609
 [#1610]: https://github.com/actix/actix-web/pull/1610
 
@@ -23,8 +26,6 @@
 * Fix actix_http::h1::dispatcher so it returns when HW_BUFFER_SIZE is reached. Should reduce peak memory consumption during large uploads. [#1550]
 * Migrate cookie handling to `cookie` crate. Actix-web no longer requires `ring` dependency.
 * MSRV is now 1.41.1
-* `web::Path` now has a public representation: `web::Path(pub T)`
-  * This means it can now be destructured the same way as `web::Json`: `async fn some_route(web::Path(s): web::Path<String>)`
 
 ### Fixed
 * `NormalizePath` improved consistency when path needs slashes added _and_ removed.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -12,6 +12,26 @@
 * `BodySize::Sized64` variant has been removed. `BodySize::Sized` now receives a
   `u64` instead of a `usize`.
 
+* Code that was using `path.<index>` to access a `web::Path<(A, B, C)>`s elements now needs to use
+  destructuring or `.into_inner()`. For example:
+
+  ```rust
+  // Previously:
+  async fn some_route(path: web::Path<(String, String)>) -> String {
+    format!("Hello, {} {}", path.0, path.1)
+  }
+
+  // Now (this also worked before):
+  async fn some_route(path: web::Path<(String, String)>) -> String {
+    let (first_name, last_name) = path.into_inner();
+    format!("Hello, {} {}", first_name, last_name)
+  }
+  // Or (this wasn't previously supported):
+  async fn some_route(web::Path((first_name, last_name)): web::Path<(String, String)>) -> String {
+    format!("Hello, {} {}", first_name, last_name)
+  }
+  ```
+
 ## 2.0.0
 
 * `HttpServer::start()` renamed to `HttpServer::run()`. It also possible to

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ Code:
 use actix_web::{get, web, App, HttpServer, Responder};
 
 #[get("/{id}/{name}/index.html")]
-async fn index(info: web::Path<(u32, String)>) -> impl Responder {
-    format!("Hello {}! id:{}", info.1, info.0)
+async fn index(web::Path((id, name)): web::Path<(u32, String)>) -> impl Responder {
+    format!("Hello {}! id:{}", name, id)
 }
 
 #[actix_web::main]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,8 +9,8 @@
 //! use actix_web::{get, web, App, HttpServer, Responder};
 //!
 //! #[get("/{id}/{name}/index.html")]
-//! async fn index(info: web::Path<(u32, String)>) -> impl Responder {
-//!     format!("Hello {}! id:{}", info.1, info.0)
+//! async fn index(web::Path((id, name)): web::Path<(u32, String)>) -> impl Responder {
+//!     format!("Hello {}! id:{}", name, id)
 //! }
 //!
 //! #[actix_web::main]


### PR DESCRIPTION
## PR Type

Feature

## PR Checklist

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.

## Overview

Currently, it is impossible to destructure a `web::Path` to obtain the inner value in a pattern (for example an argument definiton in a function signature), while the same is supported for other extractors, such as `web::Json` and `web::Query`. This means it is common to have one of the first lines of a handler be

```rust
let x = x.into_inner();
```

for single-path-parameter routes, or

```rust
let (a, b, c) = path.into_inner();
```

unless borrowing from the `web::Path` is feasible, in which case `Deref` takes care of the job.

This change makes `web::Path` behave the same way as `web::Json` and `web::Query`, which is breaking change because derefs to tuples stop working. In practice, I would expect destructuring to be more concise over `.into_inner` in many cases because it can be done right in the function signature and often, every parameter is on its own line already. It also moves assignment of path parameter names closer to the route definition if using route attributes.