### PR TITLE
Add web::ReqData extractor

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -19,12 +19,11 @@ pub(crate) type FnDataFactory =
 
 /// Application data.
 ///
-/// Application data is an arbitrary data attached to the app.
-/// Application data is available to all routes and could be added
-/// during application configuration process
-/// with `App::data()` method.
+/// Application data is a piece of arbitrary data attached to the app.
+/// Application data is available to all routes and can be added
+/// during the application configuration process via `App::data()`.
 ///
-/// Application data could be accessed by using `Data<T>`
+/// Application data can be accessed by using `Data<T>`
 /// extractor where `T` is data type.
 ///
 /// **Note**: http server accepts an application factory rather than
@@ -32,9 +31,7 @@ pub(crate) type FnDataFactory =
 /// instance for each thread, thus application data must be constructed
 /// multiple times. If you want to share data between different
 /// threads, a shareable object should be used, e.g. `Send + Sync`. Application
-/// data does not need to be `Send` or `Sync`. Internally `Data` type
-/// uses `Arc`. if your data implements `Send` + `Sync` traits you can
-/// use `web::Data::new()` and avoid double `Arc`.
+/// data does not need to be `Send` or `Sync`. Internally `Data` uses `Arc`.
 ///
 /// If route data is not set for a handler, using `Data<T>` extractor would
 /// cause *Internal Server Error* response.
@@ -47,7 +44,7 @@ pub(crate) type FnDataFactory =
 ///     counter: usize,
 /// }
 ///
-/// /// Use `Data<T>` extractor to access data in handler.
+/// /// Use the `Data<T>` extractor to access data in a handler.
 /// async fn index(data: web::Data<Mutex<MyData>>) -> impl Responder {
 ///     let mut data = data.lock().unwrap();
 ///     data.counter += 1;
@@ -70,10 +67,6 @@ pub struct Data<T: ?Sized>(Arc<T>);
 
 impl<T> Data<T> {
     /// Create new `Data` instance.
-    ///
-    /// Internally `Data` type uses `Arc`. if your data implements
-    /// `Send` + `Sync` traits you can use `web::Data::new()` and
-    /// avoid double `Arc`.
     pub fn new(state: T) -> Data<T> {
         Data(Arc::new(state))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,7 @@ mod handler;
 mod info;
 pub mod middleware;
 mod request;
+mod request_data;
 mod resource;
 mod responder;
 mod rmap;

--- a/src/request_data.rs
+++ b/src/request_data.rs
@@ -1,0 +1,51 @@
+use std::ops::{Deref, DerefMut};
+
+use actix_http::error::{Error, ErrorInternalServerError};
+use futures_util::future;
+
+use crate::{dev::Payload, FromRequest, HttpRequest};
+
+/// Request data.
+///
+/// Request data is a piece of arbitrary data attached to a request.
+///
+/// It can be set via [`HttpMessage::extensions_mut`].
+///
+/// [`HttpMessage::extensions_mut`]: crate::HttpMessage::extensions_mut
+#[derive(Clone, Debug)]
+pub struct ReqData<T: Clone + 'static>(pub T);
+
+impl<T: Clone + 'static> Deref for ReqData<T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        &self.0
+    }
+}
+
+impl<T: Clone + 'static> DerefMut for ReqData<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<T: Clone + 'static> FromRequest for ReqData<T> {
+    type Config = ();
+    type Error = Error;
+    type Future = future::Ready<Result<Self, Error>>;
+
+    fn from_request(req: &HttpRequest, _: &mut Payload) -> Self::Future {
+        if let Some(st) = req.extensions().get::<T>() {
+            future::ok(ReqData(st.clone()))
+        } else {
+            log::debug!(
+                "Failed to construct App-level ReqData extractor. \
+                 Request path: {:?}",
+                req.path()
+            );
+            future::err(ErrorInternalServerError(
+                "Missing expected request extension data",
+            ))
+        }
+    }
+}

--- a/src/web.rs
+++ b/src/web.rs
@@ -19,6 +19,7 @@ use crate::service::WebService;
 pub use crate::config::ServiceConfig;
 pub use crate::data::Data;
 pub use crate::request::HttpRequest;
+pub use crate::request_data::ReqData;
 pub use crate::types::*;
 
 /// Create resource for a specific path.


### PR DESCRIPTION
## PR Type

Feature

## PR Checklist

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt

## Overview

Adds a `ReqData` extractor for request data / request extensions, analogous to `web::Data`.