### PR TITLE
PoC: multipart form derive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ members = [
   "actix-http",
   "actix-files",
   "actix-multipart",
+  "actix-multipart-derive",
   "actix-web-actors",
   "actix-web-codegen",
   "test-server",

--- a/actix-multipart-derive/Cargo.toml
+++ b/actix-multipart-derive/Cargo.toml
@@ -10,6 +10,7 @@ proc-macro = true
 [dependencies]
 quote = "1"
 syn = { version = "1", features = ["extra-traits"] }
+proc-macro2 = "1"
 
 # [dev-dependencies]
 actix-multipart = "0.3.0-beta.1"

--- a/actix-multipart-derive/Cargo.toml
+++ b/actix-multipart-derive/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "actix-multipart-derive"
+version = "0.1.0"
+authors = ["Rob Ede <robjtede@icloud.com>"]
+edition = "2018"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+quote = "1"
+syn = { version = "1", features = ["extra-traits"] }
+
+# [dev-dependencies]
+actix-multipart = "0.3.0-beta.1"
+actix-web = "3.0.0-beta.3"
+bytes = "0.5"
+futures-util = "0.3"
+serde = { version = "1", features = ["derive"] }
+trybuild = "1"

--- a/actix-multipart-derive/src/lib.rs
+++ b/actix-multipart-derive/src/lib.rs
@@ -1,0 +1,139 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{
+    parse_macro_input, Data, DataStruct, DeriveInput, Field, Fields, FieldsNamed, Ident,
+};
+
+#[proc_macro_derive(MultipartForm, attributes(multipart))]
+pub fn derive(input: TokenStream) -> TokenStream {
+    let ast = parse_macro_input!(input as DeriveInput);
+
+    let name = ast.ident;
+
+    let b_name = format!("{}MultipartBuilder", name);
+    let b_ident = Ident::new(&b_name, name.span());
+
+    let fields = if let Data::Struct(DataStruct {
+        fields: Fields::Named(FieldsNamed { ref named, .. }),
+        ..
+    }) = ast.data
+    {
+        named
+    } else {
+        unimplemented!()
+    };
+
+    let optioned = fields.iter().map(|f| {
+        let Field { ident, ty, .. } = f;
+        quote! { #ident: ::std::option::Option<#ty> }
+    });
+
+    let field_max_sizes = fields.iter().map(|f| {
+        let Field { ident, .. } = f;
+
+        // TODO: parse field attributes find
+        // #[multipart(max_size = n)]
+
+        quote! { stringify!(#ident) => Some(8096) }
+    });
+
+    let build_fields = fields.iter().map(|f| {
+        let Field { ident, .. } = f;
+        quote! { #ident: self.#ident.unwrap() }
+    });
+
+    let field_appending = fields.iter().map(|f| {
+        let Field { ident, ty, .. } = f;
+
+        quote! {
+           stringify!(#ident) => match builder.#ident {
+               Some(ref mut field) => {
+                   field.append(chunk);
+               }
+               None => {
+                   let mut field = #ty::default();
+                   field.append(chunk);
+                   builder.#ident.replace(field);
+               }
+           },
+
+        }
+    });
+
+    let expanded = quote! {
+        #[derive(Debug, Clone, Default)]
+        struct #b_ident {
+            #(#optioned,)*
+        }
+
+        impl #b_ident {
+            fn max_size(field: &str) -> Option<usize> {
+                match field {
+                    #(#field_max_sizes,)*
+                    _ => None,
+                }
+            }
+
+            fn build(self) -> Result<#name, ::actix_web::Error> {
+                Ok(Form {
+                    #(#build_fields,)*
+                })
+            }
+        }
+
+        impl ::actix_web::FromRequest for #name {
+            type Error = ::actix_web::Error;
+            type Future = ::futures_util::future::LocalBoxFuture<'static, Result<Self, Self::Error>>;
+            type Config = ();
+
+            fn from_request(req: &::actix_web::HttpRequest, payload: &mut ::actix_web::dev::Payload) -> Self::Future {
+                use futures_util::future::FutureExt;
+                use futures_util::stream::StreamExt;
+                use actix_multipart::BuildFromBytes;
+
+                let pl = payload.take();
+                let req2 = req.clone();
+
+                async move {
+                    let mut mp = ::actix_multipart::Multipart::new(req2.headers(), pl);
+
+                    let mut builder = #b_ident::default();
+
+                    while let Some(item) = mp.next().await {
+                        let mut field = item?;
+
+                        let headers = field.headers();
+
+                        let cd = field.content_disposition().unwrap();
+                        let name = cd.get_name().unwrap();
+                        println!("FIELD: {}", name);
+
+                        let mut size = 0;
+
+                        while let Some(chunk) = field.next().await {
+                            let chunk = chunk?;
+                            size += chunk.len();
+
+                            if (size > #b_ident::max_size(&name).unwrap_or(std::usize::MAX)) {
+                                return Err(::actix_web::error::ErrorPayloadTooLarge("field is too large"));
+                            }
+
+                            match name {
+                                #(#field_appending)*
+
+                                _ => todo!("unknown field"),
+                            }
+                        }
+
+                        println!();
+                    }
+
+                    builder.build()
+                }
+                .boxed_local()
+            }
+        }
+    };
+
+    expanded.into()
+}

--- a/actix-multipart-derive/src/main.rs
+++ b/actix-multipart-derive/src/main.rs
@@ -6,7 +6,7 @@ use bytes::BytesMut;
 struct Form {
     name: String,
 
-    #[multipart(max_size = 8096)]
+    #[multipart(max_size = 1024)]
     file: BytesMut,
 }
 

--- a/actix-multipart-derive/src/main.rs
+++ b/actix-multipart-derive/src/main.rs
@@ -1,0 +1,27 @@
+use actix_multipart_derive::MultipartForm;
+use actix_web::{post, App, HttpServer};
+use bytes::BytesMut;
+
+#[derive(Debug, Clone, Default, MultipartForm)]
+struct Form {
+    name: String,
+
+    #[multipart(max_size = 8096)]
+    file: BytesMut,
+}
+
+#[post("/")]
+async fn no_params(form: Form) -> &'static str {
+    println!("{:?}", &form);
+
+    "Hello world!\r\n"
+}
+
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    HttpServer::new(|| App::new().service(no_params))
+        .bind("127.0.0.1:8080")?
+        .workers(1)
+        .run()
+        .await
+}

--- a/actix-multipart-derive/tests/server.rs.bak
+++ b/actix-multipart-derive/tests/server.rs.bak
@@ -1,0 +1,19 @@
+
+#[post("/")]
+async fn no_params(form: Form) -> &'static str {
+    println!("{:?}", &form);
+
+    "Hello world!\r\n"
+}
+
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    std::env::set_var("RUST_LOG", "actix_server=info,actix_web=info");
+    env_logger::init();
+
+    HttpServer::new(|| App::new().service(no_params))
+        .bind("127.0.0.1:8080")?
+        .workers(1)
+        .run()
+        .await
+}

--- a/actix-multipart-derive/tests/trybuild.rs
+++ b/actix-multipart-derive/tests/trybuild.rs
@@ -1,0 +1,9 @@
+#[test]
+fn compile_macros() {
+    let t = trybuild::TestCases::new();
+
+    t.pass("tests/trybuild/01-basic.rs");
+    t.pass("tests/trybuild/02-max-size.rs");
+    // t.pass("tests/trybuild/03-inert-filter.rs");
+    // t.compile_fail("tests/trybuild/02-only-async.rs");
+}

--- a/actix-multipart-derive/tests/trybuild/01-basic.rs
+++ b/actix-multipart-derive/tests/trybuild/01-basic.rs
@@ -1,0 +1,10 @@
+use actix_multipart_derive::MultipartForm;
+use bytes::BytesMut;
+
+#[derive(Debug, Clone, Default, MultipartForm)]
+struct Form {
+    name: String,
+    file: BytesMut,
+}
+
+fn main() {}

--- a/actix-multipart-derive/tests/trybuild/02-max-size.rs
+++ b/actix-multipart-derive/tests/trybuild/02-max-size.rs
@@ -1,0 +1,11 @@
+use actix_multipart_derive::MultipartForm;
+use bytes::BytesMut;
+
+#[derive(Debug, Clone, Default, MultipartForm)]
+struct Form {
+    name: String,
+    #[multipart(max_size = 8096)]
+    file: BytesMut,
+}
+
+fn main () {}

--- a/actix-multipart-derive/tests/trybuild/03-inert-filter.rs
+++ b/actix-multipart-derive/tests/trybuild/03-inert-filter.rs
@@ -1,0 +1,13 @@
+use actix_multipart_derive::MultipartForm;
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Default, Deserialize, MultipartForm)]
+struct Form {
+    name: String,
+
+    #[multipart(max_size = 8096)]
+    #[serde(rename = "mFile")]
+    file: String,
+}
+
+fn main() {}

--- a/actix-multipart/Cargo.toml
+++ b/actix-multipart/Cargo.toml
@@ -30,3 +30,4 @@ twoway = "0.2"
 [dev-dependencies]
 actix-rt = "1.0.0"
 actix-http = "2.0.0-beta.3"
+env_logger = "0.7"

--- a/actix-multipart/src/byte_builder.rs
+++ b/actix-multipart/src/byte_builder.rs
@@ -1,18 +1,25 @@
-use bytes::{BufMut, Bytes, BytesMut};
+use bytes::{Bytes, BytesMut};
 
-pub trait BuildFromBytes {
-    fn append(&mut self, next: Bytes);
+pub trait FromBytes {
+    fn from_bytes(next: Bytes) -> Self;
 }
 
-impl BuildFromBytes for String {
-    fn append(&mut self, chunk: Bytes) {
-        let chunk_str = std::str::from_utf8(&chunk).expect("string field is not utf-8");
-        self.push_str(chunk_str);
+impl FromBytes for String {
+    fn from_bytes(bytes: Bytes) -> Self {
+        std::str::from_utf8(&bytes)
+            .expect("string field is not utf-8")
+            .to_owned()
     }
 }
 
-impl BuildFromBytes for BytesMut {
-    fn append(&mut self, chunk: Bytes) {
-        self.put(&chunk[..]);
+impl FromBytes for Bytes {
+    fn from_bytes(bytes: Bytes) -> Self {
+        bytes
+    }
+}
+
+impl FromBytes for BytesMut {
+    fn from_bytes(bytes: Bytes) -> Self {
+        BytesMut::from(bytes.as_ref())
     }
 }

--- a/actix-multipart/src/byte_builder.rs
+++ b/actix-multipart/src/byte_builder.rs
@@ -1,0 +1,18 @@
+use bytes::{BufMut, Bytes, BytesMut};
+
+pub trait BuildFromBytes {
+    fn append(&mut self, next: Bytes);
+}
+
+impl BuildFromBytes for String {
+    fn append(&mut self, chunk: Bytes) {
+        let chunk_str = std::str::from_utf8(&chunk).expect("string field is not utf-8");
+        self.push_str(chunk_str);
+    }
+}
+
+impl BuildFromBytes for BytesMut {
+    fn append(&mut self, chunk: Bytes) {
+        self.put(&chunk[..]);
+    }
+}

--- a/actix-multipart/src/lib.rs
+++ b/actix-multipart/src/lib.rs
@@ -6,3 +6,22 @@ mod server;
 
 pub use self::error::MultipartError;
 pub use self::server::{Field, Multipart};
+
+use bytes::{BufMut, Bytes, BytesMut};
+
+pub trait BuildFromBytes {
+    fn append(&mut self, next: Bytes);
+}
+
+impl BuildFromBytes for String {
+    fn append(&mut self, chunk: Bytes) {
+        let chunk_str = std::str::from_utf8(&chunk).expect("string field is not utf-8");
+        self.push_str(chunk_str);
+    }
+}
+
+impl BuildFromBytes for BytesMut {
+    fn append(&mut self, chunk: Bytes) {
+        self.put(&chunk[..]);
+    }
+}

--- a/actix-multipart/src/lib.rs
+++ b/actix-multipart/src/lib.rs
@@ -1,27 +1,10 @@
 #![allow(clippy::borrow_interior_mutable_const)]
 
+mod byte_builder;
 mod error;
 mod extractor;
 mod server;
 
+pub use self::byte_builder::BuildFromBytes;
 pub use self::error::MultipartError;
 pub use self::server::{Field, Multipart};
-
-use bytes::{BufMut, Bytes, BytesMut};
-
-pub trait BuildFromBytes {
-    fn append(&mut self, next: Bytes);
-}
-
-impl BuildFromBytes for String {
-    fn append(&mut self, chunk: Bytes) {
-        let chunk_str = std::str::from_utf8(&chunk).expect("string field is not utf-8");
-        self.push_str(chunk_str);
-    }
-}
-
-impl BuildFromBytes for BytesMut {
-    fn append(&mut self, chunk: Bytes) {
-        self.put(&chunk[..]);
-    }
-}

--- a/actix-multipart/src/lib.rs
+++ b/actix-multipart/src/lib.rs
@@ -5,6 +5,6 @@ mod error;
 mod extractor;
 mod server;
 
-pub use self::byte_builder::BuildFromBytes;
+pub use self::byte_builder::FromBytes;
 pub use self::error::MultipartError;
 pub use self::server::{Field, Multipart};


### PR DESCRIPTION
## PR Type
Feature


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [ ] Format code with the latest stable rustfmt


## Overview
Currently, multipart forms are quite difficult to wrangle. Requiring reasonably detailed knowledge of the streaming interface to extract fields and no standard serde interface for deserializing, for example. This has good reason, it would be prone to abuse from large files filling memory, especially since multipart forms are used primarily for file uploads; often these files are binary and not necessarily suitable for "deserializing".

The goal of this PR is to introduce a new derive crate for multipart that allows simpler declaration of field names, value types, maximum field sizes, content type assertions, and anything else that might be useful for multipart extraction.

The design is subject to change, but at the moment it uses a custom FromRequest impl on the Form struct, a builder struct for the Form, and a trait that allows building values from chunks of Bytes.

Simple Example:

```rust
#[derive(Debug, Clone, Default, MultipartForm)]
struct Form {
    name: String,

    #[multipart(max_size = 1024)]
    file: BytesMut,
}

#[post("/")]
async fn handler(form: Form) -> &'static str {
    println!("{:?}", &form);
    "Hello world!\r\n"
}
```