### PR TITLE
Multipart client implementation

### DIFF
--- a/actix-multipart/Cargo.toml
+++ b/actix-multipart/Cargo.toml
@@ -18,13 +18,16 @@ path = "src/lib.rs"
 [dependencies]
 actix-web = { version = "3.0.0", default-features = false }
 actix-service = "1.0.6"
+actix-http = "2.1.0"
 actix-utils = "2.0.0"
 bytes = "0.5.3"
 derive_more = "0.99.2"
 httparse = "1.3"
+futures = { version = "0.3.5", default-features = false }
 futures-util = { version = "0.3.5", default-features = false }
 log = "0.4"
 mime = "0.3"
+rand = "0.7"
 twoway = "0.2"
 
 [dev-dependencies]

--- a/actix-multipart/src/client.rs
+++ b/actix-multipart/src/client.rs
@@ -1,0 +1,52 @@
+//! Multipart payload support for Actix Web Client
+
+use bytes::Bytes;
+use futures::prelude::*;
+
+pub struct Form<'a> {
+    boundary: String,
+    fields: Vec<Field<'a>>,
+}
+
+/// A field in a multipart Form
+pub struct Field<'a> {
+    inner: FieldInner<'a>,
+    content_type: String,
+    content_length: Option<usize>,
+}
+
+impl<'a> Default for Form<'a> {
+    fn default() -> Self {
+        use rand::{distributions::Alphanumeric, thread_rng, Rng};
+        let rng = thread_rng();
+
+        Self::with_boundary(rng.sample_iter(&Alphanumeric).take(60).collect())
+    }
+}
+
+impl<'a> Form<'a> {
+    /// Constructs a new multipart Form with a specific boundary.
+    ///
+    /// If you do not want to manually construct a boundary, use `Form::default()`.
+    pub fn with_boundary(boundary: String) -> Self {
+        Form {
+            boundary,
+            fields: Vec::new(),
+        }
+    }
+
+    pub fn add_stream<S>(&mut self, content_type: String, content: S)
+    where
+        S: Stream<Item = Result<Bytes, actix_http::Error>> + 'a,
+    {
+        self.fields.push(Field {
+            inner: FieldInner::Stream(Box::new(content)),
+            content_type,
+            content_length: None, // XXX
+        })
+    }
+}
+
+enum FieldInner<'a> {
+    Stream(Box<dyn Stream<Item = Result<Bytes, actix_http::Error>> + 'a>),
+}

--- a/actix-multipart/src/lib.rs
+++ b/actix-multipart/src/lib.rs
@@ -3,6 +3,7 @@
 #![deny(rust_2018_idioms)]
 #![allow(clippy::borrow_interior_mutable_const)]
 
+pub mod client;
 mod error;
 mod extractor;
 mod server;


### PR DESCRIPTION
## PR Type
Feature


## PR Checklist

<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [ ] Format code with the latest stable rustfmt


## Overview

`awc` should be able to send multipart forms. Currently, a programmer needs to revert to additional, often unmaintained crates.  This adds a multipart body generator to `actix-multipart`, which currently contains just a parser for the Actix web server.

I am basing myself of https://github.com/cetra3/mpart-async/blob/master/src/client.rs and https://github.com/ferristseng/rust-multipart-rfc7578/pull/19

The former is by @cetra3, who wrote a few years ago in #195 that it was okay to base this on their code. The latter is my update to `multipart-rfc7578` to support the latest Actix, but it is an unresponsive PR.

I decided to make the `Form` type generic in the `dyn Stream` lifetime, as opposed to `mpart-async`, which is generic in the `Stream` implementation itself. Both have advantages and disadvantages, feel free to give me pointers to decide which approach is better for Actix.

Closes #195 
