### PR TITLE
Re-export all error types from awc

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
   destructuring. [#1594]
 * `ServiceRequest::app_data` allows retrieval of non-Data data without splitting into parts to
   access `HttpRequest` which already allows this. [#1618]
+* Re-export all error types from `awc`. [#1621]
 * MSRV is now 1.42.0.
 
 ### Fixed
@@ -17,6 +18,7 @@
 [#1609]: https://github.com/actix/actix-web/pull/1609
 [#1610]: https://github.com/actix/actix-web/pull/1610
 [#1618]: https://github.com/actix/actix-web/pull/1610
+[#1621]: https://github.com/actix/actix-web/pull/1621
 
 
 ## 3.0.0-beta.1 - 2020-07-13

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,7 +17,7 @@
 [#1594]: https://github.com/actix/actix-web/pull/1594
 [#1609]: https://github.com/actix/actix-web/pull/1609
 [#1610]: https://github.com/actix/actix-web/pull/1610
-[#1618]: https://github.com/actix/actix-web/pull/1610
+[#1618]: https://github.com/actix/actix-web/pull/1618
 [#1621]: https://github.com/actix/actix-web/pull/1621
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,9 +213,7 @@ pub mod client {
     //! }
     //! ```
 
-    pub use awc::error::{
-        ConnectError, InvalidUrl, PayloadError, SendRequestError, WsClientError,
-    };
+    pub use awc::error::*;
     pub use awc::{
         test, Client, ClientBuilder, ClientRequest, ClientResponse, Connector,
     };


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type

<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->

Other

## PR Checklist

Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated. (_N/A_)
- [x] Documentation comments have been added / updated. (_N/A_)
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt

## Overview

<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->

This makes using error handling while using the `awc::Client` *much easier*.

Closes #1474

<br>

Or I can update this PR to do one of the following (in order of ascending levels of change):

1. Import the rest of the missing `errors` (and the rest of the API as well?) like `FrozenClientRequest` _individually_.
1. Change the `error` imports to:
   ```rust
   pub use awc::error::*;
   ```
1. Change the whole `client` module to:
   
   1. Re-export everything while keeping the current structure:
        ```rust
        pub use awc::error::*;
        pub use awc::*;
        ```
    1. Re-export everything to keep the same structure as `awc` (__breaking change__):
        ```rust
        pub use awc::*;
        ```