### PR TITLE
Configurable trailing slash behaviour for NormalizePath

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## Unreleased
+### Added
+* `middleware::NormalizePath` now has configurable behaviour for either always having a trailing slash,
+  or as the new addition, always trimming trailing slashes.
+
 ## 3.0.0-beta.3 - 2020-08-17
 ### Changed
 * Update `rustls` to 0.18

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -32,6 +32,10 @@
   }
   ```
 
+* `middleware::NormalizePath` can now also be configured to trim trailing slashes instead of always keeping one.
+  It will need `middleware::normalize::TrailingSlash` when being constructed with `NormalizePath::new(...)`,
+  or for an easier migration you can replace `wrap(middleware::NormalizePath)` with `wrap(middleware::NormalizePath::default())`.
+
 ## 2.0.0
 
 * `HttpServer::start()` renamed to `HttpServer::run()`. It also possible to

--- a/src/middleware/condition.rs
+++ b/src/middleware/condition.rs
@@ -17,7 +17,7 @@ use futures_util::future::{ok, Either, FutureExt, LocalBoxFuture};
 /// # fn main() {
 /// let enable_normalize = std::env::var("NORMALIZE_PATH") == Ok("true".into());
 /// let app = App::new()
-///     .wrap(Condition::new(enable_normalize, NormalizePath));
+///     .wrap(Condition::new(enable_normalize, NormalizePath::default()));
 /// # }
 /// ```
 pub struct Condition<T> {


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Feature


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
Currently NormalizePath always adds a trailing slash. This change would make it configurable to either follow that style, or to always trim the trailing slash instead.
<!-- Emphasize any breaking changes. -->
Will be a breaking change to `NormalizePath` usage, since `middleware::NormalizePath` will need to be replaced by `middleware::NormalizePath::default()` or `::new(...)` when creating the middleware.


<!-- If this PR fixes or closes an issue, reference it here. -->
Closes #1612
