### PR TITLE
ameliorate awc timeouts on windows

### DIFF
--- a/awc/CHANGES.md
+++ b/awc/CHANGES.md
@@ -1,7 +1,8 @@
 # Changes
 
 ## Unreleased - 2020-xx-xx
-
+### Fixed
+* Reduced chance of timeouts on Windows.
 
 ## 2.0.0-beta.4 - 2020-09-09
 ### Changed

--- a/awc/src/builder.rs
+++ b/awc/src/builder.rs
@@ -40,7 +40,14 @@ impl ClientBuilder {
             allow_redirects: true,
             max_redirects: 10,
             headers: HeaderMap::new(),
+
+            #[cfg(not(target_os = "windows"))]
             timeout: Some(Duration::from_secs(5)),
+
+            // HACK: Issue #1560 - ameliorate connect timeouts from DNS lookups
+            #[cfg(target_os = "windows")]
+            timeout: Some(Duration::from_secs(10)),
+
             connector: None,
             max_http_version: None,
             stream_window_size: None,


### PR DESCRIPTION
## PR Type
Bug Workaround


## PR Checklist
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
Works around issues on Windows seemingly caused by slow DNS lookups by doubling the default timeout period when built for Windows.

See conversation in #1560 

cc: @Pzixel @popzxc