### PR TITLE
Add redirect support

### DIFF
--- a/awc/CHANGES.md
+++ b/awc/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## Unreleased - 2020-xx-xx
 
+### Fixed
+* Follows redirects and respects `disable_redirects` and `max_redirects` options.
+
 
 ## 2.0.3 - 2020-11-29
 ### Fixed

--- a/awc/Cargo.toml
+++ b/awc/Cargo.toml
@@ -56,6 +56,7 @@ serde_json = "1.0"
 serde_urlencoded = "0.7"
 open-ssl = { version = "0.10", package = "openssl", optional = true }
 rust-tls = { version = "0.18.0", package = "rustls", optional = true, features = ["dangerous_configuration"] }
+if_chain = "1.0.1"
 
 [dev-dependencies]
 actix-connect = { version = "2.0.0", features = ["openssl"] }

--- a/awc/Cargo.toml
+++ b/awc/Cargo.toml
@@ -57,6 +57,7 @@ serde_urlencoded = "0.7"
 open-ssl = { version = "0.10", package = "openssl", optional = true }
 rust-tls = { version = "0.18.0", package = "rustls", optional = true, features = ["dangerous_configuration"] }
 if_chain = "1.0.1"
+url = "2.1.1"
 
 [dev-dependencies]
 actix-connect = { version = "2.0.0", features = ["openssl"] }

--- a/awc/src/builder.rs
+++ b/awc/src/builder.rs
@@ -17,7 +17,6 @@ use crate::{Client, ClientConfig};
 /// builder-like pattern.
 pub struct ClientBuilder {
     default_headers: bool,
-    allow_redirects: bool,
     max_redirects: usize,
     max_http_version: Option<http::Version>,
     stream_window_size: Option<u32>,
@@ -37,7 +36,6 @@ impl ClientBuilder {
     pub fn new() -> Self {
         ClientBuilder {
             default_headers: true,
-            allow_redirects: true,
             max_redirects: 10,
             headers: HeaderMap::new(),
             timeout: Some(Duration::from_secs(5)),
@@ -81,7 +79,7 @@ impl ClientBuilder {
     ///
     /// Redirects are allowed by default.
     pub fn disable_redirects(mut self) -> Self {
-        self.allow_redirects = false;
+        self.max_redirects = 0;
         self
     }
 

--- a/awc/src/builder.rs
+++ b/awc/src/builder.rs
@@ -191,6 +191,7 @@ impl ClientBuilder {
         let config = ClientConfig {
             headers: self.headers,
             timeout: self.timeout,
+            max_redirects: self.max_redirects,
             connector,
         };
         Client(Rc::new(config))

--- a/awc/src/builder.rs
+++ b/awc/src/builder.rs
@@ -56,7 +56,9 @@ impl ClientBuilder {
         <T::Response as Connection>::Future: 'static,
         T::Future: 'static,
     {
-        self.connector = Some(RefCell::new(Box::new(ConnectorWrapper(connector))));
+        self.connector = Some(RefCell::new(Box::new(ConnectorWrapper(Rc::new(
+            RefCell::new(connector),
+        )))));
         self
     }
 
@@ -182,9 +184,9 @@ impl ClientBuilder {
             if let Some(val) = self.stream_window_size {
                 connector = connector.initial_window_size(val)
             };
-            RefCell::new(
-                Box::new(ConnectorWrapper(connector.finish())) as Box<dyn Connect>
-            )
+            RefCell::new(Box::new(ConnectorWrapper(Rc::new(RefCell::new(
+                connector.finish(),
+            )))) as Box<dyn Connect>)
         };
         let config = ClientConfig {
             headers: self.headers,

--- a/awc/src/connect.rs
+++ b/awc/src/connect.rs
@@ -142,13 +142,10 @@ where
                     Ok((resphead, payload)) => {
                         if_chain! {
                             if resphead.status.is_redirection();
+                            if redirect_count < max_redirects;
                             if let Some(location_value) = resphead.headers.get(actix_http::http::header::LOCATION);
                             if let Ok(location_str) = location_value.to_str();
                             then {
-                                if redirect_count >= max_redirects {
-                                     // TODO: need a better error
-                                    return Err(SendRequestError::Timeout);
-                                }
                                 if resphead.status == actix_http::http::StatusCode::SEE_OTHER {
                                     reqhead.method = actix_http::http::Method::GET;
                                     reqbody = Body::None;

--- a/awc/src/connect.rs
+++ b/awc/src/connect.rs
@@ -118,6 +118,7 @@ where
                     Body::Message(_) => Body::Empty,
                 };
 
+                let uri = head.uri.clone();
                 let mut reqhead = RequestHead::default();
                 reqhead.method = head.method.clone();
                 reqhead.version = head.version.clone();
@@ -144,7 +145,12 @@ where
                                     reqhead.method = actix_http::http::Method::GET;
                                     reqbody = Body::None;
                                 }
-                                reqhead.uri = location_uri;
+                                let mut parts = location_uri.clone().into_parts();
+                                if location_uri.authority().is_none() {
+                                    parts.scheme = Some(uri.scheme().unwrap().clone());
+                                    parts.authority = Some(uri.authority().unwrap().clone());
+                                }
+                                reqhead.uri = Uri::from_parts(parts).unwrap();
                                 return deal_with_redirects(
                                     backend.clone(),
                                     reqhead,

--- a/awc/src/lib.rs
+++ b/awc/src/lib.rs
@@ -153,9 +153,9 @@ pub(crate) struct ClientConfig {
 impl Default for Client {
     fn default() -> Self {
         Client(Rc::new(ClientConfig {
-            connector: RefCell::new(Box::new(ConnectorWrapper(
+            connector: RefCell::new(Box::new(ConnectorWrapper(Rc::new(RefCell::new(
                 Connector::new().finish(),
-            ))),
+            ))))),
             headers: HeaderMap::new(),
             timeout: Some(Duration::from_secs(5)),
         }))

--- a/awc/src/lib.rs
+++ b/awc/src/lib.rs
@@ -148,6 +148,7 @@ pub(crate) struct ClientConfig {
     pub(crate) connector: RefCell<Box<dyn Connect>>,
     pub(crate) headers: HeaderMap,
     pub(crate) timeout: Option<Duration>,
+    pub(crate) max_redirects: usize,
 }
 
 impl Default for Client {
@@ -158,6 +159,7 @@ impl Default for Client {
             ))))),
             headers: HeaderMap::new(),
             timeout: Some(Duration::from_secs(5)),
+            max_redirects: 10,
         }))
     }
 }

--- a/awc/src/sender.rs
+++ b/awc/src/sender.rs
@@ -186,7 +186,7 @@ impl RequestSender {
 
         let fut = match self {
             RequestSender::Owned(head) => {
-                connector.send_request(head, body.into(), addr)
+                connector.send_request(head, body.into(), addr, config.max_redirects)
             }
             RequestSender::Rc(head, extra_headers) => {
                 connector.send_request_extra(head, extra_headers, body.into(), addr)


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Feature

## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt

TODO:

- [x] allow configuration (enable/disable and max redirects)
- [x] trigger body resend per status code
- [x] trigger method switching per status code
- [ ] document that won't resend streamed bodies
- [ ] should also work with send_request_extra
- [ ] sanitize headers on cross-origin redirect
- [x] refactor unwraps out

## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

This makes AWC follow redirects by default and allows configuration to disable it.

This may be a *breaking change* because, even if the documentation says redirects are followed by default, they weren't followed in practice.

<!-- If this PR fixes or closes an issue, reference it here. -->
Closes #1571
