### PR TITLE
Remove Sized Bound for web::Data

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 * Add `TrailingSlash::MergeOnly` behaviour to `NormalizePath`, which allow `NormalizePath`
   to keep the trailing slash's existance as it is. [#1695]
 * Fix `ResourceMap` recursive references when printing/debugging. [#1708]
+* Remove bound `std::marker::Sized` from `web::Data` to support storing `Arc<dyn Trait>` via `web::Data::from` [#1710]
 
 [#1708]: https://github.com/actix/actix-web/pull/1708
 

--- a/src/data.rs
+++ b/src/data.rs
@@ -300,17 +300,17 @@ mod tests {
             fn get_num(&self) -> i32;
         }
         struct A {}
-        impl TestTrait for A{
+        impl TestTrait for A {
             fn get_num(&self) -> i32 {
                 42
             }
         }
         // This works when Sized is required
-        let dyn_arc_box: Arc<Box<dyn TestTrait>> = Arc::new(Box::new(A{}));
+        let dyn_arc_box: Arc<Box<dyn TestTrait>> = Arc::new(Box::new(A {}));
         let data_arc_box = Data::from(dyn_arc_box);
         // This works when Data Sized Bound is removed
-        let dyn_arc: Arc<dyn TestTrait> = Arc::new(A{});
+        let dyn_arc: Arc<dyn TestTrait> = Arc::new(A {});
         let data_arc = Data::from(dyn_arc);
         assert_eq!(data_arc_box.get_num(), data_arc.get_num())
-    }    
+    }
 }


### PR DESCRIPTION
## PR Type
Improvement


## PR Checklist
- [X] Tests for the changes have been added / updated.
- [X] Documentation comments have been added / updated.
- [X] A changelog entry has been made in CHANGES.md
- [x] Format code with the latest stable rustfmt


## Overview
See #1710. It's now possible to use Arc<dyn Trait> as a source for constructing web::Data. Arc itself already supports it, so the Data wrapper should too. Otherwise there's yet another wrapper required.


Closes #1710