### PR TITLE
use idenity encoding on client if no compression features are enabled

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,14 +1,9 @@
 # Changes
 
 ## Unreleased - 2020-xx-xx
-
 * Implement Logger middleware regex exclude pattern [#1723]
+
 [#1723]: https://github.com/actix/actix-web/pull/1723
-
-### Fixed
-
-* awc now uses `Accept-Encoding: identity` instead of `Accept-Encoding: br` when no compression feature is enabled
-[#1737](https://github.com/actix/actix-web/pull/1737)
 
 ## 3.1.0 - 2020-09-29
 ### Changed

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased - 2020-xx-xx
 
+### Fixed
+
+* awc now uses `Accept-Encoding: identity` instead of `Accept-Encoding: br` when no compression feature is enabled
+[#1737](https://github.com/actix/actix-web/pull/1737)
 
 ## 3.1.0 - 2020-09-29
 ### Changed

--- a/awc/CHANGES.md
+++ b/awc/CHANGES.md
@@ -1,6 +1,10 @@
 # Changes
 
 ## Unreleased - 2020-xx-xx
+### Fixed
+* Use `Accept-Encoding: identity` instead of `Accept-Encoding: br` when no compression feature is enabled [#1737]
+
+[#1737]: https://github.com/actix/actix-web/pull/1737
 
 
 ## 2.0.0 - 2020-09-11

--- a/awc/Cargo.toml
+++ b/awc/Cargo.toml
@@ -44,6 +44,7 @@ actix-rt = "1.0.0"
 
 base64 = "0.12"
 bytes = "0.5.3"
+cfg-if = "1.0"
 derive_more = "0.99.2"
 futures-core = { version = "0.3.5", default-features = false }
 log =" 0.4"

--- a/awc/src/request.rs
+++ b/awc/src/request.rs
@@ -23,8 +23,17 @@ use crate::ClientConfig;
 
 #[cfg(any(feature = "flate2-zlib", feature = "flate2-rust"))]
 const HTTPS_ENCODING: &str = "br, gzip, deflate";
-#[cfg(not(any(feature = "flate2-zlib", feature = "flate2-rust")))]
+#[cfg(all(
+    not(any(feature = "flate2-zlib", feature = "flate2-rust")),
+    feature = "compress"
+))]
 const HTTPS_ENCODING: &str = "br";
+#[cfg(not(any(
+    feature = "flate2-zlib",
+    feature = "flate2-rust",
+    feature = "compress"
+)))]
+const HTTPS_ENCODING: &str = "identity";
 
 /// An HTTP Client request builder
 ///

--- a/awc/src/request.rs
+++ b/awc/src/request.rs
@@ -21,19 +21,15 @@ use crate::frozen::FrozenClientRequest;
 use crate::sender::{PrepForSendingError, RequestSender, SendClientRequest};
 use crate::ClientConfig;
 
-#[cfg(any(feature = "flate2-zlib", feature = "flate2-rust"))]
-const HTTPS_ENCODING: &str = "br, gzip, deflate";
-#[cfg(all(
-    not(any(feature = "flate2-zlib", feature = "flate2-rust")),
-    feature = "compress"
-))]
-const HTTPS_ENCODING: &str = "br";
-#[cfg(not(any(
-    feature = "flate2-zlib",
-    feature = "flate2-rust",
-    feature = "compress"
-)))]
-const HTTPS_ENCODING: &str = "identity";
+cfg_if::cfg_if! {
+    if #[cfg(any(feature = "flate2-zlib", feature = "flate2-rust"))] {
+        const HTTPS_ENCODING: &str = "br, gzip, deflate";
+    } else if #[cfg(feature = "compress")] {
+        const HTTPS_ENCODING: &str = "br";
+    } else {
+        const HTTPS_ENCODING: &str = "identity";
+    }
+}
 
 /// An HTTP Client request builder
 ///


### PR DESCRIPTION
## PR Type
Bugfix

## Overview
Fixes https://github.com/actix/actix-web/issues/1731 by using `Accept-Encoding: identity` when no compression feature is enabled.
