### PR TITLE
Drop content length headers from 101 responses

### DIFF
--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -1,6 +1,10 @@
 # Changes
 
 ## Unreleased - 2020-xx-xx
+### Fixed
+* Started dropping `transfer-encoding: chunked` and `Content-Length` for 1XX and 204 responses. [#1767]
+
+[#1767]: https://github.com/actix/actix-web/pull/1767
 
 
 ## 2.1.0 - 2020-10-30

--- a/actix-web-actors/src/ws.rs
+++ b/actix-web-actors/src/ws.rs
@@ -164,7 +164,6 @@ pub fn handshake_with_protocols(
 
     let mut response = HttpResponse::build(StatusCode::SWITCHING_PROTOCOLS)
         .upgrade("websocket")
-        .header(header::TRANSFER_ENCODING, "chunked")
         .header(header::SEC_WEBSOCKET_ACCEPT, key.as_str())
         .take();
 
@@ -664,10 +663,10 @@ mod tests {
             )
             .to_http_request();
 
-        assert_eq!(
-            StatusCode::SWITCHING_PROTOCOLS,
-            handshake(&req).unwrap().finish().status()
-        );
+        let resp = handshake(&req).unwrap().finish();
+        assert_eq!(StatusCode::SWITCHING_PROTOCOLS, resp.status());
+        assert_eq!(None, resp.headers().get(&header::CONTENT_LENGTH));
+        assert_eq!(None, resp.headers().get(&header::TRANSFER_ENCODING));
 
         let req = TestRequest::default()
             .header(


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type
Bug Fix


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview

After the refactor in 3901239128ac9d076cdaaeb46220117a8043f7ad 101 responses started to be forced to emit `transfer-encoding: chunked` headers. However, similarly to 100, 102 and 204, the HTTP standard says 101 MUST NOT contain either content-length or transfer-encoding.

This leads to incompatibilities in the ecosystem. While browsers just ignore the header, envoy is unable to process responses like this.

This change goes a bit further than just restoring the old behaviour and extends the skip_len flag to all of these status codes, meaning even if they were user provided, they'll be ignored in the future to better match the standard.