### PR TITLE
Remove a panic in normalize middleware

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,9 @@
 * Re-export bytes::Buf{Mut} in web module. [#1750]
 * Upgrade `pin-project` to `1.0`.
 
+### Fixed
+* Removed an occasional `unwrap` on `None` panic in `NormalizePathNormalization`.
+
 [#1723]: https://github.com/actix/actix-web/pull/1723
 [#1743]: https://github.com/actix/actix-web/pull/1743
 [#1748]: https://github.com/actix/actix-web/pull/1748

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## Unreleased - 2020-xx-xx
 ### Fixed
 * Ensure `actix-http` dependency uses same `serde_urlencoded`.
+* Removed an occasional `unwrap` on `None` panic in `NormalizePathNormalization`.
 
 
 ## 3.3.0 - 2020-11-25
@@ -29,9 +30,6 @@
 * Print non-configured `Data<T>` type when attempting extraction. [#1743]
 * Re-export bytes::Buf{Mut} in web module. [#1750]
 * Upgrade `pin-project` to `1.0`.
-
-### Fixed
-* Removed an occasional `unwrap` on `None` panic in `NormalizePathNormalization`.
 
 [#1723]: https://github.com/actix/actix-web/pull/1723
 [#1743]: https://github.com/actix/actix-web/pull/1743

--- a/src/middleware/normalize.rs
+++ b/src/middleware/normalize.rs
@@ -137,9 +137,9 @@ where
         // so the change can not be deduced from the length comparison
         if path != original_path {
             let mut parts = head.uri.clone().into_parts();
-            let pq = parts.path_and_query.as_ref().unwrap();
+            let query = parts.path_and_query.as_ref().and_then(|pq| pq.query());
 
-            let path = if let Some(q) = pq.query() {
+            let path = if let Some(q) = query {
                 Bytes::from(format!("{}?{}", path, q))
             } else {
                 Bytes::copy_from_slice(path.as_bytes())


### PR DESCRIPTION
## PR Type
Big Fix


## PR Checklist
- [ ] Tests for the changes have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt

## Overview
Fixes a panic that occurred occasionally when using path normalization middleware. If the original path was empty due to a malformed request, `parts.path_and_query` would be `None`. Actual panic logged on a live system :upside_down_face::

```
Oct 29 14:46:09 polkadot-telemetry-0 a1e8ee04ee4a[678]: thread 'actix-rt:worker:2' panicked at 'called `Option::unwrap()` on a `None` value', /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/actix-web-3.1.0/src/middleware/normalize.rs:140:22
```