### PR TITLE
Upgrade `serde_urlencoded` to `0.7`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 # Changes
 
 ## Unreleased - 2020-xx-xx
+### Changed
+* Upgrade `serde_urlencoded` to `0.7`.
 
 
 ## 3.2.0 - 2020-10-30

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ pin-project = "1.0.0"
 regex = "1.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde_urlencoded = "0.6.1"
+serde_urlencoded = "0.7"
 time = { version = "0.2.7", default-features = false, features = ["std"] }
 url = "2.1"
 open-ssl = { package = "openssl", version = "0.10", optional = true }

--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -7,6 +7,9 @@
 ### Fixed
 * Started dropping `transfer-encoding: chunked` and `Content-Length` for 1XX and 204 responses. [#1767]
 
+### Changed
+* Upgrade `serde_urlencoded` to `0.7`.
+
 [#1767]: https://github.com/actix/actix-web/pull/1767
 [#1768]: https://github.com/actix/actix-web/pull/1768
 

--- a/actix-http/Cargo.toml
+++ b/actix-http/Cargo.toml
@@ -78,7 +78,7 @@ serde = "1.0"
 serde_json = "1.0"
 sha-1 = "0.9"
 slab = "0.4"
-serde_urlencoded = "0.6.1"
+serde_urlencoded = "0.7"
 time = { version = "0.2.7", default-features = false, features = ["std"] }
 
 # compression

--- a/awc/CHANGES.md
+++ b/awc/CHANGES.md
@@ -1,7 +1,8 @@
 # Changes
 
 ## Unreleased - 2020-xx-xx
-
+### Changed
+* Upgrade `serde_urlencoded` to `0.7`.
 
 ## 2.0.1 - 2020-10-30
 ### Changed

--- a/awc/Cargo.toml
+++ b/awc/Cargo.toml
@@ -53,7 +53,7 @@ percent-encoding = "2.1"
 rand = "0.7"
 serde = "1.0"
 serde_json = "1.0"
-serde_urlencoded = "0.6.1"
+serde_urlencoded = "0.7"
 open-ssl = { version = "0.10", package = "openssl", optional = true }
 rust-tls = { version = "0.18.0", package = "rustls", optional = true, features = ["dangerous_configuration"] }
 

--- a/test-server/CHANGES.md
+++ b/test-server/CHANGES.md
@@ -4,6 +4,7 @@
 
 * add ability to set address for `TestServer` [#1645]
 * Upgrade `base64` to `0.13`.
+* Upgrade `serde_urlencoded` to `0.7`.
 
 [#1645]: https://github.com/actix/actix-web/pull/1645
 

--- a/test-server/Cargo.toml
+++ b/test-server/Cargo.toml
@@ -47,7 +47,7 @@ socket2 = "0.3"
 serde = "1.0"
 serde_json = "1.0"
 slab = "0.4"
-serde_urlencoded = "0.6.1"
+serde_urlencoded = "0.7"
 time = { version = "0.2.7", default-features = false, features = ["std"] }
 open-ssl = { version = "0.10", package = "openssl", optional = true }
 


### PR DESCRIPTION
# Overview
Most are internal changes.
https://github.com/nox/serde_urlencoded/compare/v0.6.1...26b1a99659dda63429efd1db7eac7c95521b4668