### PR TITLE
Skip some tests that cause ICE on nightly

### DIFF
--- a/actix-web-codegen/tests/trybuild.rs
+++ b/actix-web-codegen/tests/trybuild.rs
@@ -6,9 +6,8 @@ fn compile_macros() {
     t.compile_fail("tests/trybuild/simple-fail.rs");
 
     t.pass("tests/trybuild/route-ok.rs");
-    t.compile_fail("tests/trybuild/route-duplicate-method-fail.rs");
-    t.compile_fail("tests/trybuild/route-unexpected-method-fail.rs");
 
+    test_route_duplicate_unexpected_method(&t);
     test_route_missing_method(&t)
 }
 
@@ -25,3 +24,13 @@ fn test_route_missing_method(t: &trybuild::TestCases) {
 
 #[rustversion::nightly]
 fn test_route_missing_method(_t: &trybuild::TestCases) {}
+
+// FIXME: Re-test them on nightly once rust-lang/rust#77993 is fixed.
+#[rustversion::not(nightly)]
+fn test_route_duplicate_unexpected_method(t: &trybuild::TestCases) {
+    t.compile_fail("tests/trybuild/route-duplicate-method-fail.rs");
+    t.compile_fail("tests/trybuild/route-unexpected-method-fail.rs");
+}
+
+#[rustversion::nightly]
+fn test_route_duplicate_unexpected_method(_t: &trybuild::TestCases) {}


### PR DESCRIPTION
This skips the tests that cause ICE on nightly.
I'm not sure when the issue is fixed (it's marked as `P-high` though) so I think it makes sense to skip them meanwhile.