### PR TITLE
fix continous growth of app data in pooled requests

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 # Changes
 
 ## Unreleased - 2020-xx-xx
+### Fixed
+* Memory leak of app data in pooled requests. [#1609]
+
+[#1609]: https://github.com/actix/actix-web/pull/1609
 
 
 ## 3.0.0-beta.1 - 2020-07-13

--- a/src/app_service.rs
+++ b/src/app_service.rs
@@ -10,6 +10,7 @@ use actix_router::{Path, ResourceDef, ResourceInfo, Router, Url};
 use actix_service::boxed::{self, BoxService, BoxServiceFactory};
 use actix_service::{fn_service, Service, ServiceFactory};
 use futures_util::future::{join_all, ok, FutureExt, LocalBoxFuture};
+use tinyvec::tiny_vec;
 
 use crate::config::{AppConfig, AppService};
 use crate::data::{DataFactory, FnDataFactory};
@@ -245,7 +246,7 @@ where
             inner.path.reset();
             inner.head = head;
             inner.payload = payload;
-            inner.app_data.push(self.data.clone());
+            inner.app_data = tiny_vec![self.data.clone()];
             req
         } else {
             HttpRequest::new(


### PR DESCRIPTION
## PR Type
What kind of change does this PR make?

<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Bug Fix


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
A change made in PR #1486 to support multiple layers of application data caused a leak of app data for each request object that was reclaimed by the request pool. This PR makes a simple change to set fresh app data for a re-used request object rather than appending to the existing vec of app data layers.

This PR also adds some documentation around the request pool so readers can better understand its purpose and life cycle.

<!-- If this PR fixes or closes an issue, reference it here. -->
fixes #1606
fixes #1607
