### PR TITLE
Update return type of Extensions::insert to match documented behavior

### DIFF
--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## Unreleased - 2020-xx-xx
 
+### Changed
+
+* Change the return type of `Extensions::insert` from `()` to `Option<T>`
 
 ## 2.0.0 - 2020-09-11
 * No significant changes from `2.0.0-beta.4`.

--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -3,8 +3,7 @@
 ## Unreleased - 2020-xx-xx
 
 ### Changed
-
-* Change the return type of `Extensions::insert` from `()` to `Option<T>`
+* Change the return type of `Extensions::insert` from `()` to `Option<T>` [#1721]
 
 ## 2.0.0 - 2020-09-11
 * No significant changes from `2.0.0-beta.4`.

--- a/actix-http/src/extensions.rs
+++ b/actix-http/src/extensions.rs
@@ -24,8 +24,10 @@ impl Extensions {
     ///
     /// If a extension of this type already existed, it will
     /// be returned.
-    pub fn insert<T: 'static>(&mut self, val: T) {
-        self.map.insert(TypeId::of::<T>(), Box::new(val));
+    pub fn insert<T: 'static>(&mut self, val: T) -> Option<T> {
+        self.map
+            .insert(TypeId::of::<T>(), Box::new(val))
+            .and_then(|boxed| boxed.downcast().ok().map(|boxed| *boxed))
     }
 
     /// Check if container contains entry

--- a/actix-http/src/extensions.rs
+++ b/actix-http/src/extensions.rs
@@ -76,6 +76,19 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_insert() {
+        let mut map = Extensions::new();
+
+        let prev = map.insert("foo");
+        assert_eq!(prev, None);
+        assert_eq!(map.get::<&str>().copied(), Some("foo"));
+
+        let prev = map.insert("bar");
+        assert_eq!(prev, Some("foo"));
+        assert_eq!(map.get::<&str>().copied(), Some("bar"));
+    }
+
+    #[test]
     fn test_remove() {
         let mut map = Extensions::new();
 

--- a/actix-http/src/helpers.rs
+++ b/actix-http/src/helpers.rs
@@ -63,7 +63,7 @@ pub(crate) struct Data<T>(pub(crate) T);
 
 impl<T: Clone + 'static> DataFactory for Data<T> {
     fn set(&self, ext: &mut Extensions) {
-        ext.insert(self.0.clone())
+        ext.insert(self.0.clone());
     }
 }
 


### PR DESCRIPTION
This is a breaking change, but Extensions::insert was strictly less useful with the previous behavior.

## PR Type

Not sure whether to consider this a bug fix or feature :shrug: 

## PR Checklist

- [x] Tests for the changes have been added / updated.
- [ ] ~~Documentation comments have been added / updated.~~ N/A
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt

## Overview

Before, `Extensions::insert` did not return anything, contradicting its documentation. Now it does return the previously present value, if any. This is a breaking change.