### PR TITLE
Update rustls to 0.18

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,8 @@
 # Changes
 
 ## Unreleased
-
+### Changed
+* Update `rustls` to 0.18
 
 ## 3.0.0-beta.2 - 2020-08-17
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ actix-server = "1.0.0"
 actix-testing = "1.0.0"
 actix-macros = "0.1.0"
 actix-threadpool = "0.3.1"
-actix-tls = "2.0.0-alpha.1"
+actix-tls = "2.0.0-alpha.2"
 
 actix-web-codegen = "0.3.0-beta.1"
 actix-http = "2.0.0-beta.3"
@@ -98,7 +98,7 @@ serde_urlencoded = "0.6.1"
 time = { version = "0.2.7", default-features = false, features = ["std"] }
 url = "2.1"
 open-ssl = { package = "openssl", version = "0.10", optional = true }
-rust-tls = { package = "rustls", version = "0.17.0", optional = true }
+rust-tls = { package = "rustls", version = "0.18.0", optional = true }
 tinyvec = { version = "0.3", features = ["alloc"] }
 
 [dev-dependencies]

--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -1,5 +1,8 @@
 # Changes
 
+## Unreleased
+
+
 ## [2.0.0-beta.3] - 2020-08-14
 
 ### Fixed

--- a/actix-http/Cargo.toml
+++ b/actix-http/Cargo.toml
@@ -42,11 +42,11 @@ actors = ["actix"]
 [dependencies]
 actix-service = "1.0.5"
 actix-codec = "0.2.0"
-actix-connect = "2.0.0-alpha.3"
+actix-connect = "2.0.0-alpha.4"
 actix-utils = "1.0.6"
 actix-rt = "1.0.0"
 actix-threadpool = "0.3.1"
-actix-tls = { version = "2.0.0-alpha.1", optional = true }
+actix-tls = { version = "2.0.0-alpha.2", optional = true }
 actix = { version = "0.10.0-alpha.1", optional = true }
 
 base64 = "0.12"
@@ -87,14 +87,14 @@ flate2 = { version = "1.0.13", optional = true }
 
 [dev-dependencies]
 actix-server = "1.0.1"
-actix-connect = { version = "2.0.0-alpha.2", features = ["openssl"] }
+actix-connect = { version = "2.0.0-alpha.4", features = ["openssl"] }
 actix-http-test = { version = "2.0.0-alpha.1", features = ["openssl"] }
-actix-tls = { version = "2.0.0-alpha.1", features = ["openssl"] }
+actix-tls = { version = "2.0.0-alpha.2", features = ["openssl"] }
 criterion = "0.3"
 env_logger = "0.7"
 serde_derive = "1.0"
 open-ssl = { version="0.10", package = "openssl" }
-rust-tls = { version="0.17", package = "rustls" }
+rust-tls = { version="0.18", package = "rustls" }
 
 [[bench]]
 name = "content-length"

--- a/awc/CHANGES.md
+++ b/awc/CHANGES.md
@@ -1,6 +1,8 @@
 # Changes
 
 ## Unreleased - 2020-xx-xx
+### Changed
+* Update `rustls` to 0.18
 
 
 ## 2.0.0-beta.2 - 2020-07-21

--- a/awc/Cargo.toml
+++ b/awc/Cargo.toml
@@ -54,16 +54,16 @@ serde = "1.0"
 serde_json = "1.0"
 serde_urlencoded = "0.6.1"
 open-ssl = { version = "0.10", package = "openssl", optional = true }
-rust-tls = { version = "0.17.0", package = "rustls", optional = true, features = ["dangerous_configuration"] }
+rust-tls = { version = "0.18.0", package = "rustls", optional = true, features = ["dangerous_configuration"] }
 
 [dev-dependencies]
-actix-connect = { version = "2.0.0-alpha.2", features = ["openssl"] }
+actix-connect = { version = "2.0.0-alpha.4", features = ["openssl"] }
 actix-web = { version = "3.0.0-beta.2", features = ["openssl"] }
 actix-http = { version = "2.0.0-beta.3", features = ["openssl"] }
 actix-http-test = { version = "2.0.0-alpha.1", features = ["openssl"] }
 actix-utils = "1.0.3"
 actix-server = "1.0.0"
-actix-tls = { version = "2.0.0-alpha.1", features = ["openssl", "rustls"] }
+actix-tls = { version = "2.0.0-alpha.2", features = ["openssl", "rustls"] }
 brotli2 = "0.3.2"
 flate2 = "1.0.13"
 futures-util = { version = "0.3.5", default-features = false }

--- a/test-server/Cargo.toml
+++ b/test-server/Cargo.toml
@@ -31,7 +31,7 @@ openssl = ["open-ssl", "awc/openssl"]
 [dependencies]
 actix-service = "1.0.1"
 actix-codec = "0.2.0"
-actix-connect = "2.0.0-alpha.2"
+actix-connect = "2.0.0-alpha.4"
 actix-utils = "1.0.3"
 actix-rt = "1.0.0"
 actix-server = "1.0.0"


### PR DESCRIPTION
Updates rustls to 0.18.
~~Note that it's currently using my own fork to use unreleased actix-connect and -tls.~~
Once actix/actix-net/pull/181 gets merged, we could drop the latter commit and merge it asap.