### PR TITLE
Fix examples hyperlink in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 ## Documentation
 
 * [Website & User Guide](https://actix.rs)
-* [Examples Repository](https://actix.rs/actix-web/actix_web)
+* [Examples Repository](https://github.com/actix/examples)
 * [API Documentation](https://docs.rs/actix-web)
 * [API Documentation (master branch)](https://actix.rs/actix-web/actix_web)
 


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
`Refactor`

## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

Just changed the wrong hyperlink. The `Examples Repository` was wrongly linked to the URL of [`API Documentation (master branch)`](https://actix.rs/actix-web/actix_web), I confirmed from the [official website](https://actix.rs/actix-web/actix_web/) that the URL was indeed wrong.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
