### PR TITLE
Re-export bytes::Buf and bytes::BufMut as well

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,10 +7,12 @@
 
 ### Changed
 * Print non-configured `Data<T>` type when attempting extraction. [#1743]
+* Re-export bytes::Buf{Mut} in web module. [#1750]
 
 [#1723]: https://github.com/actix/actix-web/pull/1723
 [#1743]: https://github.com/actix/actix-web/pull/1743
 [#1748]: https://github.com/actix/actix-web/pull/1748
+[#1750]: https://github.com/actix/actix-web/pull/1750
 
 
 ## 3.1.0 - 2020-09-29

--- a/src/web.rs
+++ b/src/web.rs
@@ -4,7 +4,7 @@ use actix_router::IntoPattern;
 use std::future::Future;
 
 pub use actix_http::Response as HttpResponse;
-pub use bytes::{Bytes, BytesMut};
+pub use bytes::{Buf, BufMut, Bytes, BytesMut};
 pub use futures_channel::oneshot::Canceled;
 
 use crate::error::BlockingError;


### PR DESCRIPTION
## PR Type

Other


## PR Checklist
Check your PR fulfills the following:

- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt

## Overview

actix-web is re-exporting `bytes::Bytes` and `bytes::BytesMut`, however it does not re-export the traits `bytes::Buf` and `bytes::BufMut` which are required to actually do something with the types in applications which means that users of those types have to import the traits from `bytes` directly which (as it currently the case) can cause version clashes. By re-exporting the traits as well we can eliminate this stumbling block and simplify the use.

Signed-off-by: Daniel Egger <daniel.egger@axiros.com>