### PR TITLE
Fix cyclic references in ResourceMap

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,9 @@
 ### Changed
 * Add `TrailingSlash::MergeOnly` behaviour to `NormalizePath`, which allow `NormalizePath`
   to keep the trailing slash's existance as it is. [#1695]
+* Fix `ResourceMap` recursive references when printing/debugging. [#1708]
 
+[#1708]: https://github.com/actix/actix-web/pull/1708
 
 ## 3.0.2 - 2020-09-15
 ### Fixed

--- a/src/rmap.rs
+++ b/src/rmap.rs
@@ -394,7 +394,7 @@ mod tests {
         root.finish(Rc::clone(&root));
 
         let output = format!("{:?}", root);
-        assert!(output.starts_with("ResourceMap"));
-        assert!(output.ends_with("}"));
+        assert!(output.starts_with("ResourceMap {"));
+        assert!(output.ends_with(" }"));
     }
 }

--- a/src/rmap.rs
+++ b/src/rmap.rs
@@ -393,6 +393,8 @@ mod tests {
         let root = Rc::new(root);
         root.finish(Rc::clone(&root));
 
-        println!("{:?}", root);
+        let output = format!("{:?}", root);
+        assert!(output.starts_with("ResourceMap"));
+        assert!(output.ends_with("}"));
     }
 }

--- a/src/rmap.rs
+++ b/src/rmap.rs
@@ -383,8 +383,6 @@ mod tests {
             None,
         );
 
-        root.add(&mut ResourceDef::new("/info"), None);
-        root.add(&mut ResourceDef::new("/v{version:[[:digit:]]{1}}"), None);
         root.add(
             &mut ResourceDef::root_prefix("/user/{id}"),
             Some(Rc::new(user_map)),
@@ -392,6 +390,16 @@ mod tests {
 
         let root = Rc::new(root);
         root.finish(Rc::clone(&root));
+
+        // check root has no parent
+        assert!(root.parent.borrow().upgrade().is_none());
+        // check child has parent reference
+        assert!(root.patterns[0].1.is_some());
+        // check child's parent root id matches root's root id
+        assert_eq!(
+            root.patterns[0].1.as_ref().unwrap().root.id(),
+            root.root.id()
+        );
 
         let output = format!("{:?}", root);
         assert!(output.starts_with("ResourceMap {"));

--- a/src/rmap.rs
+++ b/src/rmap.rs
@@ -367,4 +367,32 @@ mod tests {
         assert_eq!(root.match_name("/user/22/"), None);
         assert_eq!(root.match_name("/user/22/post/55"), Some("user_post"));
     }
+
+    #[test]
+    fn bug_fix_issue_1582_debug_print_exits() {
+        // ref: https://github.com/actix/actix-web/issues/1582
+        let mut root = ResourceMap::new(ResourceDef::root_prefix(""));
+
+        let mut user_map = ResourceMap::new(ResourceDef::root_prefix(""));
+        user_map.add(&mut ResourceDef::new("/"), None);
+        user_map.add(&mut ResourceDef::new("/profile"), None);
+        user_map.add(&mut ResourceDef::new("/article/{id}"), None);
+        user_map.add(&mut ResourceDef::new("/post/{post_id}"), None);
+        user_map.add(
+            &mut ResourceDef::new("/post/{post_id}/comment/{comment_id}"),
+            None,
+        );
+
+        root.add(&mut ResourceDef::new("/info"), None);
+        root.add(&mut ResourceDef::new("/v{version:[[:digit:]]{1}}"), None);
+        root.add(
+            &mut ResourceDef::root_prefix("/user/{id}"),
+            Some(Rc::new(user_map)),
+        );
+
+        let root = Rc::new(root);
+        root.finish(Rc::clone(&root));
+
+        println!("{:?}", root);
+    }
 }


### PR DESCRIPTION

<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Bug Fix


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
What
--
Refactor `ResourceMap` struct to remove hard references to parent ResourceMap.

How
--
Assuming the child resource maps are always nested within a parent, then
we can always assume the parent will be there and use a weak reference to
refer back to it.

> A Weak pointer is useful for keeping a temporary reference to the allocation managed by Rc without preventing its inner value from being dropped. It is also used to prevent circular references between Rc pointers, since mutual owning references would never allow either Rc to be dropped. For example, a tree could have strong Rc pointers from parent nodes to children, and Weak pointers from children back to their parents.

[_from the stdlib docs_](https://doc.rust-lang.org/nightly/std/rc/struct.Weak.html)


<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
Closes https://github.com/actix/actix-web/issues/1582