### PR TITLE
remove generic type B for app::App

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,9 +2,15 @@
 
 ## Unreleased - 2020-xx-xx
 ### Changed
-* remove generic type `B` for `app::App` and it's not bound to `actix_http::body::MessageBody` trait anymore. [#1692]
+* Remove generic type `B` for `app::App`, `app_service::{AppInit, AppInitResult, AppInitService}`.
+  Change `middleware::{Compressed, Logger}` to return `ServiceResponse<Body>` directly. [#1692]
+* Add `TrailingSlash::MergeOnly` behaviour to `NormalizePath`, which allow `NormalizePath`
+  to keep the trailing slash's existance as it is. [#1695]
+* Fix `ResourceMap` recursive references when printing/debugging. [#1708]
 
 [#1692]: https://github.com/actix/actix-web/pull/1692
+[#1695]: https://github.com/actix/actix-web/pull/1695
+[#1708]: https://github.com/actix/actix-web/pull/1708
 
 
 ## 3.0.2 - 2020-09-15

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 # Changes
 
 ## Unreleased - 2020-xx-xx
+### Changed
+* remove generic type `B` for `app::App` and it's not bound to `actix_http::body::MessageBody` trait anymore. [#1692]
+
+[#1692]: https://github.com/actix/actix-web/pull/1692
 
 
 ## 3.0.2 - 2020-09-15

--- a/actix-http/src/response.rs
+++ b/actix-http/src/response.rs
@@ -232,7 +232,10 @@ impl<B> Response<B> {
     }
 
     /// Set a body and return previous body value
-    pub(crate) fn replace_body<B2>(self, body: B2) -> (Response<B2>, ResponseBody<B>) {
+    pub(crate) fn replace_body<B2: Unpin>(
+        self,
+        body: B2,
+    ) -> (Response<B2>, ResponseBody<B>) {
         (
             Response {
                 head: self.head,

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,10 +1,9 @@
 use std::cell::RefCell;
 use std::fmt;
 use std::future::Future;
-use std::marker::PhantomData;
 use std::rc::Rc;
 
-use actix_http::body::{Body, MessageBody};
+use actix_http::body::MessageBody;
 use actix_http::Extensions;
 use actix_service::boxed::{self, BoxServiceFactory};
 use actix_service::{
@@ -28,7 +27,7 @@ type HttpNewService = BoxServiceFactory<(), ServiceRequest, ServiceResponse, Err
 
 /// Application builder - structure that follows the builder pattern
 /// for building application instances.
-pub struct App<T, B> {
+pub struct App<T> {
     endpoint: T,
     services: Vec<Box<dyn AppServiceFactory>>,
     default: Option<Rc<HttpNewService>>,
@@ -37,10 +36,9 @@ pub struct App<T, B> {
     data_factories: Vec<FnDataFactory>,
     external: Vec<ResourceDef>,
     extensions: Extensions,
-    _t: PhantomData<B>,
 }
 
-impl App<AppEntry, Body> {
+impl App<AppEntry> {
     /// Create application builder. Application can be configured with a builder-like pattern.
     #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
@@ -54,12 +52,11 @@ impl App<AppEntry, Body> {
             factory_ref: fref,
             external: Vec::new(),
             extensions: Extensions::new(),
-            _t: PhantomData,
         }
     }
 }
 
-impl<T, B> App<T, B>
+impl<T, B> App<T>
 where
     B: MessageBody,
     T: ServiceFactory<
@@ -358,7 +355,6 @@ where
             Error = Error,
             InitError = (),
         >,
-        B1,
     >
     where
         M: Transform<
@@ -379,7 +375,6 @@ where
             factory_ref: self.factory_ref,
             external: self.external,
             extensions: self.extensions,
-            _t: PhantomData,
         }
     }
 
@@ -425,7 +420,6 @@ where
             Error = Error,
             InitError = (),
         >,
-        B1,
     >
     where
         B1: MessageBody,
@@ -441,12 +435,11 @@ where
             factory_ref: self.factory_ref,
             external: self.external,
             extensions: self.extensions,
-            _t: PhantomData,
         }
     }
 }
 
-impl<T, B> IntoServiceFactory<AppInit<T, B>> for App<T, B>
+impl<T, B> IntoServiceFactory<AppInit<T, B>> for App<T>
 where
     B: MessageBody,
     T: ServiceFactory<

--- a/src/middleware/compress.rs
+++ b/src/middleware/compress.rs
@@ -53,11 +53,11 @@ impl Default for Compress {
 
 impl<S, B> Transform<S> for Compress
 where
-    B: MessageBody,
+    B: MessageBody + Unpin + 'static,
     S: Service<Request = ServiceRequest, Response = ServiceResponse<B>, Error = Error>,
 {
     type Request = ServiceRequest;
-    type Response = ServiceResponse<Encoder<B>>;
+    type Response = ServiceResponse<B>;
     type Error = Error;
     type InitError = ();
     type Transform = CompressMiddleware<S>;
@@ -78,11 +78,11 @@ pub struct CompressMiddleware<S> {
 
 impl<S, B> Service for CompressMiddleware<S>
 where
-    B: MessageBody,
+    B: MessageBody + Unpin + 'static,
     S: Service<Request = ServiceRequest, Response = ServiceResponse<B>, Error = Error>,
 {
     type Request = ServiceRequest;
-    type Response = ServiceResponse<Encoder<B>>;
+    type Response = ServiceResponse<B>;
     type Error = Error;
     type Future = CompressResponse<S, B>;
 
@@ -126,10 +126,10 @@ where
 
 impl<S, B> Future for CompressResponse<S, B>
 where
-    B: MessageBody,
+    B: MessageBody + Unpin + 'static,
     S: Service<Request = ServiceRequest, Response = ServiceResponse<B>, Error = Error>,
 {
-    type Output = Result<ServiceResponse<Encoder<B>>, Error>;
+    type Output = Result<ServiceResponse<B>, Error>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.project();


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Refactor


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
This generic type is unnecessary as type `B` is constraint by `T` so we can leave it out of `App`.
Not big improvement as the major block for easy binding/returning `App` is the type `T` but with this PR if no middleware and/or middleware function is warpped it would be pretty easy to bind the `App`. 


<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
