### PR TITLE
Print unconfigured `Data<T>` type when attempting extraction

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,8 +2,10 @@
 
 ## Unreleased - 2020-xx-xx
 * Implement Logger middleware regex exclude pattern [#1723]
+* Print unconfigured AppData type [#1743]
 
 [#1723]: https://github.com/actix/actix-web/pull/1723
+[#1743]: https://github.com/actix/actix-web/pull/1743
 
 ## 3.1.0 - 2020-09-29
 ### Changed

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## Unreleased - 2020-xx-xx
 * Implement Logger middleware regex exclude pattern [#1723]
-* Print unconfigured AppData type [#1743]
+* Print unconfigured `Data<T>` type when attempting extraction. [#1743]
 
 [#1723]: https://github.com/actix/actix-web/pull/1723
 [#1743]: https://github.com/actix/actix-web/pull/1743

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,3 +1,4 @@
+use std::any::type_name;
 use std::ops::Deref;
 use std::sync::Arc;
 
@@ -121,8 +122,9 @@ impl<T: ?Sized + 'static> FromRequest for Data<T> {
         } else {
             log::debug!(
                 "Failed to construct App-level Data extractor. \
-                 Request path: {:?}",
-                req.path()
+                 Request path: {:?} (type: {})",
+                req.path(),
+                type_name::<T>(),
             );
             err(ErrorInternalServerError(
                 "App data is not configured, to configure use App::data()",


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Other


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] A changelog entry has been made for the appropriate packages.
- [X] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
This PR aims to help developers when facing the 

```
Failed to construct App-level Data extractor. Request path: "/your-endpoint"
```

Now, it will print something like the following:

```
Failed to construct App-level Data extractor. Request path: "/your-endpoint" (type = THE_TYPE_WILL_APPEAR_HERE)
```


<!-- Emphasize any breaking changes. -->

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->