### PR TITLE
`actix-files` intra-doc migration

### DIFF
--- a/.github/workflows/upload-doc.yml
+++ b/.github/workflows/upload-doc.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable-x86_64-unknown-linux-gnu
+          toolchain: nightly-x86_64-unknown-linux-gnu
           profile: minimal
           override: true
 

--- a/actix-files/src/named.rs
+++ b/actix-files/src/named.rs
@@ -193,7 +193,7 @@ impl NamedFile {
     /// image, and video content types, and `attachment` otherwise, and
     /// the filename is taken from the path provided in the `open` method
     /// after converting it to UTF-8 using.
-    /// [to_string_lossy](https://doc.rust-lang.org/std/ffi/struct.OsStr.html#method.to_string_lossy).
+    /// [`std::ffi::OsStr::to_string_lossy`]
     #[inline]
     pub fn set_content_disposition(mut self, cd: header::ContentDisposition) -> Self {
         self.content_disposition = cd;


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->

Documentation

## PR Checklist


<!-- For draft PRs check the boxes as you complete them. -->
- [x] Documentation comments have been added / updated.



## Overview
`actix-files` was an easy conversion, found only only instance that needed change. 

That said, I don't understand why the changed part was put there in the first place. Maybe the implied meaning is that `std::ffi::OsStr::to_string_lossy` is used for making the UTF-8 conversion(which is true, by the way). I think I can improve the docs by being more specific. Suggestions?

Please see the documentation under [`set_content_disposition`](https://docs.rs/actix-files/0.4.0/actix_files/struct.NamedFile.html#method.set_content_disposition).