### PR TITLE
Bump v_htmlescape from 0.11.x to 0.12.x

### DIFF
--- a/actix-files/CHANGES.md
+++ b/actix-files/CHANGES.md
@@ -1,6 +1,7 @@
 # Changes
 
 ## Unreleased - 2020-xx-xx
+* Bump `v_htmlescape` to `0.12`
 
 
 ## 0.4.1 - 2020-11-24

--- a/actix-files/Cargo.toml
+++ b/actix-files/Cargo.toml
@@ -28,7 +28,7 @@ log = "0.4"
 mime = "0.3"
 mime_guess = "2.0.1"
 percent-encoding = "2.1"
-v_htmlescape = "0.11"
+v_htmlescape = { version = "0.12", default-features = false, features = ["bytes-buf-tokio3"] }
 
 [dev-dependencies]
 actix-rt = "1.0.0"


### PR DESCRIPTION
## PR Type
Dependency bump

## PR Checklist
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt

## Overview
The most notable change in `v_htmlescape` 0.12.0 is its dependency on `buf-min` 0.4 (bumped from 0.2). `buf-min` 0.4.0 depends on `bytes` 0.5 by default (as does `buf-min` 0.2), but has a new opt-in feature flag to compile with `bytes` 0.6 instead. `actix-files`'s usage of `v_htmlescape` actually doesn't need `bytes` at all, although at least one of its versions is required for compilation of `v_escape`, so I opted for using the newer `bytes` 0.6-enabling feature for forward compability. We can use `bytes` 0.5 instead if that is desired though.