### PR TITLE
Wrong parsing made by serde_urlencoded for Option, replacing with serde_qs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,8 +3,10 @@
 ## Unreleased - 2020-xx-xx
 ### Fixed
 * added the actual parsing error to `test::read_body_json` [#1812]
+* Migrate from `serde_urlencoded` to `serde_qs`. [#1816]
 
 [#1812]: https://github.com/actix/actix-web/pull/1812
+[#1816]: https://github.com/actix/actix-web/pull/1816
 
 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,6 @@
 [#1816]: https://github.com/actix/actix-web/pull/1816
 
 
-
 ## 3.3.2 - 2020-12-01
 ### Fixed
 * Removed an occasional `unwrap` on `None` panic in `NormalizePathNormalization`. [#1762]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ pin-project = "1.0.0"
 regex = "1.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde_urlencoded = "0.7"
+serde_qs = "0.8.1"
 time = { version = "0.2.7", default-features = false, features = ["std"] }
 url = "2.1"
 open-ssl = { package = "openssl", version = "0.10", optional = true }

--- a/actix-http-test/CHANGES.md
+++ b/actix-http-test/CHANGES.md
@@ -1,7 +1,9 @@
 # Changes
 
 ## Unreleased - 2020-xx-xx
+* Migrate from `serde_urlencoded` to `serde_qs`. [#1816]
 
+[#1816]: https://github.com/actix/actix-web/pull/1816
 
 ## 2.1.0 - 2020-11-25
 * Add ability to set address for `TestServer`. [#1645]

--- a/actix-http-test/Cargo.toml
+++ b/actix-http-test/Cargo.toml
@@ -47,7 +47,7 @@ socket2 = "0.3"
 serde = "1.0"
 serde_json = "1.0"
 slab = "0.4"
-serde_urlencoded = "0.7"
+serde_qs = "0.8.1"
 time = { version = "0.2.7", default-features = false, features = ["std"] }
 open-ssl = { version = "0.10", package = "openssl", optional = true }
 

--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -1,7 +1,9 @@
 # Changes
 
 ## Unreleased - 2020-xx-xx
+* Migrate from `serde_urlencoded` to `serde_qs`. [#1816]
 
+[#1816]: https://github.com/actix/actix-web/pull/1816
 
 ## 2.2.0 - 2020-11-25
 ### Added

--- a/actix-http/Cargo.toml
+++ b/actix-http/Cargo.toml
@@ -78,7 +78,7 @@ serde = "1.0"
 serde_json = "1.0"
 sha-1 = "0.9"
 slab = "0.4"
-serde_urlencoded = "0.7"
+serde_qs = "0.8.1"
 time = { version = "0.2.7", default-features = false, features = ["std"] }
 
 # compression

--- a/actix-http/src/error.rs
+++ b/actix-http/src/error.rs
@@ -17,7 +17,7 @@ use http::uri::InvalidUri;
 use http::{header, Error as HttpError, StatusCode};
 use serde::de::value::Error as DeError;
 use serde_json::error::Error as JsonError;
-use serde_urlencoded::ser::Error as FormError;
+use serde_qs::Error as FormError;
 
 // re-export for convenience
 use crate::body::Body;

--- a/awc/CHANGES.md
+++ b/awc/CHANGES.md
@@ -1,7 +1,9 @@
 # Changes
 
 ## Unreleased - 2020-xx-xx
+* Migrate from `serde_urlencoded` to `serde_qs`. [#]
 
+[#1816]: https://github.com/actix/actix-web/pull/
 
 ## 2.0.3 - 2020-11-29
 ### Fixed

--- a/awc/CHANGES.md
+++ b/awc/CHANGES.md
@@ -1,9 +1,9 @@
 # Changes
 
 ## Unreleased - 2020-xx-xx
-* Migrate from `serde_urlencoded` to `serde_qs`. [#]
+* Migrate from `serde_urlencoded` to `serde_qs`. [#1816]
 
-[#1816]: https://github.com/actix/actix-web/pull/
+[#1816]: https://github.com/actix/actix-web/pull/1816
 
 ## 2.0.3 - 2020-11-29
 ### Fixed

--- a/awc/Cargo.toml
+++ b/awc/Cargo.toml
@@ -53,7 +53,7 @@ percent-encoding = "2.1"
 rand = "0.7"
 serde = "1.0"
 serde_json = "1.0"
-serde_urlencoded = "0.7"
+serde_qs = "0.8.1"
 open-ssl = { version = "0.10", package = "openssl", optional = true }
 rust-tls = { version = "0.18.0", package = "rustls", optional = true, features = ["dangerous_configuration"] }
 

--- a/awc/src/request.rs
+++ b/awc/src/request.rs
@@ -590,6 +590,12 @@ mod tests {
     use super::*;
     use crate::Client;
 
+    #[derive(Serialize, Debug)]
+    struct Query<'a> {
+        key1: &'a str,
+        key2: &'a str,
+    }
+
     #[actix_rt::test]
     async fn test_debug() {
         let request = Client::new().get("/").header("x-test", "111");
@@ -715,7 +721,10 @@ mod tests {
     async fn client_query() {
         let req = Client::new()
             .get("/")
-            .query(&[("key1", "val1"), ("key2", "val2")])
+            .query(&Query {
+                key1: &"val1",
+                key2: &"val2",
+            })
             .unwrap();
         assert_eq!(req.get_uri().query().unwrap(), "key1=val1&key2=val2");
     }

--- a/awc/src/request.rs
+++ b/awc/src/request.rs
@@ -383,14 +383,11 @@ impl ClientRequest {
     }
 
     /// Sets the query part of the request
-    pub fn query<T: Serialize>(
-        mut self,
-        query: &T,
-    ) -> Result<Self, serde_urlencoded::ser::Error> {
+    pub fn query<T: Serialize>(mut self, query: &T) -> Result<Self, serde_qs::Error> {
         let mut parts = self.head.uri.clone().into_parts();
 
         if let Some(path_and_query) = parts.path_and_query {
-            let query = serde_urlencoded::to_string(query)?;
+            let query = serde_qs::to_string(query)?;
             let path = path_and_query.path();
             parts.path_and_query = format!("{}?{}", path, query).parse().ok();
 

--- a/awc/src/sender.rs
+++ b/awc/src/sender.rs
@@ -231,7 +231,7 @@ impl RequestSender {
         config: &ClientConfig,
         value: &T,
     ) -> SendClientRequest {
-        let body = match serde_urlencoded::to_string(value) {
+        let body = match serde_qs::to_string(value) {
             Ok(body) => body,
             Err(e) => return Error::from(e).into(),
         };

--- a/src/error.rs
+++ b/src/error.rs
@@ -120,7 +120,7 @@ impl ResponseError for PathError {
 pub enum QueryPayloadError {
     /// Deserialize error
     #[display(fmt = "Query deserialize error: {}", _0)]
-    Deserialize(serde::de::value::Error),
+    Deserialize(serde_qs::Error),
 }
 
 impl std::error::Error for QueryPayloadError {}
@@ -188,7 +188,7 @@ mod tests {
     #[test]
     fn test_query_payload_error() {
         let resp: HttpResponse = QueryPayloadError::Deserialize(
-            serde_urlencoded::from_str::<i32>("bad query").unwrap_err(),
+            serde_qs::from_str::<i32>("bad query").unwrap_err(),
         )
         .error_response();
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);

--- a/src/test.rs
+++ b/src/test.rs
@@ -496,7 +496,7 @@ impl TestRequest {
     /// Serialize `data` to a URL encoded form and set it as the request payload. The `Content-Type`
     /// header is set to `application/x-www-form-urlencoded`.
     pub fn set_form<T: Serialize>(mut self, data: &T) -> Self {
-        let bytes = serde_urlencoded::to_string(data)
+        let bytes = serde_qs::to_string(data)
             .expect("Failed to serialize test data as a urlencoded form");
         self.req.set_payload(bytes);
         self.req.set(ContentType::form_url_encoded());

--- a/src/types/form.rs
+++ b/src/types/form.rs
@@ -162,7 +162,7 @@ impl<T: Serialize> Responder for Form<T> {
     type Future = Ready<Result<Response, Error>>;
 
     fn respond_to(self, _: &HttpRequest) -> Self::Future {
-        let body = match serde_urlencoded::to_string(&self.0) {
+        let body = match serde_qs::to_string(&self.0) {
             Ok(body) => body,
             Err(e) => return err(e.into()),
         };
@@ -359,15 +359,13 @@ where
                 }
 
                 if encoding == UTF_8 {
-                    serde_urlencoded::from_bytes::<U>(&body)
-                        .map_err(|_| UrlencodedError::Parse)
+                    serde_qs::from_bytes::<U>(&body).map_err(|_| UrlencodedError::Parse)
                 } else {
                     let body = encoding
                         .decode_without_bom_handling_and_without_replacement(&body)
                         .map(|s| s.into_owned())
                         .ok_or(UrlencodedError::Parse)?;
-                    serde_urlencoded::from_str::<U>(&body)
-                        .map_err(|_| UrlencodedError::Parse)
+                    serde_qs::from_str::<U>(&body).map_err(|_| UrlencodedError::Parse)
                 }
             }
             .boxed_local(),

--- a/src/types/query.rs
+++ b/src/types/query.rs
@@ -64,7 +64,7 @@ impl<T> Query<T> {
     where
         T: de::DeserializeOwned,
     {
-        serde_urlencoded::from_str::<T>(query_str)
+        serde_qs::from_str::<T>(query_str)
             .map(|val| Ok(Query(val)))
             .unwrap_or_else(move |e| Err(QueryPayloadError::Deserialize(e)))
     }
@@ -144,7 +144,7 @@ where
             .map(|c| c.ehandler.clone())
             .unwrap_or(None);
 
-        serde_urlencoded::from_str::<T>(req.query_string())
+        serde_qs::from_str::<T>(req.query_string())
             .map(|val| ok(Query(val)))
             .unwrap_or_else(move |e| {
                 let e = QueryPayloadError::Deserialize(e);


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Bug fix

## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt

## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Can break an already existing actix instance based on the old (bad) implementation because of `serde_urlencoded`.
This change the way we pass Query. But we can, if needed only use `serde_qs` for Deserialize purpose and fallback to `serde_urlencoded` for the `::to_string()` function.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
Closes #1815
