### PR TITLE
Deprecate functions for following redirects

### DIFF
--- a/awc/src/builder.rs
+++ b/awc/src/builder.rs
@@ -17,8 +17,6 @@ use crate::{Client, ClientConfig};
 /// builder-like pattern.
 pub struct ClientBuilder {
     default_headers: bool,
-    allow_redirects: bool,
-    max_redirects: usize,
     max_http_version: Option<http::Version>,
     stream_window_size: Option<u32>,
     conn_window_size: Option<u32>,
@@ -37,8 +35,6 @@ impl ClientBuilder {
     pub fn new() -> Self {
         ClientBuilder {
             default_headers: true,
-            allow_redirects: true,
-            max_redirects: 10,
             headers: HeaderMap::new(),
             timeout: Some(Duration::from_secs(5)),
             connector: None,
@@ -77,9 +73,9 @@ impl ClientBuilder {
 
     /// Do not follow redirects.
     ///
-    /// Redirects are allowed by default.
+    /// Deprecated: this is a noop. Redirects aren't followed.
+    #[deprecated(since="2.0.1", note="this is a noop")]
     pub fn disable_redirects(mut self) -> Self {
-        self.allow_redirects = false;
         self
     }
 
@@ -110,9 +106,9 @@ impl ClientBuilder {
 
     /// Set max number of redirects.
     ///
-    /// Max redirects is set to 10 by default.
+    /// Deprecated: this is a noop. Redirects aren' followed.
+    #[deprecated(since="2.0.1", note="this is a noop")]
     pub fn max_redirects(mut self, num: usize) -> Self {
-        self.max_redirects = num;
         self
     }
 


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Documentation


## PR Checklist
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt

## Overview

I'm planning on adding support for following redirects. For the time being, here's a PR that adds deprecation notices to the
builder functions that reference redirects since they are effectively no-ops for the time being.

Related to #1571