### PR TITLE
Depend on actix-http with default-features = false

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ actix-threadpool = "0.3.1"
 actix-tls = "2.0.0-alpha.2"
 
 actix-web-codegen = "0.3.0-beta.1"
-actix-http = "2.0.0-beta.3"
+actix-http = { version = "2.0.0-beta.3", default-features = false }
 awc = { version = "2.0.0-beta.3", default-features = false }
 
 bytes = "0.5.3"

--- a/actix-files/Cargo.toml
+++ b/actix-files/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 
 [dependencies]
 actix-web = { version = "3.0.0-beta.3", default-features = false }
-actix-http = "2.0.0-beta.3"
+actix-http = { version = "2.0.0-beta.3", default-features = false }
 actix-service = "1.0.1"
 bitflags = "1"
 bytes = "0.5.3"

--- a/actix-web-actors/Cargo.toml
+++ b/actix-web-actors/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 [dependencies]
 actix = "0.10.0-alpha.2"
 actix-web = { version = "3.0.0-beta.3", default-features = false }
-actix-http = "2.0.0-beta.3"
+actix-http = { version = "2.0.0-beta.3", default-features = false }
 actix-codec = "0.2.0"
 bytes = "0.5.2"
 futures-channel = { version = "0.3.5", default-features = false }

--- a/awc/Cargo.toml
+++ b/awc/Cargo.toml
@@ -39,7 +39,7 @@ compress = ["actix-http/compress"]
 [dependencies]
 actix-codec = "0.2.0"
 actix-service = "1.0.1"
-actix-http = "2.0.0-beta.3"
+actix-http = { version = "2.0.0-beta.3", default-features = false }
 actix-rt = "1.0.0"
 
 base64 = "0.12"


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Other


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [ ] Format code with the latest stable rustfmt


## Overview
Some depedendents have been carefully crafted to have their own
`compress` feature which enables the `compress` feature on `actix-http`
on demand, however that is all for naught when some dependents simply
use `actix-http` without opting out of `default-features` because
`compress` is a default feature.

Signed-off-by: Daniel Egger <daniel.egger@axiros.com>