### PR TITLE
Add TrailingSlash::MergeOnly behavior

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 # Changes
 
 ## Unreleased - 2020-xx-xx
+### Changed
+* Add `TrailingSlash::MergeOnly` behaviour to `NormalizePath`, which allow `NormalizePath`
+  to keep the trailing slash's existance as it is. fix [#1694] [#1695]
 
 
 ## 3.0.2 - 2020-09-15

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@
 ## Unreleased - 2020-xx-xx
 ### Changed
 * Add `TrailingSlash::MergeOnly` behaviour to `NormalizePath`, which allow `NormalizePath`
-  to keep the trailing slash's existance as it is. fix [#1694] [#1695]
+  to keep the trailing slash's existance as it is. [#1695]
 
 
 ## 3.0.2 - 2020-09-15

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -48,7 +48,7 @@
 
 * `middleware::NormalizePath` can now also be configured to trim trailing slashes instead of always keeping one.
   It will need `middleware::normalize::TrailingSlash` when being constructed with `NormalizePath::new(...)`,
-  or for an easier migration you can replace `wrap(middleware::NormalizePath)` with `wrap(middleware::NormalizePath::default())`.
+  or for an easier migration you can replace `wrap(middleware::NormalizePath)` with `wrap(middleware::NormalizePath::new(TrailingSlash::MergeOnly))`.
 
 * `HttpServer::maxconn` is renamed to the more expressive `HttpServer::max_connections`.
 

--- a/src/middleware/normalize.rs
+++ b/src/middleware/normalize.rs
@@ -17,8 +17,9 @@ pub enum TrailingSlash {
     /// Always add a trailing slash to the end of the path.
     /// This will require all routes to end in a trailing slash for them to be accessible.
     Always,
-    /// Neither add nor trim slash at end of path. Merge multiple slashes only
-    /// This is compatible with actix-web 2.0
+    /// Only merge any present multiple trailing slashes.
+    ///
+    /// Note: This option provides the best compatibility with the v2 version of this middlware.
     MergeOnly,
     /// Trim trailing slashes from the end of the path.
     Trim,
@@ -36,7 +37,8 @@ impl Default for TrailingSlash {
 /// Performs following:
 ///
 /// - Merges multiple slashes into one.
-/// - Appends a trailing slash if one is not present, or removes one if present, or keep trailing slash's existance as it was, depending on the supplied `TrailingSlash`.
+/// - Appends a trailing slash if one is not present, removes one if present, or keeps trailing
+///   slashes as-is, depending on the supplied `TrailingSlash` variant.
 ///
 /// ```rust
 /// use actix_web::{web, http, middleware, App, HttpResponse};


### PR DESCRIPTION

Behavior of `NormalizePath` in actix-web 2.0 would keep the trailing slash's existance as it is,
which is different from that in 3.0.

This patch add a new option called `MergeOnly` in `TrailingSlash`, which only merge the trailing
slashes into one if there exist. This option makes `NormalizePath` able to be compatible with
actix-web 2.0 and makes it eaiser for users who want to migrate from 2.0 to 3.0.

This will close #1694.

## PR Type

Bug Fix


## PR Checklist
Check your PR fulfills the following:

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview

New option in `TrailingSlash` will makes it easy for developers who want to migrate
from 1.0 / 2.0 to 3.0, because the behavior of this option is compatible with legacy versions.

No breaking changes.

close #1694.
