### PR TITLE
prepare awc v2.0.0-beta.1 release

### DIFF
--- a/awc/CHANGES.md
+++ b/awc/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+## [2.0.0-beta.1] - 2020-07-14
+### Changed
+* Update `actix-http` dependency to 2.0.0-beta.1
+
 ## [2.0.0-alpha.2] - 2020-05-21
 
 ### Changed

--- a/awc/Cargo.toml
+++ b/awc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "awc"
-version = "2.0.0-alpha.2"
+version = "2.0.0-beta.1"
 authors = ["Nikolay Kim <fafhrd91@gmail.com>"]
 description = "Actix http client."
 readme = "README.md"
@@ -36,7 +36,7 @@ compress = ["actix-http/compress"]
 [dependencies]
 actix-codec = "0.2.0"
 actix-service = "1.0.1"
-actix-http = "2.0.0-alpha.4"
+actix-http = "2.0.0-beta.1"
 actix-rt = "1.0.0"
 
 base64 = "0.12"
@@ -56,7 +56,7 @@ rust-tls = { version = "0.17.0", package = "rustls", optional = true, features =
 [dev-dependencies]
 actix-connect = { version = "2.0.0-alpha.2", features = ["openssl"] }
 actix-web = { version = "3.0.0-alpha.3", features = ["openssl"] }
-actix-http = { version = "2.0.0-alpha.4", features = ["openssl"] }
+actix-http = { version = "2.0.0-beta.1", features = ["openssl"] }
 actix-http-test = { version = "2.0.0-alpha.1", features = ["openssl"] }
 actix-utils = "1.0.3"
 actix-server = "1.0.0"

--- a/test-server/Cargo.toml
+++ b/test-server/Cargo.toml
@@ -2,7 +2,7 @@
 name = "actix-http-test"
 version = "2.0.0-alpha.1"
 authors = ["Nikolay Kim <fafhrd91@gmail.com>"]
-description = "Actix http test server"
+description = "Actix HTTP test server"
 readme = "README.md"
 keywords = ["http", "web", "framework", "async", "futures"]
 homepage = "https://actix.rs"
@@ -53,4 +53,4 @@ open-ssl = { version = "0.10", package = "openssl", optional = true }
 
 [dev-dependencies]
 actix-web = "3.0.0-alpha.3"
-actix-http = "2.0.0-alpha.4"
+actix-http = "2.0.0-beta.1"


### PR DESCRIPTION
following the dep graph backwards shows this should be done before actix-web