### PR TITLE
deprecate builder if-x methods

### DIFF
--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -3,6 +3,7 @@
 ## Unreleased - 2020-xx-xx
 * Upgrade `base64` to `0.13`.
 * Upgrade `pin-project` to `1.0`.
+* Deprecate `ResponseBuilder::{if_some, if_true}`.
 
 ## 2.0.0 - 2020-09-11
 * No significant changes from `2.0.0-beta.4`.

--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -3,7 +3,10 @@
 ## Unreleased - 2020-xx-xx
 * Upgrade `base64` to `0.13`.
 * Upgrade `pin-project` to `1.0`.
-* Deprecate `ResponseBuilder::{if_some, if_true}`.
+* Deprecate `ResponseBuilder::{if_some, if_true}`. [#1760]
+
+[#1760]: https://github.com/actix/actix-web/pull/1760
+
 
 ## 2.0.0 - 2020-09-11
 * No significant changes from `2.0.0-beta.4`.

--- a/actix-http/src/response.rs
+++ b/actix-http/src/response.rs
@@ -554,8 +554,9 @@ impl ResponseBuilder {
         self
     }
 
-    /// This method calls provided closure with builder reference if value is
-    /// true.
+    /// This method calls provided closure with builder reference if value is `true`.
+    #[doc(hidden)]
+    #[deprecated = "Use an if statement."]
     pub fn if_true<F>(&mut self, value: bool, f: F) -> &mut Self
     where
         F: FnOnce(&mut ResponseBuilder),
@@ -566,8 +567,9 @@ impl ResponseBuilder {
         self
     }
 
-    /// This method calls provided closure with builder reference if value is
-    /// Some.
+    /// This method calls provided closure with builder reference if value is `Some`.
+    #[doc(hidden)]
+    #[deprecated = "Use an if-let construction."]
     pub fn if_some<T, F>(&mut self, value: Option<T>, f: F) -> &mut Self
     where
         F: FnOnce(T, &mut ResponseBuilder),

--- a/awc/CHANGES.md
+++ b/awc/CHANGES.md
@@ -3,11 +3,13 @@
 ## Unreleased - 2020-xx-xx
 ### Changed
 * Upgrade `base64` to `0.13`.
+* Deprecate `ClientRequest::{if_some, if_true}`. [#1760]
 
 ### Fixed
 * Use `Accept-Encoding: identity` instead of `Accept-Encoding: br` when no compression feature is enabled [#1737]
 
 [#1737]: https://github.com/actix/actix-web/pull/1737
+[#1760]: https://github.com/actix/actix-web/pull/1760
 
 
 ## 2.0.0 - 2020-09-11

--- a/awc/src/request.rs
+++ b/awc/src/request.rs
@@ -354,8 +354,9 @@ impl ClientRequest {
         self
     }
 
-    /// This method calls provided closure with builder reference if
-    /// value is `true`.
+    /// This method calls provided closure with builder reference if value is `true`.
+    #[doc(hidden)]
+    #[deprecated = "Use an if statement."]
     pub fn if_true<F>(self, value: bool, f: F) -> Self
     where
         F: FnOnce(ClientRequest) -> ClientRequest,
@@ -367,8 +368,9 @@ impl ClientRequest {
         }
     }
 
-    /// This method calls provided closure with builder reference if
-    /// value is `Some`.
+    /// This method calls provided closure with builder reference if value is `Some`.
+    #[doc(hidden)]
+    #[deprecated = "Use an if-let construction."]
     pub fn if_some<T, F>(self, value: Option<T>, f: F) -> Self
     where
         F: FnOnce(T, ClientRequest) -> ClientRequest,
@@ -601,20 +603,27 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_basics() {
-        let mut req = Client::new()
+        let req = Client::new()
             .put("/")
             .version(Version::HTTP_2)
             .set(header::Date(SystemTime::now().into()))
             .content_type("plain/text")
-            .if_true(true, |req| req.header(header::SERVER, "awc"))
-            .if_true(false, |req| req.header(header::EXPECT, "awc"))
-            .if_some(Some("server"), |val, req| {
-                req.header(header::USER_AGENT, val)
-            })
-            .if_some(Option::<&str>::None, |_, req| {
-                req.header(header::ALLOW, "1")
-            })
-            .content_length(100);
+            .header(header::SERVER, "awc");
+
+        let req = if let Some(val) = Some("server") {
+            req.header(header::USER_AGENT, val)
+        } else {
+            req
+        };
+
+        let req = if let Some(_val) = Option::<&str>::None {
+            req.header(header::ALLOW, "1")
+        } else {
+            req
+        };
+
+        let mut req = req.content_length(100);
+
         assert!(req.headers().contains_key(header::CONTENT_TYPE));
         assert!(req.headers().contains_key(header::DATE));
         assert!(req.headers().contains_key(header::SERVER));
@@ -622,6 +631,7 @@ mod tests {
         assert!(!req.headers().contains_key(header::ALLOW));
         assert!(!req.headers().contains_key(header::EXPECT));
         assert_eq!(req.head.version, Version::HTTP_2);
+
         let _ = req.headers_mut();
         let _ = req.send_body("");
     }


### PR DESCRIPTION
## PR Type
Deprecation


## PR Checklist
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
These methods serve little purpose where standard if-let constructions exists.