### PR TITLE
Upgrade socket2 dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ futures-util = { version = "0.3.5", default-features = false }
 fxhash = "0.2.1"
 log = "0.4"
 mime = "0.3"
-socket2 = "0.3"
+socket2 = "0.3.16"
 pin-project = "1.0.0"
 regex = "1.4"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
## PR Type
Bug Fix / Other: Upgrades a dependency to a version not making invalid assumptions about the memory layout of standard library types (`std::net::SocketAddr`).

Helps unblock https://github.com/rust-lang/rust/pull/78802. See that PR for more details. This PR simply helps adoption of the fixed version(s) of `socket2`.