### PR TITLE
Fix Multipart consuming payload before header checks

### DIFF
--- a/actix-multipart/CHANGES.md
+++ b/actix-multipart/CHANGES.md
@@ -1,6 +1,7 @@
 # Changes
 
 ## Unreleased - 2020-xx-xx
+* Fix multipart consuming payload before header checks #1513
 
 
 ## 3.0.0 - 2020-09-11

--- a/actix-multipart/src/extractor.rs
+++ b/actix-multipart/src/extractor.rs
@@ -36,6 +36,9 @@ impl FromRequest for Multipart {
 
     #[inline]
     fn from_request(req: &HttpRequest, payload: &mut Payload) -> Self::Future {
-        ok(Multipart::new(req.headers(), payload.take()))
+        ok(match Multipart::boundary(req.headers()) {
+            Ok(boundary) => Multipart::from_boundary(boundary, payload.take()),
+            Err(err) => Multipart::from_error(err),
+        })
     }
 }

--- a/actix-multipart/src/server.rs
+++ b/actix-multipart/src/server.rs
@@ -1164,4 +1164,20 @@ mod tests {
         );
         assert_eq!(payload.buf.len(), 0);
     }
+
+    #[actix_rt::test]
+    async fn test_multipart_from_error() {
+        let err = MultipartError::NoContentType;
+        let mut multipart = Multipart::from_error(err);
+        assert!(multipart.next().await.unwrap().is_err())
+    }
+
+    #[actix_rt::test]
+    async fn test_multipart_from_boundary() {
+        let (_, payload) = create_stream();
+        let (_, headers) = create_simple_request_with_header();
+        let boundary = Multipart::boundary(&headers);
+        assert!(boundary.is_ok());
+        let _ = Multipart::from_boundary(boundary.unwrap(), payload);
+    }
 }


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Bug Fix


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Enable headers checks before payload consumption by introducing two new `Multipart` constructor methods:
- **from_boundary:** build Multipart from boundary and stream
- **from_error:** build Multipart for MultipartError

We then refactor the `from_request` extractor to perform a header checks using the existing `Multipart::boundary` method and then call the appropriate constructor based on the result of the checks.




<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
Closes #1513 
