### PR TITLE
Avoid using deprecated `/` in license field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/actix-web/"
 categories = ["network-programming", "asynchronous",
               "web-programming::http-server",
               "web-programming::websocket"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [package.metadata.docs.rs]

--- a/actix-files/Cargo.toml
+++ b/actix-files/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://actix.rs"
 repository = "https://github.com/actix/actix-web.git"
 documentation = "https://docs.rs/actix-files/"
 categories = ["asynchronous", "web-programming::http-server"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [lib]

--- a/actix-http/Cargo.toml
+++ b/actix-http/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/actix-http/"
 categories = ["network-programming", "asynchronous",
               "web-programming::http-server",
               "web-programming::websocket"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [package.metadata.docs.rs]

--- a/actix-multipart/Cargo.toml
+++ b/actix-multipart/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["http", "web", "framework", "async", "futures"]
 homepage = "https://actix.rs"
 repository = "https://github.com/actix/actix-web.git"
 documentation = "https://docs.rs/actix-multipart/"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [lib]

--- a/actix-web-actors/Cargo.toml
+++ b/actix-web-actors/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["actix", "http", "web", "framework", "async"]
 homepage = "https://actix.rs"
 repository = "https://github.com/actix/actix-web.git"
 documentation = "https://docs.rs/actix-web-actors/"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [lib]

--- a/actix-web-codegen/Cargo.toml
+++ b/actix-web-codegen/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://actix.rs"
 repository = "https://github.com/actix/actix-web"
 documentation = "https://docs.rs/actix-web-codegen"
 authors = ["Nikolay Kim <fafhrd91@gmail.com>"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [lib]

--- a/awc/Cargo.toml
+++ b/awc/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/awc/"
 categories = ["network-programming", "asynchronous",
               "web-programming::http-client",
               "web-programming::websocket"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [lib]

--- a/test-server/Cargo.toml
+++ b/test-server/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/actix-http-test/"
 categories = ["network-programming", "asynchronous",
               "web-programming::http-server",
               "web-programming::websocket"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 exclude = [".gitignore", ".cargo/config"]
 edition = "2018"
 


### PR DESCRIPTION
It's more clearer.
see: https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields