### PR TITLE
split up files lib

### DIFF
--- a/actix-files/Cargo.toml
+++ b/actix-files/Cargo.toml
@@ -18,7 +18,6 @@ path = "src/lib.rs"
 
 [dependencies]
 actix-web = { version = "3.0.0", default-features = false }
-actix-http = "2.0.0"
 actix-service = "1.0.6"
 bitflags = "1"
 bytes = "0.5.3"

--- a/actix-files/src/chunked.rs
+++ b/actix-files/src/chunked.rs
@@ -1,5 +1,5 @@
 use std::{
-    cmp,
+    cmp, fmt,
     fs::File,
     future::Future,
     io::{self, Read, Seek},
@@ -29,6 +29,12 @@ pub struct ChunkedReadFile {
     pub(crate) file: Option<File>,
     pub(crate) fut: Option<ChunkedBoxFuture>,
     pub(crate) counter: u64,
+}
+
+impl fmt::Debug for ChunkedReadFile {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("ChunkedReadFile")
+    }
 }
 
 impl Stream for ChunkedReadFile {

--- a/actix-files/src/chunked.rs
+++ b/actix-files/src/chunked.rs
@@ -12,7 +12,7 @@ use actix_web::{
     web,
 };
 use bytes::Bytes;
-use futures_core::Stream;
+use futures_core::{ready, Stream};
 use futures_util::future::{FutureExt, LocalBoxFuture};
 
 use crate::handle_error;
@@ -39,16 +39,17 @@ impl Stream for ChunkedReadFile {
         cx: &mut Context<'_>,
     ) -> Poll<Option<Self::Item>> {
         if let Some(ref mut fut) = self.fut {
-            return match Pin::new(fut).poll(cx) {
-                Poll::Ready(Ok((file, bytes))) => {
+            return match ready!(Pin::new(fut).poll(cx)) {
+                Ok((file, bytes)) => {
                     self.fut.take();
                     self.file = Some(file);
+
                     self.offset += bytes.len() as u64;
                     self.counter += bytes.len() as u64;
+
                     Poll::Ready(Some(Ok(bytes)))
                 }
-                Poll::Ready(Err(e)) => Poll::Ready(Some(Err(handle_error(e)))),
-                Poll::Pending => Poll::Pending,
+                Err(e) => Poll::Ready(Some(Err(handle_error(e)))),
             };
         }
 
@@ -60,21 +61,27 @@ impl Stream for ChunkedReadFile {
             Poll::Ready(None)
         } else {
             let mut file = self.file.take().expect("Use after completion");
+
             self.fut = Some(
                 web::block(move || {
-                    let max_bytes: usize;
-                    max_bytes = cmp::min(size.saturating_sub(counter), 65_536) as usize;
+                    let max_bytes =
+                        cmp::min(size.saturating_sub(counter), 65_536) as usize;
+
                     let mut buf = Vec::with_capacity(max_bytes);
                     file.seek(io::SeekFrom::Start(offset))?;
-                    let nbytes =
+
+                    let n_bytes =
                         file.by_ref().take(max_bytes as u64).read_to_end(&mut buf)?;
-                    if nbytes == 0 {
+
+                    if n_bytes == 0 {
                         return Err(io::ErrorKind::UnexpectedEof.into());
                     }
+
                     Ok((file, Bytes::from(buf)))
                 })
                 .boxed_local(),
             );
+
             self.poll_next(cx)
         }
     }

--- a/actix-files/src/chunked.rs
+++ b/actix-files/src/chunked.rs
@@ -1,0 +1,81 @@
+use std::{
+    cmp,
+    fs::File,
+    future::Future,
+    io::{self, Read, Seek},
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use actix_web::{
+    error::{BlockingError, Error},
+    web,
+};
+use bytes::Bytes;
+use futures_core::Stream;
+use futures_util::future::{FutureExt, LocalBoxFuture};
+
+use crate::handle_error;
+
+type ChunkedBoxFuture =
+    LocalBoxFuture<'static, Result<(File, Bytes), BlockingError<io::Error>>>;
+
+#[doc(hidden)]
+/// A helper created from a `std::fs::File` which reads the file
+/// chunk-by-chunk on a `ThreadPool`.
+pub struct ChunkedReadFile {
+    pub(crate) size: u64,
+    pub(crate) offset: u64,
+    pub(crate) file: Option<File>,
+    pub(crate) fut: Option<ChunkedBoxFuture>,
+    pub(crate) counter: u64,
+}
+
+impl Stream for ChunkedReadFile {
+    type Item = Result<Bytes, Error>;
+
+    fn poll_next(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        if let Some(ref mut fut) = self.fut {
+            return match Pin::new(fut).poll(cx) {
+                Poll::Ready(Ok((file, bytes))) => {
+                    self.fut.take();
+                    self.file = Some(file);
+                    self.offset += bytes.len() as u64;
+                    self.counter += bytes.len() as u64;
+                    Poll::Ready(Some(Ok(bytes)))
+                }
+                Poll::Ready(Err(e)) => Poll::Ready(Some(Err(handle_error(e)))),
+                Poll::Pending => Poll::Pending,
+            };
+        }
+
+        let size = self.size;
+        let offset = self.offset;
+        let counter = self.counter;
+
+        if size == counter {
+            Poll::Ready(None)
+        } else {
+            let mut file = self.file.take().expect("Use after completion");
+            self.fut = Some(
+                web::block(move || {
+                    let max_bytes: usize;
+                    max_bytes = cmp::min(size.saturating_sub(counter), 65_536) as usize;
+                    let mut buf = Vec::with_capacity(max_bytes);
+                    file.seek(io::SeekFrom::Start(offset))?;
+                    let nbytes =
+                        file.by_ref().take(max_bytes as u64).read_to_end(&mut buf)?;
+                    if nbytes == 0 {
+                        return Err(io::ErrorKind::UnexpectedEof.into());
+                    }
+                    Ok((file, Bytes::from(buf)))
+                })
+                .boxed_local(),
+            );
+            self.poll_next(cx)
+        }
+    }
+}

--- a/actix-files/src/directory.rs
+++ b/actix-files/src/directory.rs
@@ -1,0 +1,114 @@
+use std::{fmt::Write, fs::DirEntry, io, path::Path, path::PathBuf};
+
+use actix_web::{dev::ServiceResponse, HttpRequest, HttpResponse};
+use percent_encoding::{utf8_percent_encode, CONTROLS};
+use v_htmlescape::escape as escape_html_entity;
+
+/// A directory; responds with the generated directory listing.
+#[derive(Debug)]
+pub struct Directory {
+    /// Base directory.
+    pub base: PathBuf,
+
+    /// Path of subdirectory to generate listing for.
+    pub path: PathBuf,
+}
+
+impl Directory {
+    /// Create a new directory
+    pub fn new(base: PathBuf, path: PathBuf) -> Directory {
+        Directory { base, path }
+    }
+
+    /// Is this entry visible from this directory?
+    pub fn is_visible(&self, entry: &io::Result<DirEntry>) -> bool {
+        if let Ok(ref entry) = *entry {
+            if let Some(name) = entry.file_name().to_str() {
+                if name.starts_with('.') {
+                    return false;
+                }
+            }
+            if let Ok(ref md) = entry.metadata() {
+                let ft = md.file_type();
+                return ft.is_dir() || ft.is_file() || ft.is_symlink();
+            }
+        }
+        false
+    }
+}
+
+pub(crate) type DirectoryRenderer =
+    dyn Fn(&Directory, &HttpRequest) -> Result<ServiceResponse, io::Error>;
+
+// show file url as relative to static path
+macro_rules! encode_file_url {
+    ($path:ident) => {
+        utf8_percent_encode(&$path, CONTROLS)
+    };
+}
+
+// " -- &quot;  & -- &amp;  ' -- &#x27;  < -- &lt;  > -- &gt;  / -- &#x2f;
+macro_rules! encode_file_name {
+    ($entry:ident) => {
+        escape_html_entity(&$entry.file_name().to_string_lossy())
+    };
+}
+
+pub(crate) fn directory_listing(
+    dir: &Directory,
+    req: &HttpRequest,
+) -> Result<ServiceResponse, io::Error> {
+    let index_of = format!("Index of {}", req.path());
+    let mut body = String::new();
+    let base = Path::new(req.path());
+
+    for entry in dir.path.read_dir()? {
+        if dir.is_visible(&entry) {
+            let entry = entry.unwrap();
+            let p = match entry.path().strip_prefix(&dir.path) {
+                Ok(p) if cfg!(windows) => {
+                    base.join(p).to_string_lossy().replace("\\", "/")
+                }
+                Ok(p) => base.join(p).to_string_lossy().into_owned(),
+                Err(_) => continue,
+            };
+
+            // if file is a directory, add '/' to the end of the name
+            if let Ok(metadata) = entry.metadata() {
+                if metadata.is_dir() {
+                    let _ = write!(
+                        body,
+                        "<li><a href=\"{}\">{}/</a></li>",
+                        encode_file_url!(p),
+                        encode_file_name!(entry),
+                    );
+                } else {
+                    let _ = write!(
+                        body,
+                        "<li><a href=\"{}\">{}</a></li>",
+                        encode_file_url!(p),
+                        encode_file_name!(entry),
+                    );
+                }
+            } else {
+                continue;
+            }
+        }
+    }
+
+    let html = format!(
+        "<html>\
+         <head><title>{}</title></head>\
+         <body><h1>{}</h1>\
+         <ul>\
+         {}\
+         </ul></body>\n</html>",
+        index_of, index_of, body
+    );
+    Ok(ServiceResponse::new(
+        req.clone(),
+        HttpResponse::Ok()
+            .content_type("text/html; charset=utf-8")
+            .body(html),
+    ))
+}

--- a/actix-files/src/files.rs
+++ b/actix-files/src/files.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, io, path::PathBuf, rc::Rc};
+use std::{cell::RefCell, fmt, io, path::PathBuf, rc::Rc};
 
 use actix_service::{boxed, IntoServiceFactory, ServiceFactory};
 use actix_web::{
@@ -17,7 +17,7 @@ use crate::{
     HttpNewService, MimeOverride,
 };
 
-/// Static files handling
+/// Static files handling service.
 ///
 /// `Files` service must be registered with `App::service()` method.
 ///
@@ -39,6 +39,12 @@ pub struct Files {
     mime_override: Option<Rc<MimeOverride>>,
     file_flags: named::Flags,
     guards: Option<Rc<dyn Guard>>,
+}
+
+impl fmt::Debug for Files {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("Files")
+    }
 }
 
 impl Clone for Files {
@@ -193,11 +199,13 @@ impl HttpServiceFactory for Files {
         if self.default.borrow().is_none() {
             *self.default.borrow_mut() = Some(config.default_service());
         }
+
         let rdef = if config.is_root() {
             ResourceDef::root_prefix(&self.path)
         } else {
             ResourceDef::prefix(&self.path)
         };
+
         config.register_service(rdef, None, self, None)
     }
 }

--- a/actix-files/src/files.rs
+++ b/actix-files/src/files.rs
@@ -38,9 +38,7 @@ pub struct Files {
     renderer: Rc<DirectoryRenderer>,
     mime_override: Option<Rc<MimeOverride>>,
     file_flags: named::Flags,
-    // FIXME: Should re-visit later.
-    #[allow(clippy::redundant_allocation)]
-    guards: Option<Rc<Box<dyn Guard>>>,
+    guards: Option<Rc<dyn Guard>>,
 }
 
 impl Clone for Files {
@@ -157,7 +155,7 @@ impl Files {
     /// Default behaviour allows GET and HEAD.
     #[inline]
     pub fn use_guards<G: Guard + 'static>(mut self, guards: G) -> Self {
-        self.guards = Some(Rc::new(Box::new(guards)));
+        self.guards = Some(Rc::new(guards));
         self
     }
 

--- a/actix-files/src/files.rs
+++ b/actix-files/src/files.rs
@@ -1,0 +1,244 @@
+use std::{cell::RefCell, io, path::PathBuf, rc::Rc};
+
+use actix_service::{boxed, IntoServiceFactory, ServiceFactory};
+use actix_web::{
+    dev::{
+        AppService, HttpServiceFactory, ResourceDef, ServiceRequest, ServiceResponse,
+    },
+    error::Error,
+    guard::Guard,
+    http::header::DispositionType,
+    HttpRequest,
+};
+use futures_util::future::{ok, FutureExt, LocalBoxFuture};
+
+use crate::{
+    directory_listing, named, Directory, DirectoryRenderer, FilesService,
+    HttpNewService, MimeOverride,
+};
+
+/// Static files handling
+///
+/// `Files` service must be registered with `App::service()` method.
+///
+/// ```rust
+/// use actix_web::App;
+/// use actix_files::Files;
+///
+/// let app = App::new()
+///     .service(Files::new("/static", "."));
+/// ```
+pub struct Files {
+    path: String,
+    directory: PathBuf,
+    index: Option<String>,
+    show_index: bool,
+    redirect_to_slash: bool,
+    default: Rc<RefCell<Option<Rc<HttpNewService>>>>,
+    renderer: Rc<DirectoryRenderer>,
+    mime_override: Option<Rc<MimeOverride>>,
+    file_flags: named::Flags,
+    // FIXME: Should re-visit later.
+    #[allow(clippy::redundant_allocation)]
+    guards: Option<Rc<Box<dyn Guard>>>,
+}
+
+impl Clone for Files {
+    fn clone(&self) -> Self {
+        Self {
+            directory: self.directory.clone(),
+            index: self.index.clone(),
+            show_index: self.show_index,
+            redirect_to_slash: self.redirect_to_slash,
+            default: self.default.clone(),
+            renderer: self.renderer.clone(),
+            file_flags: self.file_flags,
+            path: self.path.clone(),
+            mime_override: self.mime_override.clone(),
+            guards: self.guards.clone(),
+        }
+    }
+}
+
+impl Files {
+    /// Create new `Files` instance for specified base directory.
+    ///
+    /// `File` uses `ThreadPool` for blocking filesystem operations.
+    /// By default pool with 5x threads of available cpus is used.
+    /// Pool size can be changed by setting ACTIX_THREADPOOL environment variable.
+    pub fn new<T: Into<PathBuf>>(path: &str, dir: T) -> Files {
+        let orig_dir = dir.into();
+        let dir = match orig_dir.canonicalize() {
+            Ok(canon_dir) => canon_dir,
+            Err(_) => {
+                log::error!("Specified path is not a directory: {:?}", orig_dir);
+                PathBuf::new()
+            }
+        };
+
+        Files {
+            path: path.to_string(),
+            directory: dir,
+            index: None,
+            show_index: false,
+            redirect_to_slash: false,
+            default: Rc::new(RefCell::new(None)),
+            renderer: Rc::new(directory_listing),
+            mime_override: None,
+            file_flags: named::Flags::default(),
+            guards: None,
+        }
+    }
+
+    /// Show files listing for directories.
+    ///
+    /// By default show files listing is disabled.
+    pub fn show_files_listing(mut self) -> Self {
+        self.show_index = true;
+        self
+    }
+
+    /// Redirects to a slash-ended path when browsing a directory.
+    ///
+    /// By default never redirect.
+    pub fn redirect_to_slash_directory(mut self) -> Self {
+        self.redirect_to_slash = true;
+        self
+    }
+
+    /// Set custom directory renderer
+    pub fn files_listing_renderer<F>(mut self, f: F) -> Self
+    where
+        for<'r, 's> F: Fn(&'r Directory, &'s HttpRequest) -> Result<ServiceResponse, io::Error>
+            + 'static,
+    {
+        self.renderer = Rc::new(f);
+        self
+    }
+
+    /// Specifies mime override callback
+    pub fn mime_override<F>(mut self, f: F) -> Self
+    where
+        F: Fn(&mime::Name<'_>) -> DispositionType + 'static,
+    {
+        self.mime_override = Some(Rc::new(f));
+        self
+    }
+
+    /// Set index file
+    ///
+    /// Shows specific index file for directory "/" instead of
+    /// showing files listing.
+    pub fn index_file<T: Into<String>>(mut self, index: T) -> Self {
+        self.index = Some(index.into());
+        self
+    }
+
+    #[inline]
+    /// Specifies whether to use ETag or not.
+    ///
+    /// Default is true.
+    pub fn use_etag(mut self, value: bool) -> Self {
+        self.file_flags.set(named::Flags::ETAG, value);
+        self
+    }
+
+    #[inline]
+    /// Specifies whether to use Last-Modified or not.
+    ///
+    /// Default is true.
+    pub fn use_last_modified(mut self, value: bool) -> Self {
+        self.file_flags.set(named::Flags::LAST_MD, value);
+        self
+    }
+
+    /// Specifies custom guards to use for directory listings and files.
+    ///
+    /// Default behaviour allows GET and HEAD.
+    #[inline]
+    pub fn use_guards<G: Guard + 'static>(mut self, guards: G) -> Self {
+        self.guards = Some(Rc::new(Box::new(guards)));
+        self
+    }
+
+    /// Disable `Content-Disposition` header.
+    ///
+    /// By default Content-Disposition` header is enabled.
+    #[inline]
+    pub fn disable_content_disposition(mut self) -> Self {
+        self.file_flags.remove(named::Flags::CONTENT_DISPOSITION);
+        self
+    }
+
+    /// Sets default handler which is used when no matched file could be found.
+    pub fn default_handler<F, U>(mut self, f: F) -> Self
+    where
+        F: IntoServiceFactory<U>,
+        U: ServiceFactory<
+                Config = (),
+                Request = ServiceRequest,
+                Response = ServiceResponse,
+                Error = Error,
+            > + 'static,
+    {
+        // create and configure default resource
+        self.default = Rc::new(RefCell::new(Some(Rc::new(boxed::factory(
+            f.into_factory().map_init_err(|_| ()),
+        )))));
+
+        self
+    }
+}
+
+impl HttpServiceFactory for Files {
+    fn register(self, config: &mut AppService) {
+        if self.default.borrow().is_none() {
+            *self.default.borrow_mut() = Some(config.default_service());
+        }
+        let rdef = if config.is_root() {
+            ResourceDef::root_prefix(&self.path)
+        } else {
+            ResourceDef::prefix(&self.path)
+        };
+        config.register_service(rdef, None, self, None)
+    }
+}
+
+impl ServiceFactory for Files {
+    type Request = ServiceRequest;
+    type Response = ServiceResponse;
+    type Error = Error;
+    type Config = ();
+    type Service = FilesService;
+    type InitError = ();
+    type Future = LocalBoxFuture<'static, Result<Self::Service, Self::InitError>>;
+
+    fn new_service(&self, _: ()) -> Self::Future {
+        let mut srv = FilesService {
+            directory: self.directory.clone(),
+            index: self.index.clone(),
+            show_index: self.show_index,
+            redirect_to_slash: self.redirect_to_slash,
+            default: None,
+            renderer: self.renderer.clone(),
+            mime_override: self.mime_override.clone(),
+            file_flags: self.file_flags,
+            guards: self.guards.clone(),
+        };
+
+        if let Some(ref default) = *self.default.borrow() {
+            default
+                .new_service(())
+                .map(move |result| match result {
+                    Ok(default) => {
+                        srv.default = Some(default);
+                        Ok(srv)
+                    }
+                    Err(_) => Err(()),
+                })
+                .boxed_local()
+        } else {
+            ok(srv).boxed_local()
+        }
+    }
+}

--- a/actix-files/src/lib.rs
+++ b/actix-files/src/lib.rs
@@ -1,7 +1,6 @@
 //! Static files support
 
 #![deny(rust_2018_idioms)]
-#![allow(clippy::borrow_interior_mutable_const)]
 
 use std::io;
 
@@ -29,9 +28,9 @@ pub use crate::named::NamedFile;
 pub use crate::range::HttpRange;
 pub use crate::service::FilesService;
 
-pub(crate) use self::directory::{directory_listing, DirectoryRenderer};
-pub(crate) use self::error::FilesError;
-pub(crate) use self::path_buf::PathBufWrap;
+use self::directory::{directory_listing, DirectoryRenderer};
+use self::error::FilesError;
+use self::path_buf::PathBufWrap;
 
 type HttpService = BoxService<ServiceRequest, ServiceResponse, Error>;
 type HttpNewService = BoxServiceFactory<(), ServiceRequest, ServiceResponse, Error, ()>;

--- a/actix-files/src/lib.rs
+++ b/actix-files/src/lib.rs
@@ -3,27 +3,20 @@
 #![deny(rust_2018_idioms)]
 #![allow(clippy::borrow_interior_mutable_const)]
 
-use std::{cell::RefCell, io, path::PathBuf, rc::Rc};
+use std::io;
 
-use actix_service::{
-    boxed::{self, BoxService, BoxServiceFactory},
-    IntoServiceFactory, ServiceFactory,
-};
+use actix_service::boxed::{BoxService, BoxServiceFactory};
 use actix_web::{
-    dev::{
-        AppService, HttpServiceFactory, ResourceDef, ServiceRequest, ServiceResponse,
-    },
+    dev::{ServiceRequest, ServiceResponse},
     error::{BlockingError, Error, ErrorInternalServerError},
-    guard::Guard,
     http::header::DispositionType,
-    HttpRequest,
 };
-use futures_util::future::{ok, FutureExt, LocalBoxFuture};
 use mime_guess::from_ext;
 
 mod chunked;
 mod directory;
 mod error;
+mod files;
 mod named;
 mod path_buf;
 mod range;
@@ -31,6 +24,7 @@ mod service;
 
 pub use crate::chunked::ChunkedReadFile;
 pub use crate::directory::Directory;
+pub use crate::files::Files;
 pub use crate::named::NamedFile;
 pub use crate::range::HttpRange;
 pub use crate::service::FilesService;
@@ -59,232 +53,6 @@ pub(crate) fn handle_error(err: BlockingError<io::Error>) -> Error {
 
 type MimeOverride = dyn Fn(&mime::Name<'_>) -> DispositionType;
 
-/// Static files handling
-///
-/// `Files` service must be registered with `App::service()` method.
-///
-/// ```rust
-/// use actix_web::App;
-/// use actix_files::Files;
-///
-/// let app = App::new()
-///     .service(Files::new("/static", "."));
-/// ```
-pub struct Files {
-    path: String,
-    directory: PathBuf,
-    index: Option<String>,
-    show_index: bool,
-    redirect_to_slash: bool,
-    default: Rc<RefCell<Option<Rc<HttpNewService>>>>,
-    renderer: Rc<DirectoryRenderer>,
-    mime_override: Option<Rc<MimeOverride>>,
-    file_flags: named::Flags,
-    // FIXME: Should re-visit later.
-    #[allow(clippy::redundant_allocation)]
-    guards: Option<Rc<Box<dyn Guard>>>,
-}
-
-impl Clone for Files {
-    fn clone(&self) -> Self {
-        Self {
-            directory: self.directory.clone(),
-            index: self.index.clone(),
-            show_index: self.show_index,
-            redirect_to_slash: self.redirect_to_slash,
-            default: self.default.clone(),
-            renderer: self.renderer.clone(),
-            file_flags: self.file_flags,
-            path: self.path.clone(),
-            mime_override: self.mime_override.clone(),
-            guards: self.guards.clone(),
-        }
-    }
-}
-
-impl Files {
-    /// Create new `Files` instance for specified base directory.
-    ///
-    /// `File` uses `ThreadPool` for blocking filesystem operations.
-    /// By default pool with 5x threads of available cpus is used.
-    /// Pool size can be changed by setting ACTIX_THREADPOOL environment variable.
-    pub fn new<T: Into<PathBuf>>(path: &str, dir: T) -> Files {
-        let orig_dir = dir.into();
-        let dir = match orig_dir.canonicalize() {
-            Ok(canon_dir) => canon_dir,
-            Err(_) => {
-                log::error!("Specified path is not a directory: {:?}", orig_dir);
-                PathBuf::new()
-            }
-        };
-
-        Files {
-            path: path.to_string(),
-            directory: dir,
-            index: None,
-            show_index: false,
-            redirect_to_slash: false,
-            default: Rc::new(RefCell::new(None)),
-            renderer: Rc::new(directory_listing),
-            mime_override: None,
-            file_flags: named::Flags::default(),
-            guards: None,
-        }
-    }
-
-    /// Show files listing for directories.
-    ///
-    /// By default show files listing is disabled.
-    pub fn show_files_listing(mut self) -> Self {
-        self.show_index = true;
-        self
-    }
-
-    /// Redirects to a slash-ended path when browsing a directory.
-    ///
-    /// By default never redirect.
-    pub fn redirect_to_slash_directory(mut self) -> Self {
-        self.redirect_to_slash = true;
-        self
-    }
-
-    /// Set custom directory renderer
-    pub fn files_listing_renderer<F>(mut self, f: F) -> Self
-    where
-        for<'r, 's> F: Fn(&'r Directory, &'s HttpRequest) -> Result<ServiceResponse, io::Error>
-            + 'static,
-    {
-        self.renderer = Rc::new(f);
-        self
-    }
-
-    /// Specifies mime override callback
-    pub fn mime_override<F>(mut self, f: F) -> Self
-    where
-        F: Fn(&mime::Name<'_>) -> DispositionType + 'static,
-    {
-        self.mime_override = Some(Rc::new(f));
-        self
-    }
-
-    /// Set index file
-    ///
-    /// Shows specific index file for directory "/" instead of
-    /// showing files listing.
-    pub fn index_file<T: Into<String>>(mut self, index: T) -> Self {
-        self.index = Some(index.into());
-        self
-    }
-
-    #[inline]
-    /// Specifies whether to use ETag or not.
-    ///
-    /// Default is true.
-    pub fn use_etag(mut self, value: bool) -> Self {
-        self.file_flags.set(named::Flags::ETAG, value);
-        self
-    }
-
-    #[inline]
-    /// Specifies whether to use Last-Modified or not.
-    ///
-    /// Default is true.
-    pub fn use_last_modified(mut self, value: bool) -> Self {
-        self.file_flags.set(named::Flags::LAST_MD, value);
-        self
-    }
-
-    /// Specifies custom guards to use for directory listings and files.
-    ///
-    /// Default behaviour allows GET and HEAD.
-    #[inline]
-    pub fn use_guards<G: Guard + 'static>(mut self, guards: G) -> Self {
-        self.guards = Some(Rc::new(Box::new(guards)));
-        self
-    }
-
-    /// Disable `Content-Disposition` header.
-    ///
-    /// By default Content-Disposition` header is enabled.
-    #[inline]
-    pub fn disable_content_disposition(mut self) -> Self {
-        self.file_flags.remove(named::Flags::CONTENT_DISPOSITION);
-        self
-    }
-
-    /// Sets default handler which is used when no matched file could be found.
-    pub fn default_handler<F, U>(mut self, f: F) -> Self
-    where
-        F: IntoServiceFactory<U>,
-        U: ServiceFactory<
-                Config = (),
-                Request = ServiceRequest,
-                Response = ServiceResponse,
-                Error = Error,
-            > + 'static,
-    {
-        // create and configure default resource
-        self.default = Rc::new(RefCell::new(Some(Rc::new(boxed::factory(
-            f.into_factory().map_init_err(|_| ()),
-        )))));
-
-        self
-    }
-}
-
-impl HttpServiceFactory for Files {
-    fn register(self, config: &mut AppService) {
-        if self.default.borrow().is_none() {
-            *self.default.borrow_mut() = Some(config.default_service());
-        }
-        let rdef = if config.is_root() {
-            ResourceDef::root_prefix(&self.path)
-        } else {
-            ResourceDef::prefix(&self.path)
-        };
-        config.register_service(rdef, None, self, None)
-    }
-}
-
-impl ServiceFactory for Files {
-    type Request = ServiceRequest;
-    type Response = ServiceResponse;
-    type Error = Error;
-    type Config = ();
-    type Service = FilesService;
-    type InitError = ();
-    type Future = LocalBoxFuture<'static, Result<Self::Service, Self::InitError>>;
-
-    fn new_service(&self, _: ()) -> Self::Future {
-        let mut srv = FilesService {
-            directory: self.directory.clone(),
-            index: self.index.clone(),
-            show_index: self.show_index,
-            redirect_to_slash: self.redirect_to_slash,
-            default: None,
-            renderer: self.renderer.clone(),
-            mime_override: self.mime_override.clone(),
-            file_flags: self.file_flags,
-            guards: self.guards.clone(),
-        };
-
-        if let Some(ref default) = *self.default.borrow() {
-            default
-                .new_service(())
-                .map(move |result| match result {
-                    Ok(default) => {
-                        srv.default = Some(default);
-                        Ok(srv)
-                    }
-                    Err(_) => Err(()),
-                })
-                .boxed_local()
-        } else {
-            ok(srv).boxed_local()
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::{
@@ -293,6 +61,7 @@ mod tests {
         time::{Duration, SystemTime},
     };
 
+    use actix_service::ServiceFactory;
     use actix_web::{
         guard,
         http::{
@@ -303,6 +72,7 @@ mod tests {
         test::{self, TestRequest},
         web, App, HttpResponse, Responder,
     };
+    use futures_util::future::ok;
 
     use super::*;
 

--- a/actix-files/src/lib.rs
+++ b/actix-files/src/lib.rs
@@ -42,7 +42,7 @@ pub use crate::range::HttpRange;
 
 use self::directory::{directory_listing, DirectoryRenderer};
 use self::error::FilesError;
-use self::path_buf::PathBufWrp;
+use self::path_buf::PathBufWrap;
 
 type HttpService = BoxService<ServiceRequest, ServiceResponse, Error>;
 type HttpNewService = BoxServiceFactory<(), ServiceRequest, ServiceResponse, Error, ()>;
@@ -354,13 +354,13 @@ impl Service for FilesService {
             )));
         }
 
-        let real_path = match PathBufWrp::get_pathbuf(req.match_info().path()) {
+        let real_path: PathBufWrap = match req.match_info().path().parse() {
             Ok(item) => item,
             Err(e) => return Either::Left(ok(req.error_response(e))),
         };
 
         // full file path
-        let path = match self.directory.join(real_path.as_pathbuf()).canonicalize() {
+        let path = match self.directory.join(&real_path).canonicalize() {
             Ok(path) => path,
             Err(e) => return self.handle_err(e, req),
         };

--- a/actix-files/src/lib.rs
+++ b/actix-files/src/lib.rs
@@ -1,6 +1,22 @@
-//! Static files support
+//! Static files support for Actix Web.
+//!
+//! Provides a non-blocking service for serving static files from disk.
+//!
+//! # Example
+//! ```rust
+//! use actix_web::App;
+//! use actix_files::Files;
+//!
+//! let app = App::new()
+//!     .service(Files::new("/static", "."));
+//! ```
+//!
+//! # Implementation Quirks
+//! - If a filename contains non-ascii characters, that file will be served with the `charset=utf-8`
+//!   extension on the Content-Type header.
 
 #![deny(rust_2018_idioms)]
+#![warn(missing_docs, missing_debug_implementations)]
 
 use std::io;
 

--- a/actix-files/src/named.rs
+++ b/actix-files/src/named.rs
@@ -309,7 +309,7 @@ impl NamedFile {
         // check last modified
         let not_modified = if !none_match(etag.as_ref(), req) {
             true
-        } else if req.headers().contains_key(&header::IF_NONE_MATCH) {
+        } else if req.headers().contains_key(header::IF_NONE_MATCH) {
             false
         } else if let (Some(ref m), Some(header::IfModifiedSince(ref since))) =
             (last_modified, req.get_header())
@@ -350,7 +350,7 @@ impl NamedFile {
         let mut offset = 0;
 
         // check for range header
-        if let Some(ranges) = req.headers().get(&header::RANGE) {
+        if let Some(ranges) = req.headers().get(header::RANGE) {
             if let Ok(rangesheader) = ranges.to_str() {
                 if let Ok(rangesvec) = HttpRange::parse(rangesheader, length) {
                     length = rangesvec[0].length;

--- a/actix-files/src/path_buf.rs
+++ b/actix-files/src/path_buf.rs
@@ -16,7 +16,7 @@ impl FromStr for PathBufWrap {
 
     fn from_str(path: &str) -> Result<Self, Self::Err> {
         let mut buf = PathBuf::new();
-        
+
         for segment in path.split('/') {
             if segment == ".." {
                 buf.pop();

--- a/actix-files/src/path_buf.rs
+++ b/actix-files/src/path_buf.rs
@@ -1,0 +1,91 @@
+use std::path::PathBuf;
+
+use actix_web::{dev::Payload, FromRequest, HttpRequest};
+use futures_util::future::{ready, Ready};
+
+use crate::error::UriSegmentError;
+
+#[derive(Debug)]
+pub(crate) struct PathBufWrp(PathBuf);
+
+impl PathBufWrp {
+    pub(crate) fn as_pathbuf(&self) -> &PathBuf {
+        &self.0
+    }
+
+    pub(crate) fn get_pathbuf(path: &str) -> Result<Self, UriSegmentError> {
+        let mut buf = PathBuf::new();
+        for segment in path.split('/') {
+            if segment == ".." {
+                buf.pop();
+            } else if segment.starts_with('.') {
+                return Err(UriSegmentError::BadStart('.'));
+            } else if segment.starts_with('*') {
+                return Err(UriSegmentError::BadStart('*'));
+            } else if segment.ends_with(':') {
+                return Err(UriSegmentError::BadEnd(':'));
+            } else if segment.ends_with('>') {
+                return Err(UriSegmentError::BadEnd('>'));
+            } else if segment.ends_with('<') {
+                return Err(UriSegmentError::BadEnd('<'));
+            } else if segment.is_empty() {
+                continue;
+            } else if cfg!(windows) && segment.contains('\\') {
+                return Err(UriSegmentError::BadChar('\\'));
+            } else {
+                buf.push(segment)
+            }
+        }
+
+        Ok(PathBufWrp(buf))
+    }
+}
+
+impl FromRequest for PathBufWrp {
+    type Error = UriSegmentError;
+    type Future = Ready<Result<Self, Self::Error>>;
+    type Config = ();
+
+    fn from_request(req: &HttpRequest, _: &mut Payload) -> Self::Future {
+        ready(PathBufWrp::get_pathbuf(req.match_info().path()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::iter::FromIterator;
+
+    use super::*;
+
+    #[test]
+    fn test_path_buf() {
+        assert_eq!(
+            PathBufWrp::get_pathbuf("/test/.tt").map(|t| t.0),
+            Err(UriSegmentError::BadStart('.'))
+        );
+        assert_eq!(
+            PathBufWrp::get_pathbuf("/test/*tt").map(|t| t.0),
+            Err(UriSegmentError::BadStart('*'))
+        );
+        assert_eq!(
+            PathBufWrp::get_pathbuf("/test/tt:").map(|t| t.0),
+            Err(UriSegmentError::BadEnd(':'))
+        );
+        assert_eq!(
+            PathBufWrp::get_pathbuf("/test/tt<").map(|t| t.0),
+            Err(UriSegmentError::BadEnd('<'))
+        );
+        assert_eq!(
+            PathBufWrp::get_pathbuf("/test/tt>").map(|t| t.0),
+            Err(UriSegmentError::BadEnd('>'))
+        );
+        assert_eq!(
+            PathBufWrp::get_pathbuf("/seg1/seg2/").unwrap().0,
+            PathBuf::from_iter(vec!["seg1", "seg2"])
+        );
+        assert_eq!(
+            PathBufWrp::get_pathbuf("/seg1/../seg2/").unwrap().0,
+            PathBuf::from_iter(vec!["seg2"])
+        );
+    }
+}

--- a/actix-files/src/path_buf.rs
+++ b/actix-files/src/path_buf.rs
@@ -16,6 +16,7 @@ impl FromStr for PathBufWrap {
 
     fn from_str(path: &str) -> Result<Self, Self::Err> {
         let mut buf = PathBuf::new();
+        
         for segment in path.split('/') {
             if segment == ".." {
                 buf.pop();

--- a/actix-files/src/range.rs
+++ b/actix-files/src/range.rs
@@ -1,7 +1,10 @@
 /// HTTP Range header representation.
 #[derive(Debug, Clone, Copy)]
 pub struct HttpRange {
+    /// Start of range.
     pub start: u64,
+
+    /// Length of range.
     pub length: u64,
 }
 

--- a/actix-files/src/range.rs
+++ b/actix-files/src/range.rs
@@ -5,7 +5,7 @@ pub struct HttpRange {
     pub length: u64,
 }
 
-static PREFIX: &str = "bytes=";
+const PREFIX: &str = "bytes=";
 const PREFIX_LEN: usize = 6;
 
 impl HttpRange {

--- a/actix-files/src/service.rs
+++ b/actix-files/src/service.rs
@@ -29,9 +29,7 @@ pub struct FilesService {
     pub(crate) renderer: Rc<DirectoryRenderer>,
     pub(crate) mime_override: Option<Rc<MimeOverride>>,
     pub(crate) file_flags: named::Flags,
-    // FIXME: Should re-visit later.
-    #[allow(clippy::redundant_allocation)]
-    pub(crate) guards: Option<Rc<Box<dyn Guard>>>,
+    pub(crate) guards: Option<Rc<dyn Guard>>,
 }
 
 impl FilesService {

--- a/actix-files/src/service.rs
+++ b/actix-files/src/service.rs
@@ -1,0 +1,165 @@
+use std::{
+    io,
+    path::PathBuf,
+    rc::Rc,
+    task::{Context, Poll},
+};
+
+use actix_service::Service;
+use actix_web::{
+    dev::{ServiceRequest, ServiceResponse},
+    error::Error,
+    guard::Guard,
+    http::{header, Method},
+    HttpResponse,
+};
+use futures_util::future::{ok, Either, LocalBoxFuture, Ready};
+
+use crate::{
+    named, Directory, DirectoryRenderer, FilesError, HttpService, MimeOverride,
+    NamedFile, PathBufWrap,
+};
+
+pub struct FilesService {
+    pub(crate) directory: PathBuf,
+    pub(crate) index: Option<String>,
+    pub(crate) show_index: bool,
+    pub(crate) redirect_to_slash: bool,
+    pub(crate) default: Option<HttpService>,
+    pub(crate) renderer: Rc<DirectoryRenderer>,
+    pub(crate) mime_override: Option<Rc<MimeOverride>>,
+    pub(crate) file_flags: named::Flags,
+    // FIXME: Should re-visit later.
+    #[allow(clippy::redundant_allocation)]
+    pub(crate) guards: Option<Rc<Box<dyn Guard>>>,
+}
+
+impl FilesService {
+    #[allow(clippy::type_complexity)]
+    fn handle_err(
+        &mut self,
+        e: io::Error,
+        req: ServiceRequest,
+    ) -> Either<
+        Ready<Result<ServiceResponse, Error>>,
+        LocalBoxFuture<'static, Result<ServiceResponse, Error>>,
+    > {
+        log::debug!("Files: Failed to handle {}: {}", req.path(), e);
+        if let Some(ref mut default) = self.default {
+            Either::Right(default.call(req))
+        } else {
+            Either::Left(ok(req.error_response(e)))
+        }
+    }
+}
+
+impl Service for FilesService {
+    type Request = ServiceRequest;
+    type Response = ServiceResponse;
+    type Error = Error;
+    #[allow(clippy::type_complexity)]
+    type Future = Either<
+        Ready<Result<Self::Response, Self::Error>>,
+        LocalBoxFuture<'static, Result<Self::Response, Self::Error>>,
+    >;
+
+    fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: ServiceRequest) -> Self::Future {
+        let is_method_valid = if let Some(guard) = &self.guards {
+            // execute user defined guards
+            (**guard).check(req.head())
+        } else {
+            // default behavior
+            matches!(*req.method(), Method::HEAD | Method::GET)
+        };
+
+        if !is_method_valid {
+            return Either::Left(ok(req.into_response(
+                actix_web::HttpResponse::MethodNotAllowed()
+                    .header(header::CONTENT_TYPE, "text/plain")
+                    .body("Request did not meet this resource's requirements."),
+            )));
+        }
+
+        let real_path: PathBufWrap = match req.match_info().path().parse() {
+            Ok(item) => item,
+            Err(e) => return Either::Left(ok(req.error_response(e))),
+        };
+
+        // full file path
+        let path = match self.directory.join(&real_path).canonicalize() {
+            Ok(path) => path,
+            Err(e) => return self.handle_err(e, req),
+        };
+
+        if path.is_dir() {
+            if let Some(ref redir_index) = self.index {
+                if self.redirect_to_slash && !req.path().ends_with('/') {
+                    let redirect_to = format!("{}/", req.path());
+                    return Either::Left(ok(req.into_response(
+                        HttpResponse::Found()
+                            .header(header::LOCATION, redirect_to)
+                            .body("")
+                            .into_body(),
+                    )));
+                }
+
+                let path = path.join(redir_index);
+
+                match NamedFile::open(path) {
+                    Ok(mut named_file) => {
+                        if let Some(ref mime_override) = self.mime_override {
+                            let new_disposition =
+                                mime_override(&named_file.content_type.type_());
+                            named_file.content_disposition.disposition = new_disposition;
+                        }
+
+                        named_file.flags = self.file_flags;
+                        let (req, _) = req.into_parts();
+                        Either::Left(ok(match named_file.into_response(&req) {
+                            Ok(item) => ServiceResponse::new(req, item),
+                            Err(e) => ServiceResponse::from_err(e, req),
+                        }))
+                    }
+                    Err(e) => self.handle_err(e, req),
+                }
+            } else if self.show_index {
+                let dir = Directory::new(self.directory.clone(), path);
+                let (req, _) = req.into_parts();
+                let x = (self.renderer)(&dir, &req);
+                match x {
+                    Ok(resp) => Either::Left(ok(resp)),
+                    Err(e) => Either::Left(ok(ServiceResponse::from_err(e, req))),
+                }
+            } else {
+                Either::Left(ok(ServiceResponse::from_err(
+                    FilesError::IsDirectory,
+                    req.into_parts().0,
+                )))
+            }
+        } else {
+            match NamedFile::open(path) {
+                Ok(mut named_file) => {
+                    if let Some(ref mime_override) = self.mime_override {
+                        let new_disposition =
+                            mime_override(&named_file.content_type.type_());
+                        named_file.content_disposition.disposition = new_disposition;
+                    }
+
+                    named_file.flags = self.file_flags;
+                    let (req, _) = req.into_parts();
+                    match named_file.into_response(&req) {
+                        Ok(item) => {
+                            Either::Left(ok(ServiceResponse::new(req.clone(), item)))
+                        }
+                        Err(e) => Either::Left(ok(ServiceResponse::from_err(e, req))),
+                    }
+                }
+                Err(e) => self.handle_err(e, req),
+            }
+        }
+    }
+}

--- a/actix-files/src/service.rs
+++ b/actix-files/src/service.rs
@@ -1,5 +1,5 @@
 use std::{
-    io,
+    fmt, io,
     path::PathBuf,
     rc::Rc,
     task::{Context, Poll},
@@ -20,6 +20,7 @@ use crate::{
     NamedFile, PathBufWrap,
 };
 
+/// Assembled file serving service.
 pub struct FilesService {
     pub(crate) directory: PathBuf,
     pub(crate) index: Option<String>,
@@ -46,6 +47,12 @@ impl FilesService {
         } else {
             Either::Left(ok(req.error_response(e)))
         }
+    }
+}
+
+impl fmt::Debug for FilesService {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("FilesService")
     }
 }
 


### PR DESCRIPTION
## PR Type
Refactor

## PR Checklist
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
Before getting to fixing the UTF-8 issue, I wanted to get an understanding for this crate and refactoring the parts out of one huge lib file seemed like a good idea. Comes with some code quality improvements.

No functional or test changes, all should still pass. Everything that was previously publicly exported is still so.