### PR TITLE
Fix/suppress clippy warnings

### DIFF
--- a/actix-http/src/lib.rs
+++ b/actix-http/src/lib.rs
@@ -7,6 +7,7 @@
     clippy::new_without_default,
     clippy::borrow_interior_mutable_const
 )]
+#![allow(clippy::manual_strip)] // Allow this to keep MSRV(1.42).
 
 #[macro_use]
 extern crate log;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,7 @@
 
 #![deny(rust_2018_idioms)]
 #![allow(clippy::needless_doctest_main, clippy::type_complexity)]
+#![allow(clippy::rc_buffer)] // FXIME: We should take a closer look for the warnings at some point.
 #![doc(html_logo_url = "https://actix.rs/img/logo.png")]
 #![doc(html_favicon_url = "https://actix.rs/favicon.ico")]
 

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -58,7 +58,6 @@ type BoxedResponse = LocalBoxFuture<'static, Result<ServiceResponse, Error>>;
 ///  * /{project_id}/path1 - responds to all http method
 ///  * /{project_id}/path2 - `GET` requests
 ///  * /{project_id}/path3 - `HEAD` requests
-///
 pub struct Scope<T = ScopeEndpoint> {
     endpoint: T,
     rdef: String,

--- a/src/types/json.rs
+++ b/src/types/json.rs
@@ -283,7 +283,7 @@ impl JsonConfig {
     fn from_req(req: &HttpRequest) -> &Self {
         req.app_data::<Self>()
             .or_else(|| req.app_data::<web::Data<Self>>().map(|d| d.as_ref()))
-            .unwrap_or_else(|| &DEFAULT_CONFIG)
+            .unwrap_or(&DEFAULT_CONFIG)
     }
 }
 

--- a/src/types/payload.rs
+++ b/src/types/payload.rs
@@ -284,7 +284,7 @@ impl PayloadConfig {
     fn from_req(req: &HttpRequest) -> &Self {
         req.app_data::<Self>()
             .or_else(|| req.app_data::<web::Data<Self>>().map(|d| d.as_ref()))
-            .unwrap_or_else(|| &DEFAULT_CONFIG)
+            .unwrap_or(&DEFAULT_CONFIG)
     }
 }
 


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Refactor


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview

This should remove all the warning annotations from clippy-check. One lint, `rc_buffer` is suppressed with a FIXME to make this PR small.