### PR TITLE
improve clarity in header setting method names

### DIFF
--- a/actix-http/src/header/common/content_type.rs
+++ b/actix-http/src/header/common/content_type.rs
@@ -1,5 +1,6 @@
-use crate::header::CONTENT_TYPE;
 use mime::Mime;
+
+use crate::header::CONTENT_TYPE;
 
 header! {
     /// `Content-Type` header, defined in
@@ -67,51 +68,51 @@ header! {
 }
 
 impl ContentType {
-    /// A constructor  to easily create a `Content-Type: application/json`
+    /// A constructor to easily create a `Content-Type: application/json`
     /// header.
     #[inline]
     pub fn json() -> ContentType {
         ContentType(mime::APPLICATION_JSON)
     }
 
-    /// A constructor  to easily create a `Content-Type: text/plain;
+    /// A constructor to easily create a `Content-Type: text/plain;
     /// charset=utf-8` header.
     #[inline]
     pub fn plaintext() -> ContentType {
         ContentType(mime::TEXT_PLAIN_UTF_8)
     }
 
-    /// A constructor  to easily create a `Content-Type: text/html` header.
+    /// A constructor to easily create a `Content-Type: text/html` header.
     #[inline]
     pub fn html() -> ContentType {
         ContentType(mime::TEXT_HTML)
     }
 
-    /// A constructor  to easily create a `Content-Type: text/xml` header.
+    /// A constructor to easily create a `Content-Type: text/xml` header.
     #[inline]
     pub fn xml() -> ContentType {
         ContentType(mime::TEXT_XML)
     }
 
-    /// A constructor  to easily create a `Content-Type:
+    /// A constructor to easily create a `Content-Type:
     /// application/www-form-url-encoded` header.
     #[inline]
     pub fn form_url_encoded() -> ContentType {
         ContentType(mime::APPLICATION_WWW_FORM_URLENCODED)
     }
-    /// A constructor  to easily create a `Content-Type: image/jpeg` header.
+    /// A constructor to easily create a `Content-Type: image/jpeg` header.
     #[inline]
     pub fn jpeg() -> ContentType {
         ContentType(mime::IMAGE_JPEG)
     }
 
-    /// A constructor  to easily create a `Content-Type: image/png` header.
+    /// A constructor to easily create a `Content-Type: image/png` header.
     #[inline]
     pub fn png() -> ContentType {
         ContentType(mime::IMAGE_PNG)
     }
 
-    /// A constructor  to easily create a `Content-Type:
+    /// A constructor to easily create a `Content-Type:
     /// application/octet-stream` header.
     #[inline]
     pub fn octet_stream() -> ContentType {

--- a/actix-http/src/header/common/if_range.rs
+++ b/actix-http/src/header/common/if_range.rs
@@ -67,6 +67,7 @@ impl Header for IfRange {
     fn name() -> HeaderName {
         header::IF_RANGE
     }
+
     #[inline]
     fn parse<T>(msg: &T) -> Result<Self, ParseError>
     where
@@ -74,14 +75,18 @@ impl Header for IfRange {
     {
         let etag: Result<EntityTag, _> =
             from_one_raw_str(msg.headers().get(&header::IF_RANGE));
+
         if let Ok(etag) = etag {
             return Ok(IfRange::EntityTag(etag));
         }
+
         let date: Result<HttpDate, _> =
             from_one_raw_str(msg.headers().get(&header::IF_RANGE));
+
         if let Ok(date) = date {
             return Ok(IfRange::Date(date));
         }
+
         Err(ParseError::Header)
     }
 }

--- a/actix-http/src/header/map.rs
+++ b/actix-http/src/header/map.rs
@@ -202,9 +202,6 @@ impl HeaderMap {
 
     /// Inserts a key-value pair into the map.
     ///
-    /// If the map did not previously have this key present, then `None` is
-    /// returned.
-    ///
     /// If the map did have this key present, the new value is associated with
     /// the key and all previous values are removed. **Note** that only a single
     /// one of the previous values is returned. If there are multiple values
@@ -219,9 +216,6 @@ impl HeaderMap {
     }
 
     /// Inserts a key-value pair into the map.
-    ///
-    /// If the map did not previously have this key present, then `false` is
-    /// returned.
     ///
     /// If the map did have this key present, the new value is pushed to the end
     /// of the list of values currently associated with the key. The key is not

--- a/actix-http/src/service.rs
+++ b/actix-http/src/service.rs
@@ -218,7 +218,7 @@ mod openssl {
         U::InitError: fmt::Debug,
         <U::Service as Service>::Future: 'static,
     {
-        /// Create openssl based service
+        /// Create OpenSSL based service
         pub fn openssl(
             self,
             acceptor: SslAcceptor,
@@ -280,7 +280,7 @@ mod rustls {
         U::InitError: fmt::Debug,
         <U::Service as Service>::Future: 'static,
     {
-        /// Create openssl based service
+        /// Create Rustls based service
         pub fn rustls(
             self,
             mut config: ServerConfig,

--- a/actix-http/src/ws/mod.rs
+++ b/actix-http/src/ws/mod.rs
@@ -89,7 +89,7 @@ impl ResponseError for HandshakeError {
     fn error_response(&self) -> Response {
         match *self {
             HandshakeError::GetMethodRequired => Response::MethodNotAllowed()
-                .header(header::ALLOW, "GET")
+                .insert_header(header::ALLOW, "GET")
                 .finish(),
             HandshakeError::NoWebsocketUpgrade => Response::BadRequest()
                 .reason("No WebSocket UPGRADE header found")
@@ -181,8 +181,8 @@ pub fn handshake_response(req: &RequestHead) -> ResponseBuilder {
 
     Response::build(StatusCode::SWITCHING_PROTOCOLS)
         .upgrade("websocket")
-        .header(header::TRANSFER_ENCODING, "chunked")
-        .header(header::SEC_WEBSOCKET_ACCEPT, key.as_str())
+        .insert_header(header::TRANSFER_ENCODING, "chunked")
+        .insert_header(header::SEC_WEBSOCKET_ACCEPT, key.as_str())
         .take()
 }
 

--- a/awc/tests/test_client.rs
+++ b/awc/tests/test_client.rs
@@ -12,7 +12,7 @@ use flate2::Compression;
 use futures_util::future::ok;
 use rand::Rng;
 
-use actix_http::HttpService;
+use actix_http::{http::ContentEncoding, HttpService};
 use actix_http_test::test_server;
 use actix_service::{map_config, pipeline_factory};
 use actix_web::dev::{AppConfig, BodyEncoding};
@@ -438,7 +438,7 @@ async fn test_client_gzip_encoding() {
             let data = e.finish().unwrap();
 
             HttpResponse::Ok()
-                .header("content-encoding", "gzip")
+                .insert_header(header::CONTENT_ENCODING, ContentEncoding::Gzip.as_str())
                 .body(data)
         })))
     });
@@ -461,7 +461,7 @@ async fn test_client_gzip_encoding_large() {
             let data = e.finish().unwrap();
 
             HttpResponse::Ok()
-                .header("content-encoding", "gzip")
+                .insert_header(header::CONTENT_ENCODING, ContentEncoding::Gzip.as_str())
                 .body(data)
         })))
     });
@@ -488,7 +488,7 @@ async fn test_client_gzip_encoding_large_random() {
             e.write_all(&data).unwrap();
             let data = e.finish().unwrap();
             HttpResponse::Ok()
-                .header("content-encoding", "gzip")
+                .insert_header(header::CONTENT_ENCODING, ContentEncoding::Gzip.as_str())
                 .body(data)
         })))
     });
@@ -510,7 +510,7 @@ async fn test_client_brotli_encoding() {
             e.write_all(&data).unwrap();
             let data = e.finish().unwrap();
             HttpResponse::Ok()
-                .header("content-encoding", "br")
+                .insert_header(header::CONTENT_ENCODING, ContentEncoding::Br.as_str())
                 .body(data)
         })))
     });
@@ -537,7 +537,7 @@ async fn test_client_brotli_encoding_large_random() {
             e.write_all(&data).unwrap();
             let data = e.finish().unwrap();
             HttpResponse::Ok()
-                .header("content-encoding", "br")
+                .insert_header(header::CONTENT_ENCODING, ContentEncoding::Br.as_str())
                 .body(data)
         })))
     });

--- a/src/middleware/defaultheaders.rs
+++ b/src/middleware/defaultheaders.rs
@@ -180,8 +180,11 @@ mod tests {
 
         let req = TestRequest::default().to_srv_request();
         let srv = |req: ServiceRequest| {
-            ok(req
-                .into_response(HttpResponse::Ok().header(CONTENT_TYPE, "0002").finish()))
+            ok(req.into_response(
+                HttpResponse::Ok()
+                    .insert_header(CONTENT_TYPE, "0002")
+                    .finish(),
+            ))
         };
         let mut mw = DefaultHeaders::new()
             .header(CONTENT_TYPE, "0001")

--- a/src/middleware/logger.rs
+++ b/src/middleware/logger.rs
@@ -522,7 +522,7 @@ mod tests {
         let srv = |req: ServiceRequest| {
             ok(req.into_response(
                 HttpResponse::build(StatusCode::OK)
-                    .header("X-Test", "ttt")
+                    .insert_header("X-Test", "ttt")
                     .finish(),
             ))
         };

--- a/src/service.rs
+++ b/src/service.rs
@@ -626,7 +626,7 @@ mod tests {
         assert!(s.contains("test=1"));
         assert!(s.contains("x-test"));
 
-        let res = HttpResponse::Ok().header("x-test", "111").finish();
+        let res = HttpResponse::Ok().insert_header("x-test", "111").finish();
         let res = TestRequest::post()
             .uri("/index.html?test=1")
             .to_srv_response(res);


### PR DESCRIPTION
## PR Type
Refactor

## PR Checklist
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [ ] Format code with the latest stable rustfmt


## Overview
- `ResponseBuilder`
  - Deprecate `header`. Rename to `append_header` for immediate clarity on append behavior.
  - Deprecate `set_header`. Rename to `insert_header` for naming parity with `HeaderMap` method.
  - Show `set` in docs. Kinda special method; not sure what to do about this yet. Seems useful and would be a shame to deprecate/remove it. However, `set` is kinda meh as a method name but obivously renaming wouldn't be able to use any of the above existing or renamed names.
