### PR TITLE
prepare web release 3.0.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,14 @@
 # Changes
 
 ## Unreleased - 2020-xx-xx
+
+
+## 3.0.1 - 2020-09-13
 ### Changed
 * `middleware::normalize::TrailingSlash` enum is now accessible. [#1673]
+
+[#1673]: https://github.com/actix/actix-web/pull/1673
+
 
 ## 3.0.0 - 2020-09-11
 * No significant changes from `3.0.0-beta.4`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "actix-web"
-version = "3.0.0"
+version = "3.0.1"
 authors = ["Nikolay Kim <fafhrd91@gmail.com>"]
-description = "Actix web is a simple, pragmatic and extremely fast web framework for Rust."
+description = "Actix web is a powerful, pragmatic, and extremely fast web framework for Rust."
 readme = "README.md"
 keywords = ["actix", "http", "web", "framework", "async"]
 homepage = "https://actix.rs"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,3 @@
-#![deny(rust_2018_idioms)]
-#![allow(clippy::needless_doctest_main, clippy::type_complexity)]
-
 //! Actix web is a powerful, pragmatic, and extremely fast web framework for Rust.
 //!
 //! ## Example
@@ -67,6 +64,11 @@
 //! * `openssl` - HTTPS support via `openssl` crate, supports `HTTP/2`
 //! * `rustls` - HTTPS support via `rustls` crate, supports `HTTP/2`
 //! * `secure-cookies` - secure cookies support
+
+#![deny(rust_2018_idioms)]
+#![allow(clippy::needless_doctest_main, clippy::type_complexity)]
+#![doc(html_logo_url = "https://actix.rs/img/logo.png")]
+#![doc(html_favicon_url = "https://actix.rs/favicon.ico")]
 
 mod app;
 mod app_service;


### PR DESCRIPTION
Also adds in some doc attributes to make this happen:

<img width="236" alt="2020-09-13_01 06 59-1bb37bfb" src="https://user-images.githubusercontent.com/3316789/93007164-790ed400-f55d-11ea-8324-ec88acb6d7ff.png">

<img width="284" alt="2020-09-13_01 07 03-818227dc" src="https://user-images.githubusercontent.com/3316789/93007165-7ad89780-f55d-11ea-9e1b-1ead82dbc60c.png">
