### PR TITLE
Fix match_pattern() returning None for scope with resource of empty path

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@
 ### Fixed
 * Ensure `actix-http` dependency uses same `serde_urlencoded`.
 * Removed an occasional `unwrap` on `None` panic in `NormalizePathNormalization`.
+* Fix match_pattern() returning None for scope with resource of empty path. [#1798]
+
+[#1798]: https://github.com/actix/actix-web/pull/1798
 
 
 ## 3.3.0 - 2020-11-25

--- a/src/request.rs
+++ b/src/request.rs
@@ -682,7 +682,6 @@ mod tests {
             App::new()
                 .service(web::scope("/user").service(web::scope("/{id}").service(
                     web::resource("").to(move |req: HttpRequest| {
-                        println!("req: {:#?}", req.resource_map());
                         assert_eq!(req.match_pattern(), Some("/user/{id}".to_owned()));
 
                         HttpResponse::Ok().finish()

--- a/src/rmap.rs
+++ b/src/rmap.rs
@@ -86,9 +86,7 @@ impl ResourceMap {
                 if let Some(plen) = pattern.is_prefix_match(path) {
                     return rmap.has_resource(&path[plen..]);
                 }
-            } else if pattern.is_match(path) {
-                return true;
-            } else if pattern.pattern() == "" && path == "/" {
+            } else if pattern.is_match(path) || pattern.pattern() == "" && path == "/" {
                 return true;
             }
         }

--- a/src/rmap.rs
+++ b/src/rmap.rs
@@ -88,6 +88,8 @@ impl ResourceMap {
                 }
             } else if pattern.is_match(path) {
                 return true;
+            } else if pattern.pattern() == "" && path == "/" {
+                return true;
             }
         }
         false


### PR DESCRIPTION
## PR Type
Bug Fix

## PR Checklist

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt

## Overview

`match_pattern()` was incorrectly returning a None match if a `web::scope()` was proceed by a resource with path "". Not completely sure if setting up scopes/resources in this configuration is some kind of anti-pattern but for our uses it works very well.

