### PR TITLE
Adding app_data to ServiceConfig

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 ### Added
 * Implement `exclude_regex` for Logger middleware. [#1723]
 * Add request-local data extractor `web::ReqData`. [#1748]
+* Add `app_data` to `ServiceConfig`. [#1757]
 
 ### Changed
 * Print non-configured `Data<T>` type when attempting extraction. [#1743]

--- a/actix-http/src/extensions.rs
+++ b/actix-http/src/extensions.rs
@@ -62,9 +62,9 @@ impl Extensions {
         self.map.clear();
     }
 
-    /// Extends it with the content for another `Extensions`
-    pub fn extend(&mut self, extensions: Extensions) {
-        self.map.extend(extensions.map);
+    /// Extends self with the items from another `Extensions`.
+    pub fn extend(&mut self, other: Extensions) {
+        self.map.extend(other.map);
     }
 }
 

--- a/actix-http/src/extensions.rs
+++ b/actix-http/src/extensions.rs
@@ -61,6 +61,11 @@ impl Extensions {
     pub fn clear(&mut self) {
         self.map.clear();
     }
+
+    /// Extends it with the content for another `Extensions`
+    pub fn extend(&mut self, extensions: Extensions) {
+        self.map.extend(extensions.map);
+    }
 }
 
 impl fmt::Debug for Extensions {

--- a/actix-http/src/extensions.rs
+++ b/actix-http/src/extensions.rs
@@ -66,6 +66,11 @@ impl Extensions {
     pub fn extend(&mut self, other: Extensions) {
         self.map.extend(other.map);
     }
+
+    /// Returns `true` if no extension is registered
+    pub fn is_empty(&self) -> bool {
+        self.map.is_empty()
+    }
 }
 
 impl fmt::Debug for Extensions {
@@ -93,6 +98,8 @@ mod tests {
     fn test_clear() {
         let mut map = Extensions::new();
 
+        assert!(map.is_empty());
+
         map.insert::<i8>(8);
         map.insert::<i16>(16);
         map.insert::<i32>(32);
@@ -100,12 +107,14 @@ mod tests {
         assert!(map.contains::<i8>());
         assert!(map.contains::<i16>());
         assert!(map.contains::<i32>());
+        assert!(!map.is_empty());
 
         map.clear();
 
         assert!(!map.contains::<i8>());
         assert!(!map.contains::<i16>());
         assert!(!map.contains::<i32>());
+        assert!(map.is_empty());
 
         map.insert::<i8>(10);
         assert_eq!(*map.get::<i8>().unwrap(), 10);
@@ -182,5 +191,35 @@ mod tests {
 
         assert_eq!(extensions.get::<bool>(), None);
         assert_eq!(extensions.get(), Some(&MyType(10)));
+    }
+
+    #[test]
+    fn test_extend() {
+        #[derive(Debug, PartialEq)]
+        struct MyType(i32);
+
+        let mut extensions = Extensions::new();
+
+        extensions.insert(5i32);
+        extensions.insert(MyType(10));
+
+        let mut other = Extensions::new();
+
+        other.insert(15i32);
+        other.insert(20u8);
+
+        extensions.extend(other);
+
+        assert_eq!(extensions.get(), Some(&15i32));
+        assert_eq!(extensions.get_mut(), Some(&mut 15i32));
+
+        assert_eq!(extensions.remove::<i32>(), Some(15i32));
+        assert!(extensions.get::<i32>().is_none());
+
+        assert_eq!(extensions.get::<bool>(), None);
+        assert_eq!(extensions.get(), Some(&MyType(10)));
+        
+        assert_eq!(extensions.get(), Some(&20u8));
+        assert_eq!(extensions.get_mut(), Some(&20u8));
     }
 }

--- a/actix-http/src/extensions.rs
+++ b/actix-http/src/extensions.rs
@@ -218,7 +218,7 @@ mod tests {
 
         assert_eq!(extensions.get::<bool>(), None);
         assert_eq!(extensions.get(), Some(&MyType(10)));
-        
+
         assert_eq!(extensions.get(), Some(&20u8));
         assert_eq!(extensions.get_mut(), Some(&20u8));
     }

--- a/actix-http/src/extensions.rs
+++ b/actix-http/src/extensions.rs
@@ -66,11 +66,6 @@ impl Extensions {
     pub fn extend(&mut self, other: Extensions) {
         self.map.extend(other.map);
     }
-
-    /// Returns `true` if no extension is registered
-    pub fn is_empty(&self) -> bool {
-        self.map.is_empty()
-    }
 }
 
 impl fmt::Debug for Extensions {
@@ -98,8 +93,6 @@ mod tests {
     fn test_clear() {
         let mut map = Extensions::new();
 
-        assert!(map.is_empty());
-
         map.insert::<i8>(8);
         map.insert::<i16>(16);
         map.insert::<i32>(32);
@@ -107,14 +100,12 @@ mod tests {
         assert!(map.contains::<i8>());
         assert!(map.contains::<i16>());
         assert!(map.contains::<i32>());
-        assert!(!map.is_empty());
 
         map.clear();
 
         assert!(!map.contains::<i8>());
         assert!(!map.contains::<i16>());
         assert!(!map.contains::<i32>());
-        assert!(map.is_empty());
 
         map.insert::<i8>(10);
         assert_eq!(*map.get::<i8>().unwrap(), 10);

--- a/actix-http/src/extensions.rs
+++ b/actix-http/src/extensions.rs
@@ -220,6 +220,6 @@ mod tests {
         assert_eq!(extensions.get(), Some(&MyType(10)));
 
         assert_eq!(extensions.get(), Some(&20u8));
-        assert_eq!(extensions.get_mut(), Some(&20u8));
+        assert_eq!(extensions.get_mut(), Some(&mut 20u8));
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -183,6 +183,7 @@ where
         self.data.extend(cfg.data);
         self.services.extend(cfg.services);
         self.external.extend(cfg.external);
+        self.extensions.extend(cfg.extensions);
         self
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -200,12 +200,9 @@ impl ServiceConfig {
         self
     }
 
-    /// Set application level arbitrary data item.
+    /// Set arbitrary data item.
     ///
-    /// Application data stored with `App::app_data()` method is available
-    /// via `HttpRequest::app_data()` method at runtime.
-    ///
-    /// Note: this method is ignored for `Scope::configure` method
+    /// This is same as `App::data()` method.
     pub fn app_data<U: 'static>(&mut self, ext: U) -> &mut Self {
         self.extensions.insert(ext);
         self

--- a/src/config.rs
+++ b/src/config.rs
@@ -264,12 +264,12 @@ mod tests {
     async fn test_data() {
         let cfg = |cfg: &mut ServiceConfig| {
             cfg.data(10usize);
-            cfg.app_data(10usize);
+            cfg.app_data(15u8);
         };
 
         let mut srv = init_service(App::new().configure(cfg).service(
             web::resource("/").to(|_: web::Data<usize>, req: HttpRequest| {
-                assert_eq!(*req.app_data::<usize>().unwrap(), 10usize);
+                assert_eq!(*req.app_data::<u8>().unwrap(), 15u8);
                 HttpResponse::Ok()
             }),
         ))

--- a/src/config.rs
+++ b/src/config.rs
@@ -270,14 +270,13 @@ mod tests {
             cfg.app_data(10usize);
         };
 
-        let mut srv =
-            init_service(App::new().configure(cfg).service(
-                web::resource("/").to(|_: web::Data<usize>, req: HttpRequest| {
-                    assert_eq!(*req.app_data::<usize>().unwrap(), 10usize);
-                    HttpResponse::Ok()
-                }),
-            ))
-            .await;
+        let mut srv = init_service(App::new().configure(cfg).service(
+            web::resource("/").to(|_: web::Data<usize>, req: HttpRequest| {
+                assert_eq!(*req.app_data::<usize>().unwrap(), 10usize);
+                HttpResponse::Ok()
+            }),
+        ))
+        .await;
         let req = TestRequest::default().to_request();
         let resp = srv.call(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::OK);

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -209,7 +209,9 @@ where
 
             self.data = Some(data);
         }
-        self.data.get_or_insert_with(Extensions::new).extend(cfg.extensions);
+        self.data
+            .get_or_insert_with(Extensions::new)
+            .extend(cfg.extensions);
         self
     }
 

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -209,12 +209,7 @@ where
 
             self.data = Some(data);
         }
-
-        if !cfg.extensions.is_empty() {
-            let mut data = self.data.unwrap_or_else(Extensions::new);
-            data.extend(cfg.extensions);
-            self.data = Some(data);
-        }
+        self.data.get_or_insert_with(Extensions::new).extend(cfg.extensions);
         self
     }
 

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -209,6 +209,12 @@ where
 
             self.data = Some(data);
         }
+
+        if !cfg.extensions.is_empty() {
+            let mut data = self.data.unwrap_or_else(Extensions::new);
+            data.extend(cfg.extensions);
+            self.data = Some(data);
+        }
         self
     }
 


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Adding `app_data` for `ServiceConfig` struct.


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Currently it is not possible to register `app_data` through the `App::configure` builder.
This will essentially merge the `app_data` from the `ServiceConfig` with the `App`'s. 

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
