### PR TITLE
remove unused `actix_http::h1::OneRequest`

### DIFF
--- a/actix-http/src/h1/mod.rs
+++ b/actix-http/src/h1/mod.rs
@@ -17,7 +17,7 @@ pub use self::codec::Codec;
 pub use self::dispatcher::Dispatcher;
 pub use self::expect::ExpectHandler;
 pub use self::payload::Payload;
-pub use self::service::{H1Service, H1ServiceHandler, OneRequest};
+pub use self::service::{H1Service, H1ServiceHandler};
 pub use self::upgrade::UpgradeHandler;
 pub use self::utils::SendResponse;
 


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Refactor


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
`actix_http::h1::OneRequest` is not used internall anymore.

In changelog it's removed in [0.2.0] - 2019-05-12

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
