### PR TITLE
Update `tinyvec` to 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ time = { version = "0.2.7", default-features = false, features = ["std"] }
 url = "2.1"
 open-ssl = { package = "openssl", version = "0.10", optional = true }
 rust-tls = { package = "rustls", version = "0.18.0", optional = true }
-tinyvec = { version = "0.3", features = ["alloc"] }
+tinyvec = { version = "1", features = ["alloc"] }
 
 [dev-dependencies]
 actix = "0.10.0"


### PR DESCRIPTION
Hi all, `tinyvec` lead here. Just bumping your `tinyvec` usage.

There's *likely* to be no break in practice between 0.3 and 1.0 (IIRC it was a small change in one macro match arm), but we'll let CI find out!