### PR TITLE
fix clippy async_yields_async lints

### DIFF
--- a/src/route.rs
+++ b/src/route.rs
@@ -368,7 +368,7 @@ mod tests {
                         }))
                         .route(web::post().to(|| async {
                             delay_for(Duration::from_millis(100)).await;
-                            HttpResponse::Created()
+                            Ok::<_, ()>(HttpResponse::Created())
                         }))
                         .route(web::delete().to(|| async {
                             delay_for(Duration::from_millis(100)).await;

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -826,7 +826,7 @@ mod tests {
     async fn test_scope_variable_segment() {
         let mut srv =
             init_service(App::new().service(web::scope("/ab-{project}").service(
-                web::resource("/path1").to(|r: HttpRequest| async move {
+                web::resource("/path1").to(|r: HttpRequest| {
                     HttpResponse::Ok()
                         .body(format!("project: {}", &r.match_info()["project"]))
                 }),
@@ -926,7 +926,7 @@ mod tests {
     async fn test_nested_scope_with_variable_segment() {
         let mut srv = init_service(App::new().service(web::scope("/app").service(
             web::scope("/{project_id}").service(web::resource("/path1").to(
-                |r: HttpRequest| async move {
+                |r: HttpRequest| {
                     HttpResponse::Created()
                         .body(format!("project: {}", &r.match_info()["project_id"]))
                 },
@@ -951,7 +951,7 @@ mod tests {
     async fn test_nested2_scope_with_variable_segment() {
         let mut srv = init_service(App::new().service(web::scope("/app").service(
             web::scope("/{project}").service(web::scope("/{id}").service(
-                web::resource("/path1").to(|r: HttpRequest| async move {
+                web::resource("/path1").to(|r: HttpRequest| {
                     HttpResponse::Created().body(format!(
                         "project: {} - {}",
                         &r.match_info()["project"],
@@ -1178,7 +1178,7 @@ mod tests {
                     );
                     s.route(
                         "/",
-                        web::get().to(|req: HttpRequest| async move {
+                        web::get().to(|req: HttpRequest| {
                             HttpResponse::Ok().body(
                                 req.url_for("youtube", &["xxxxxx"]).unwrap().to_string(),
                             )
@@ -1199,7 +1199,7 @@ mod tests {
     async fn test_url_for_nested() {
         let mut srv = init_service(App::new().service(web::scope("/a").service(
             web::scope("/b").service(web::resource("/c/{stuff}").name("c").route(
-                web::get().to(|req: HttpRequest| async move {
+                web::get().to(|req: HttpRequest| {
                     HttpResponse::Ok()
                         .body(format!("{}", req.url_for("c", &["12345"]).unwrap()))
                 }),

--- a/src/test.rs
+++ b/src/test.rs
@@ -1072,14 +1072,9 @@ mod tests {
         let mut app = init_service(
             App::new().service(
                 web::resource("/index.html")
-                    .route(web::put().to(|| async { HttpResponse::Ok().body("put!") }))
-                    .route(
-                        web::patch().to(|| async { HttpResponse::Ok().body("patch!") }),
-                    )
-                    .route(
-                        web::delete()
-                            .to(|| async { HttpResponse::Ok().body("delete!") }),
-                    ),
+                    .route(web::put().to(|| HttpResponse::Ok().body("put!")))
+                    .route(web::patch().to(|| HttpResponse::Ok().body("patch!")))
+                    .route(web::delete().to(|| HttpResponse::Ok().body("delete!"))),
             ),
         )
         .await;
@@ -1107,11 +1102,13 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_response() {
-        let mut app =
-            init_service(App::new().service(web::resource("/index.html").route(
-                web::post().to(|| async { HttpResponse::Ok().body("welcome!") }),
-            )))
-            .await;
+        let mut app = init_service(
+            App::new().service(
+                web::resource("/index.html")
+                    .route(web::post().to(|| HttpResponse::Ok().body("welcome!"))),
+            ),
+        )
+        .await;
 
         let req = TestRequest::post()
             .uri("/index.html")
@@ -1124,11 +1121,13 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_send_request() {
-        let mut app =
-            init_service(App::new().service(web::resource("/index.html").route(
-                web::get().to(|| async { HttpResponse::Ok().body("welcome!") }),
-            )))
-            .await;
+        let mut app = init_service(
+            App::new().service(
+                web::resource("/index.html")
+                    .route(web::get().to(|| HttpResponse::Ok().body("welcome!"))),
+            ),
+        )
+        .await;
 
         let resp = TestRequest::get()
             .uri("/index.html")
@@ -1148,7 +1147,7 @@ mod tests {
     #[actix_rt::test]
     async fn test_response_json() {
         let mut app = init_service(App::new().service(web::resource("/people").route(
-            web::post().to(|person: web::Json<Person>| async {
+            web::post().to(|person: web::Json<Person>| {
                 HttpResponse::Ok().json(person.into_inner())
             }),
         )))
@@ -1169,7 +1168,7 @@ mod tests {
     #[actix_rt::test]
     async fn test_body_json() {
         let mut app = init_service(App::new().service(web::resource("/people").route(
-            web::post().to(|person: web::Json<Person>| async {
+            web::post().to(|person: web::Json<Person>| {
                 HttpResponse::Ok().json(person.into_inner())
             }),
         )))
@@ -1191,7 +1190,7 @@ mod tests {
     #[actix_rt::test]
     async fn test_request_response_form() {
         let mut app = init_service(App::new().service(web::resource("/people").route(
-            web::post().to(|person: web::Form<Person>| async {
+            web::post().to(|person: web::Form<Person>| {
                 HttpResponse::Ok().json(person.into_inner())
             }),
         )))
@@ -1217,7 +1216,7 @@ mod tests {
     #[actix_rt::test]
     async fn test_request_response_json() {
         let mut app = init_service(App::new().service(web::resource("/people").route(
-            web::post().to(|person: web::Json<Person>| async {
+            web::post().to(|person: web::Json<Person>| {
                 HttpResponse::Ok().json(person.into_inner())
             }),
         )))


### PR DESCRIPTION
## PR Type
Clippy


## PR Checklist
- [x] Format code with the latest stable rustfmt


## Overview
Addresses a (new?) clippy lint `async_yields_async`. It's complaint is that return types from `HttpResponseBuilder::{json, body}` are themselves futures and don't require the async block.