### PR TITLE
awc: Rename Client::build to Client::builder

### DIFF
--- a/awc/CHANGES.md
+++ b/awc/CHANGES.md
@@ -1,6 +1,8 @@
 # Changes
 
 ## Unreleased - 2020-xx-xx
+### Changed
+* `Client::build` was renamed to `Client::builder`.
 
 
 ## 2.0.0-beta.4 - 2020-09-09

--- a/awc/src/lib.rs
+++ b/awc/src/lib.rs
@@ -166,8 +166,9 @@ impl Client {
         Client::default()
     }
 
-    /// Build client instance.
-    pub fn build() -> ClientBuilder {
+    /// Create a [ClientBuilder] to configure `Client`.
+    /// This function is equivalent of `ClientBuilder::new()`.
+    pub fn builder() -> ClientBuilder {
         ClientBuilder::new()
     }
 

--- a/awc/src/lib.rs
+++ b/awc/src/lib.rs
@@ -166,7 +166,7 @@ impl Client {
         Client::default()
     }
 
-    /// Create a [ClientBuilder] to configure `Client`.
+    /// Create `Client` builder.
     /// This function is equivalent of `ClientBuilder::new()`.
     pub fn builder() -> ClientBuilder {
         ClientBuilder::new()

--- a/awc/src/request.rs
+++ b/awc/src/request.rs
@@ -623,7 +623,7 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_client_header() {
-        let req = Client::build()
+        let req = Client::builder()
             .header(header::CONTENT_TYPE, "111")
             .finish()
             .get("/");
@@ -641,7 +641,7 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_client_header_override() {
-        let req = Client::build()
+        let req = Client::builder()
             .header(header::CONTENT_TYPE, "111")
             .finish()
             .get("/")

--- a/awc/src/ws.rs
+++ b/awc/src/ws.rs
@@ -434,7 +434,7 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_header_override() {
-        let req = Client::build()
+        let req = Client::builder()
             .header(header::CONTENT_TYPE, "111")
             .finish()
             .ws("/")

--- a/awc/tests/test_client.rs
+++ b/awc/tests/test_client.rs
@@ -120,7 +120,7 @@ async fn test_timeout() {
         .timeout(Duration::from_secs(15))
         .finish();
 
-    let client = awc::Client::build()
+    let client = awc::Client::builder()
         .connector(connector)
         .timeout(Duration::from_millis(50))
         .finish();
@@ -141,7 +141,7 @@ async fn test_timeout_override() {
         })))
     });
 
-    let client = awc::Client::build()
+    let client = awc::Client::builder()
         .timeout(Duration::from_millis(50000))
         .finish();
     let request = client
@@ -291,7 +291,7 @@ async fn test_connection_wait_queue() {
     })
     .await;
 
-    let client = awc::Client::build()
+    let client = awc::Client::builder()
         .connector(awc::Connector::new().limit(1).finish())
         .finish();
 
@@ -340,7 +340,7 @@ async fn test_connection_wait_queue_force_close() {
     })
     .await;
 
-    let client = awc::Client::build()
+    let client = awc::Client::builder()
         .connector(awc::Connector::new().limit(1).finish())
         .finish();
 

--- a/awc/tests/test_connector.rs
+++ b/awc/tests/test_connector.rs
@@ -47,7 +47,7 @@ async fn test_connection_window_size() {
         .set_alpn_protos(b"\x02h2\x08http/1.1")
         .map_err(|e| log::error!("Can not set alpn protocol: {:?}", e));
 
-    let client = awc::Client::build()
+    let client = awc::Client::builder()
         .connector(awc::Connector::new().ssl(builder.build()).finish())
         .initial_window_size(100)
         .initial_connection_window_size(100)

--- a/awc/tests/test_rustls_client.rs
+++ b/awc/tests/test_rustls_client.rs
@@ -82,7 +82,7 @@ async fn _test_connection_reuse_h2() {
         .dangerous()
         .set_certificate_verifier(Arc::new(danger::NoCertificateVerification {}));
 
-    let client = awc::Client::build()
+    let client = awc::Client::builder()
         .connector(awc::Connector::new().rustls(Arc::new(config)).finish())
         .finish();
 

--- a/awc/tests/test_ssl_client.rs
+++ b/awc/tests/test_ssl_client.rs
@@ -62,7 +62,7 @@ async fn test_connection_reuse_h2() {
         .set_alpn_protos(b"\x02h2\x08http/1.1")
         .map_err(|e| log::error!("Can not set alpn protocol: {:?}", e));
 
-    let client = awc::Client::build()
+    let client = awc::Client::builder()
         .connector(awc::Connector::new().ssl(builder.build()).finish())
         .finish();
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -822,7 +822,7 @@ where
             }
         };
 
-        Client::build().connector(connector).finish()
+        Client::builder().connector(connector).finish()
     };
 
     TestServer {

--- a/test-server/src/lib.rs
+++ b/test-server/src/lib.rs
@@ -90,7 +90,7 @@ pub async fn test_server<F: ServiceFactory<TcpStream>>(factory: F) -> TestServer
             }
         };
 
-        Client::build().connector(connector).finish()
+        Client::builder().connector(connector).finish()
     };
     actix_connect::start_default_resolver().await.unwrap();
 

--- a/tests/test_httpserver.rs
+++ b/tests/test_httpserver.rs
@@ -43,7 +43,7 @@ async fn test_start() {
     {
         use actix_http::client;
 
-        let client = awc::Client::build()
+        let client = awc::Client::builder()
             .connector(
                 client::Connector::new()
                     .timeout(Duration::from_millis(100))
@@ -115,7 +115,7 @@ async fn test_start_ssl() {
         .set_alpn_protos(b"\x02h2\x08http/1.1")
         .map_err(|e| log::error!("Can not set alpn protocol: {:?}", e));
 
-    let client = awc::Client::build()
+    let client = awc::Client::builder()
         .connector(
             awc::Connector::new()
                 .ssl(builder.build())


### PR DESCRIPTION
## PR Type

Refactor / Docs

**Warning:** This change is breaking!


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview

This method does not *build* a client, thus the name and comment are a bit odd. I think it makes sense to fix it before a stable release.