### PR TITLE
Add fn cookie(x: &str) in ServiceRequest

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,9 @@
 [#1812]: https://github.com/actix/actix-web/pull/1812
 
 
+* Add `fn cookie(x: &str)` in ServiceRequest [#1821]
+
+[#1821]: https://github.com/actix/actix-web/pull/1821
 
 ## 3.3.2 - 2020-12-01
 ### Fixed


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Feature


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Add a `cookie()` function into ServiceRequest to allow getting cookie by name directly instead of splitting the ServiceRequest `into_parts()`.

<!-- If this PR fixes or closes an issue, reference it here. -->
Closes #1818 