### PR TITLE
Rename factory to handler

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,8 +9,7 @@
 * added the actual parsing error to `test::read_body_json` [#1812]
 
 [#1812]: https://github.com/actix/actix-web/pull/1812
-
-
+[#1852]: https://github.com/actix/actix-web/pull/1852
 
 ## 3.3.2 - 2020-12-01
 ### Fixed

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## Unreleased - 2020-xx-xx
 ### Changed
 * Bumped `rand` to `0.8`
+* Rename `Handler` to `HandlerService` and rename `Factory` to `Handler`. [#1852]
 
 ### Fixed
 * added the actual parsing error to `test::read_body_json` [#1812]

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -20,19 +20,19 @@ use crate::service::{ServiceRequest, ServiceResponse};
 ///
 /// If you got the error `the trait Handler<_, _, _> is not implemented`, then your function is not
 /// a valid handler. See [Request Handlers](https://actix.rs/docs/handlers/) for more information.
-pub trait Handler<T, R, O>: Clone + 'static
+pub trait Handler<T, R>: Clone + 'static
 where
-    R: Future<Output = O>,
-    O: Responder,
+    R: Future,
+    R::Output: Responder,
 {
     fn call(&self, param: T) -> R;
 }
 
-impl<F, R, O> Handler<(), R, O> for F
+impl<F, R> Handler<(), R> for F
 where
     F: Fn() -> R + Clone + 'static,
-    R: Future<Output = O>,
-    O: Responder,
+    R: Future,
+    R::Output: Responder,
 {
     fn call(&self, _: ()) -> R {
         (self)()
@@ -41,23 +41,23 @@ where
 
 #[doc(hidden)]
 /// Extract arguments from request, run factory function and make response.
-pub struct HandlerService<F, T, R, O>
+pub struct HandlerService<F, T, R>
 where
-    F: Handler<T, R, O>,
+    F: Handler<T, R>,
     T: FromRequest,
-    R: Future<Output = O>,
-    O: Responder,
+    R: Future,
+    R::Output: Responder,
 {
     hnd: F,
-    _t: PhantomData<(T, R, O)>,
+    _t: PhantomData<(T, R)>,
 }
 
-impl<F, T, R, O> HandlerService<F, T, R, O>
+impl<F, T, R> HandlerService<F, T, R>
 where
-    F: Handler<T, R, O>,
+    F: Handler<T, R>,
     T: FromRequest,
-    R: Future<Output = O>,
-    O: Responder,
+    R: Future,
+    R::Output: Responder,
 {
     pub fn new(hnd: F) -> Self {
         Self {
@@ -67,12 +67,12 @@ where
     }
 }
 
-impl<F, T, R, O> Clone for HandlerService<F, T, R, O>
+impl<F, T, R> Clone for HandlerService<F, T, R>
 where
-    F: Handler<T, R, O>,
+    F: Handler<T, R>,
     T: FromRequest,
-    R: Future<Output = O>,
-    O: Responder,
+    R: Future,
+    R::Output: Responder,
 {
     fn clone(&self) -> Self {
         Self {
@@ -82,12 +82,12 @@ where
     }
 }
 
-impl<F, T, R, O> ServiceFactory for HandlerService<F, T, R, O>
+impl<F, T, R> ServiceFactory for HandlerService<F, T, R>
 where
-    F: Handler<T, R, O>,
+    F: Handler<T, R>,
     T: FromRequest,
-    R: Future<Output = O>,
-    O: Responder,
+    R: Future,
+    R::Output: Responder,
 {
     type Request = ServiceRequest;
     type Response = ServiceResponse;
@@ -103,17 +103,17 @@ where
 }
 
 // Handler is both it's ServiceHandler and Service Type.
-impl<F, T, R, O> Service for HandlerService<F, T, R, O>
+impl<F, T, R> Service for HandlerService<F, T, R>
 where
-    F: Handler<T, R, O>,
+    F: Handler<T, R>,
     T: FromRequest,
-    R: Future<Output = O>,
-    O: Responder,
+    R: Future,
+    R::Output: Responder,
 {
     type Request = ServiceRequest;
     type Response = ServiceResponse;
     type Error = Error;
-    type Future = HandlerServiceFuture<F, T, R, O>;
+    type Future = HandlerServiceFuture<F, T, R>;
 
     fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         Poll::Ready(Ok(()))
@@ -128,24 +128,24 @@ where
 
 #[doc(hidden)]
 #[pin_project(project = HandlerProj)]
-pub enum HandlerServiceFuture<F, T, R, O>
+pub enum HandlerServiceFuture<F, T, R>
 where
-    F: Handler<T, R, O>,
+    F: Handler<T, R>,
     T: FromRequest,
-    R: Future<Output = O>,
-    O: Responder,
+    R: Future,
+    R::Output: Responder,
 {
     Extract(#[pin] T::Future, Option<HttpRequest>, F),
     Handle(#[pin] R, Option<HttpRequest>),
-    Respond(#[pin] O::Future, Option<HttpRequest>),
+    Respond(#[pin] <R::Output as Responder>::Future, Option<HttpRequest>),
 }
 
-impl<F, T, R, O> Future for HandlerServiceFuture<F, T, R, O>
+impl<F, T, R> Future for HandlerServiceFuture<F, T, R>
 where
-    F: Handler<T, R, O>,
+    F: Handler<T, R>,
     T: FromRequest,
-    R: Future<Output = O>,
-    O: Responder,
+    R: Future,
+    R::Output: Responder,
 {
     // Error type in this future is a placeholder type.
     // all instances of error must be converted to ServiceResponse and return in Ok.
@@ -186,10 +186,10 @@ where
 
 /// FromRequest trait impl for tuples
 macro_rules! factory_tuple ({ $(($n:tt, $T:ident)),+} => {
-    impl<Func, $($T,)+ Res, O> Handler<($($T,)+), Res, O> for Func
+    impl<Func, $($T,)+ Res> Handler<($($T,)+), Res> for Func
     where Func: Fn($($T,)+) -> Res + Clone + 'static,
-          Res: Future<Output = O>,
-          O: Responder,
+          Res: Future,
+          Res::Output: Responder,
     {
         fn call(&self, param: ($($T,)+)) -> Res {
             (self)($(param.$n,)+)

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -15,6 +15,9 @@ use crate::responder::Responder;
 use crate::service::{ServiceRequest, ServiceResponse};
 
 /// Async handler converter factory
+/// 
+/// If you got the error `the trait Handler<_, _, _> is not implemented`, then your function is not
+/// a valid handler. See [Request Handlers](https://actix.rs/docs/handlers/) for more information.
 pub trait Handler<T, R, O>: Clone + 'static
 where
     R: Future<Output = O>,

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -14,8 +14,10 @@ use crate::request::HttpRequest;
 use crate::responder::Responder;
 use crate::service::{ServiceRequest, ServiceResponse};
 
-/// Async handler converter factory
-/// 
+///  A request handler is an async function that accepts zero or more parameters that can be
+///  extracted from a request (ie, [`impl FromRequest`](crate::FromRequest)) and returns a type that can be converted into
+///  an [`HttpResponse`](crate::HttpResponse) (ie, [`impl Responder`](crate::Responder)).
+///
 /// If you got the error `the trait Handler<_, _, _> is not implemented`, then your function is not
 /// a valid handler. See [Request Handlers](https://actix.rs/docs/handlers/) for more information.
 pub trait Handler<T, R, O>: Clone + 'static

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -36,7 +36,7 @@ where
 
 #[doc(hidden)]
 /// Extract arguments from request, run factory function and make response.
-pub struct Handler<F, T, R, O>
+pub struct HandlerService<F, T, R, O>
 where
     F: Factory<T, R, O>,
     T: FromRequest,
@@ -47,7 +47,7 @@ where
     _t: PhantomData<(T, R, O)>,
 }
 
-impl<F, T, R, O> Handler<F, T, R, O>
+impl<F, T, R, O> HandlerService<F, T, R, O>
 where
     F: Factory<T, R, O>,
     T: FromRequest,
@@ -55,14 +55,14 @@ where
     O: Responder,
 {
     pub fn new(hnd: F) -> Self {
-        Handler {
+        Self {
             hnd,
             _t: PhantomData,
         }
     }
 }
 
-impl<F, T, R, O> Clone for Handler<F, T, R, O>
+impl<F, T, R, O> Clone for HandlerService<F, T, R, O>
 where
     F: Factory<T, R, O>,
     T: FromRequest,
@@ -70,14 +70,14 @@ where
     O: Responder,
 {
     fn clone(&self) -> Self {
-        Handler {
+        Self {
             hnd: self.hnd.clone(),
             _t: PhantomData,
         }
     }
 }
 
-impl<F, T, R, O> ServiceFactory for Handler<F, T, R, O>
+impl<F, T, R, O> ServiceFactory for HandlerService<F, T, R, O>
 where
     F: Factory<T, R, O>,
     T: FromRequest,
@@ -98,7 +98,7 @@ where
 }
 
 // Handler is both it's ServiceFactory and Service Type.
-impl<F, T, R, O> Service for Handler<F, T, R, O>
+impl<F, T, R, O> Service for HandlerService<F, T, R, O>
 where
     F: Factory<T, R, O>,
     T: FromRequest,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,7 +121,7 @@ pub mod dev {
 
     pub use crate::config::{AppConfig, AppService};
     #[doc(hidden)]
-    pub use crate::handler::Factory;
+    pub use crate::handler::Handler;
     pub use crate::info::ConnectionInfo;
     pub use crate::rmap::ResourceMap;
     pub use crate::service::{

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -17,7 +17,7 @@ use crate::data::Data;
 use crate::dev::{insert_slash, AppService, HttpServiceFactory, ResourceDef};
 use crate::extract::FromRequest;
 use crate::guard::Guard;
-use crate::handler::Factory;
+use crate::handler::Handler;
 use crate::responder::Responder;
 use crate::route::{CreateRouteService, Route, RouteService};
 use crate::service::{ServiceRequest, ServiceResponse};
@@ -229,7 +229,7 @@ where
     /// ```
     pub fn to<F, I, R, U>(mut self, handler: F) -> Self
     where
-        F: Factory<I, R, U>,
+        F: Handler<I, R, U>,
         I: FromRequest + 'static,
         R: Future<Output = U> + 'static,
         U: Responder + 'static,

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -227,12 +227,12 @@ where
     /// # fn index(req: HttpRequest) -> HttpResponse { unimplemented!() }
     /// App::new().service(web::resource("/").route(web::route().to(index)));
     /// ```
-    pub fn to<F, I, R, U>(mut self, handler: F) -> Self
+    pub fn to<F, I, R>(mut self, handler: F) -> Self
     where
-        F: Handler<I, R, U>,
+        F: Handler<I, R>,
         I: FromRequest + 'static,
-        R: Future<Output = U> + 'static,
-        U: Responder + 'static,
+        R: Future + 'static,
+        R::Output: Responder + 'static,
     {
         self.routes.push(Route::new().to(handler));
         self

--- a/src/route.rs
+++ b/src/route.rs
@@ -11,7 +11,7 @@ use futures_util::future::{ready, FutureExt, LocalBoxFuture};
 
 use crate::extract::FromRequest;
 use crate::guard::{self, Guard};
-use crate::handler::{Factory, HandlerService};
+use crate::handler::{Handler, HandlerService};
 use crate::responder::Responder;
 use crate::service::{ServiceRequest, ServiceResponse};
 use crate::HttpResponse;
@@ -221,7 +221,7 @@ impl Route {
     /// ```
     pub fn to<F, T, R, U>(mut self, handler: F) -> Self
     where
-        F: Factory<T, R, U>,
+        F: Handler<T, R, U>,
         T: FromRequest + 'static,
         R: Future<Output = U> + 'static,
         U: Responder + 'static,

--- a/src/route.rs
+++ b/src/route.rs
@@ -219,12 +219,12 @@ impl Route {
     ///     );
     /// }
     /// ```
-    pub fn to<F, T, R, U>(mut self, handler: F) -> Self
+    pub fn to<F, T, R>(mut self, handler: F) -> Self
     where
-        F: Handler<T, R, U>,
+        F: Handler<T, R>,
         T: FromRequest + 'static,
-        R: Future<Output = U> + 'static,
-        U: Responder + 'static,
+        R: Future + 'static,
+        R::Output: Responder + 'static,
     {
         self.service = Box::new(RouteNewService::new(HandlerService::new(handler)));
         self

--- a/src/route.rs
+++ b/src/route.rs
@@ -11,7 +11,7 @@ use futures_util::future::{ready, FutureExt, LocalBoxFuture};
 
 use crate::extract::FromRequest;
 use crate::guard::{self, Guard};
-use crate::handler::{Factory, Handler};
+use crate::handler::{Factory, HandlerService};
 use crate::responder::Responder;
 use crate::service::{ServiceRequest, ServiceResponse};
 use crate::HttpResponse;
@@ -51,7 +51,7 @@ impl Route {
     #[allow(clippy::new_without_default)]
     pub fn new() -> Route {
         Route {
-            service: Box::new(RouteNewService::new(Handler::new(|| {
+            service: Box::new(RouteNewService::new(HandlerService::new(|| {
                 ready(HttpResponse::NotFound())
             }))),
             guards: Rc::new(Vec::new()),
@@ -226,7 +226,7 @@ impl Route {
         R: Future<Output = U> + 'static,
         U: Responder + 'static,
     {
-        self.service = Box::new(RouteNewService::new(Handler::new(handler)));
+        self.service = Box::new(RouteNewService::new(HandlerService::new(handler)));
         self
     }
 }

--- a/src/web.rs
+++ b/src/web.rs
@@ -244,12 +244,12 @@ pub fn method(method: Method) -> Route {
 ///         web::to(index))
 /// );
 /// ```
-pub fn to<F, I, R, U>(handler: F) -> Route
+pub fn to<F, I, R>(handler: F) -> Route
 where
-    F: Handler<I, R, U>,
+    F: Handler<I, R>,
     I: FromRequest + 'static,
-    R: Future<Output = U> + 'static,
-    U: Responder + 'static,
+    R: Future + 'static,
+    R::Output: Responder + 'static,
 {
     Route::new().to(handler)
 }

--- a/src/web.rs
+++ b/src/web.rs
@@ -9,7 +9,7 @@ pub use futures_channel::oneshot::Canceled;
 
 use crate::error::BlockingError;
 use crate::extract::FromRequest;
-use crate::handler::Factory;
+use crate::handler::Handler;
 use crate::resource::Resource;
 use crate::responder::Responder;
 use crate::route::Route;
@@ -246,7 +246,7 @@ pub fn method(method: Method) -> Route {
 /// ```
 pub fn to<F, I, R, U>(handler: F) -> Route
 where
-    F: Factory<I, R, U>,
+    F: Handler<I, R, U>,
     I: FromRequest + 'static,
     R: Future<Output = U> + 'static,
     U: Responder + 'static,


### PR DESCRIPTION
## PR Type
Refactor


## PR Checklist
- [x] Documentation comments have been added / updated.
- [x] A changelog entry  has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
This PR renames the `Factory` trait to `Handler`, and the `Handler` struct to `HandlerService`. This change better reflects the purpose of these types.

`The trait Factory is not satisfied` is a common error that has caused a lot of confusion as it is pretty cryptic. `The trait Handler is not satisfied` makes more sense. I also added documentation listing the requirements of a valid handler.

This is a breaking change (even users aren't really meant to implement `Factory` manually), but is important for ergonomics.

I also removed the third type parameter (`O`) from `Handler` which simplifies the type definition overall.