### PR TITLE
Improve json, form and query extractor config docs

### DIFF
--- a/src/types/form.rs
+++ b/src/types/form.rs
@@ -195,7 +195,7 @@ impl<T: Serialize> Responder for Form<T> {
 ///         web::resource("/index.html")
 ///             // change `Form` extractor configuration
 ///             .app_data(
-///                 web::Form::<FormData>::configure(|cfg| cfg.limit(4097))
+///                 web::FormConfig::default().limit(4097)
 ///             )
 ///             .route(web::get().to(index))
 ///     );

--- a/src/types/json.rs
+++ b/src/types/json.rs
@@ -209,9 +209,7 @@ where
 
 /// Json extractor configuration
 ///
-/// # Examples
-///
-/// Global extractor configuration:
+/// # Example
 ///
 /// ```rust
 /// use actix_web::{error, web, App, FromRequest, HttpResponse};
@@ -247,51 +245,6 @@ where
 /// }
 /// ```
 ///
-/// Per-type extractor configuration:
-///
-/// ```rust
-/// use actix_web::{error, web, App, FromRequest, HttpRequest, HttpResponse};
-/// use serde_derive::Deserialize;
-///
-/// #[derive(Deserialize)]
-/// struct Info {
-///     username: String,
-/// }
-///
-/// /// deserialize `Info` from request's body, max payload size is 4kb
-/// async fn index(info: web::Json<Info>) -> String {
-///     format!("Welcome {}!", info.username)
-/// }
-///
-/// /// Return either a 400 or 415, and include the error message from serde
-/// /// in the response body
-/// fn json_error_handler(err: error::JsonPayloadError, _req: &HttpRequest) -> error::Error {
-///     let detail = err.to_string();
-///     let response = match &err {
-///         error::JsonPayloadError::ContentType => {
-///             HttpResponse::UnsupportedMediaType().content_type("text/plain").body(detail)
-///         }
-///         _ => HttpResponse::BadRequest().content_type("text/plain").body(detail),
-///     };
-///     error::InternalError::from_response(err, response).into()
-/// }
-///
-/// fn main() {
-///     let app = App::new().service(
-///         web::resource("/index.html")
-///             .app_data(
-///                 // JSON extractor configuration for the `Info` struct only.
-///                 web::Json::<Info>::configure(|cfg| {
-///                     cfg.limit(4096)
-///                        .content_type(|mime| {  // <- accept text/plain content type
-///                            mime.type_() == mime::TEXT && mime.subtype() == mime::PLAIN
-///                        })
-///                        .error_handler(json_error_handler)  // Use our custom error response
-///             }))
-///             .route(web::post().to(index))
-///     );
-/// }
-/// ```
 #[derive(Clone)]
 pub struct JsonConfig {
     limit: usize,

--- a/src/types/json.rs
+++ b/src/types/json.rs
@@ -212,6 +212,7 @@ where
 /// # Examples
 ///
 /// Global extractor configuration:
+///
 /// ```rust
 /// use actix_web::{error, web, App, FromRequest, HttpResponse};
 /// use serde_derive::Deserialize;
@@ -247,6 +248,7 @@ where
 /// ```
 ///
 /// Per-type extractor configuration:
+///
 /// ```rust
 /// use actix_web::{error, web, App, FromRequest, HttpRequest, HttpResponse};
 /// use serde_derive::Deserialize;
@@ -278,7 +280,7 @@ where
 ///     let app = App::new().service(
 ///         web::resource("/index.html")
 ///             .app_data(
-///                 // Json extractor configuration for only the `Info` struct.
+///                 // JSON extractor configuration for the `Info` struct only.
 ///                 web::Json::<Info>::configure(|cfg| {
 ///                     cfg.limit(4096)
 ///                        .content_type(|mime| {  // <- accept text/plain content type

--- a/src/types/json.rs
+++ b/src/types/json.rs
@@ -211,6 +211,42 @@ where
 ///
 /// # Examples
 ///
+/// Global extractor configuration:
+/// ```rust
+/// use actix_web::{error, web, App, FromRequest, HttpResponse};
+/// use serde_derive::Deserialize;
+///
+/// #[derive(Deserialize)]
+/// struct Info {
+///     username: String,
+/// }
+///
+/// /// deserialize `Info` from request's body, max payload size is 4kb
+/// async fn index(info: web::Json<Info>) -> String {
+///     format!("Welcome {}!", info.username)
+/// }
+///
+/// fn main() {
+///     let app = App::new().service(
+///         web::resource("/index.html")
+///             .app_data(
+///                 // Json extractor configuration for this resource.
+///                 web::JsonConfig::default()
+///                     .limit(4096) // Limit request payload size
+///                     .content_type(|mime| {  // <- accept text/plain content type
+///                         mime.type_() == mime::TEXT && mime.subtype() == mime::PLAIN
+///                     })
+///                     .error_handler(|err, req| {  // <- create custom error response
+///                        error::InternalError::from_response(
+///                            err, HttpResponse::Conflict().finish()).into()
+///                     })
+///             )
+///             .route(web::post().to(index))
+///     );
+/// }
+/// ```
+///
+/// Per-type extractor configuration:
 /// ```rust
 /// use actix_web::{error, web, App, FromRequest, HttpRequest, HttpResponse};
 /// use serde_derive::Deserialize;
@@ -242,7 +278,7 @@ where
 ///     let app = App::new().service(
 ///         web::resource("/index.html")
 ///             .app_data(
-///                 // change json extractor configuration
+///                 // Json extractor configuration for only the `Info` struct.
 ///                 web::Json::<Info>::configure(|cfg| {
 ///                     cfg.limit(4096)
 ///                        .content_type(|mime| {  // <- accept text/plain content type

--- a/src/types/query.rs
+++ b/src/types/query.rs
@@ -188,12 +188,12 @@ where
 ///     let app = App::new().service(
 ///         web::resource("/index.html").app_data(
 ///             // change query extractor configuration
-///             web::Query::<Info>::configure(|cfg| {
-///                 cfg.error_handler(|err, req| {  // <- create custom error response
+///             web::QueryConfig::default()
+///                 .error_handler(|err, req| {  // <- create custom error response
 ///                     error::InternalError::from_response(
 ///                         err, HttpResponse::Conflict().finish()).into()
 ///                 })
-///             }))
+///             )
 ///             .route(web::post().to(index))
 ///     );
 /// }


### PR DESCRIPTION
Improve the `JsonConfig` docs to show example of both a global and per-type json extractor configuration.