### PR TITLE
remove deprecated on_connect methods

### DIFF
--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -4,6 +4,13 @@
 ### Changed
 * Bumped `rand` to `0.8`
 
+### Removed
+* Deprecated `on_connect` methods have been removed. Prefer the new
+  `on_connect_ext` technique. [#1857]
+
+[#1857]: https://github.com/actix/actix-web/pull/1857
+
+
 ## 2.2.0 - 2020-11-25
 ### Added
 * HttpResponse builders for 1xx status codes. [#1768]

--- a/actix-http/src/h1/dispatcher.rs
+++ b/actix-http/src/h1/dispatcher.rs
@@ -19,7 +19,6 @@ use crate::cloneable::CloneableService;
 use crate::config::ServiceConfig;
 use crate::error::{DispatchError, Error};
 use crate::error::{ParseError, PayloadError};
-use crate::helpers::DataFactory;
 use crate::httpmessage::HttpMessage;
 use crate::request::Request;
 use crate::response::Response;
@@ -96,7 +95,6 @@ where
     service: CloneableService<S>,
     expect: CloneableService<X>,
     upgrade: Option<CloneableService<U>>,
-    on_connect: Option<Box<dyn DataFactory>>,
     on_connect_data: Extensions,
     flags: Flags,
     peer_addr: Option<net::SocketAddr>,
@@ -184,7 +182,6 @@ where
         service: CloneableService<S>,
         expect: CloneableService<X>,
         upgrade: Option<CloneableService<U>>,
-        on_connect: Option<Box<dyn DataFactory>>,
         on_connect_data: Extensions,
         peer_addr: Option<net::SocketAddr>,
     ) -> Self {
@@ -197,7 +194,6 @@ where
             service,
             expect,
             upgrade,
-            on_connect,
             on_connect_data,
             peer_addr,
         )
@@ -213,7 +209,6 @@ where
         service: CloneableService<S>,
         expect: CloneableService<X>,
         upgrade: Option<CloneableService<U>>,
-        on_connect: Option<Box<dyn DataFactory>>,
         on_connect_data: Extensions,
         peer_addr: Option<net::SocketAddr>,
     ) -> Self {
@@ -246,7 +241,6 @@ where
                 service,
                 expect,
                 upgrade,
-                on_connect,
                 on_connect_data,
                 flags,
                 peer_addr,
@@ -571,12 +565,6 @@ where
                         Message::Item(mut req) => {
                             let pl = this.codec.message_type();
                             req.head_mut().peer_addr = *this.peer_addr;
-
-                            // DEPRECATED
-                            // set on_connect data
-                            if let Some(ref on_connect) = this.on_connect {
-                                on_connect.set(&mut req.extensions_mut());
-                            }
 
                             // merge on_connect_ext data into request extensions
                             req.extensions_mut().drain_from(this.on_connect_data);

--- a/actix-http/src/h1/dispatcher.rs
+++ b/actix-http/src/h1/dispatcher.rs
@@ -1026,7 +1026,6 @@ mod tests {
                 CloneableService::new(ok_service()),
                 CloneableService::new(ExpectHandler),
                 None,
-                None,
                 Extensions::new(),
                 None,
             );
@@ -1066,7 +1065,6 @@ mod tests {
                 cfg,
                 CloneableService::new(echo_path_service()),
                 CloneableService::new(ExpectHandler),
-                None,
                 None,
                 Extensions::new(),
                 None,
@@ -1122,7 +1120,6 @@ mod tests {
                 CloneableService::new(echo_path_service()),
                 CloneableService::new(ExpectHandler),
                 None,
-                None,
                 Extensions::new(),
                 None,
             );
@@ -1171,7 +1168,6 @@ mod tests {
                 cfg,
                 CloneableService::new(echo_payload_service()),
                 CloneableService::new(ExpectHandler),
-                None,
                 None,
                 Extensions::new(),
                 None,
@@ -1244,7 +1240,6 @@ mod tests {
                 CloneableService::new(echo_path_service()),
                 CloneableService::new(ExpectHandler),
                 None,
-                None,
                 Extensions::new(),
                 None,
             );
@@ -1304,7 +1299,6 @@ mod tests {
                 CloneableService::new(ok_service()),
                 CloneableService::new(ExpectHandler),
                 Some(CloneableService::new(UpgradeHandler(PhantomData))),
-                None,
                 Extensions::new(),
                 None,
             );

--- a/actix-http/src/h1/service.rs
+++ b/actix-http/src/h1/service.rs
@@ -15,7 +15,6 @@ use crate::body::MessageBody;
 use crate::cloneable::CloneableService;
 use crate::config::ServiceConfig;
 use crate::error::{DispatchError, Error};
-use crate::helpers::DataFactory;
 use crate::request::Request;
 use crate::response::Response;
 use crate::{ConnectCallback, Extensions};
@@ -30,7 +29,6 @@ pub struct H1Service<T, S, B, X = ExpectHandler, U = UpgradeHandler<T>> {
     cfg: ServiceConfig,
     expect: X,
     upgrade: Option<U>,
-    on_connect: Option<Rc<dyn Fn(&T) -> Box<dyn DataFactory>>>,
     on_connect_ext: Option<Rc<ConnectCallback<T>>>,
     _t: PhantomData<(T, B)>,
 }
@@ -53,7 +51,6 @@ where
             srv: service.into_factory(),
             expect: ExpectHandler,
             upgrade: None,
-            on_connect: None,
             on_connect_ext: None,
             _t: PhantomData,
         }
@@ -215,7 +212,6 @@ where
             cfg: self.cfg,
             srv: self.srv,
             upgrade: self.upgrade,
-            on_connect: self.on_connect,
             on_connect_ext: self.on_connect_ext,
             _t: PhantomData,
         }
@@ -232,19 +228,9 @@ where
             cfg: self.cfg,
             srv: self.srv,
             expect: self.expect,
-            on_connect: self.on_connect,
             on_connect_ext: self.on_connect_ext,
             _t: PhantomData,
         }
-    }
-
-    /// Set on connect callback.
-    pub(crate) fn on_connect(
-        mut self,
-        f: Option<Rc<dyn Fn(&T) -> Box<dyn DataFactory>>>,
-    ) -> Self {
-        self.on_connect = f;
-        self
     }
 
     /// Set on connect callback.
@@ -284,7 +270,6 @@ where
             fut_upg: self.upgrade.as_ref().map(|f| f.new_service(())),
             expect: None,
             upgrade: None,
-            on_connect: self.on_connect.clone(),
             on_connect_ext: self.on_connect_ext.clone(),
             cfg: Some(self.cfg.clone()),
             _t: PhantomData,
@@ -314,7 +299,6 @@ where
     fut_upg: Option<U::Future>,
     expect: Option<X::Service>,
     upgrade: Option<U::Service>,
-    on_connect: Option<Rc<dyn Fn(&T) -> Box<dyn DataFactory>>>,
     on_connect_ext: Option<Rc<ConnectCallback<T>>>,
     cfg: Option<ServiceConfig>,
     _t: PhantomData<(T, B)>,
@@ -371,7 +355,6 @@ where
                 service,
                 this.expect.take().unwrap(),
                 this.upgrade.take(),
-                this.on_connect.clone(),
                 this.on_connect_ext.clone(),
             )
         }))
@@ -383,7 +366,6 @@ pub struct H1ServiceHandler<T, S: Service, B, X: Service, U: Service> {
     srv: CloneableService<S>,
     expect: CloneableService<X>,
     upgrade: Option<CloneableService<U>>,
-    on_connect: Option<Rc<dyn Fn(&T) -> Box<dyn DataFactory>>>,
     on_connect_ext: Option<Rc<ConnectCallback<T>>>,
     cfg: ServiceConfig,
     _t: PhantomData<(T, B)>,
@@ -405,7 +387,6 @@ where
         srv: S,
         expect: X,
         upgrade: Option<U>,
-        on_connect: Option<Rc<dyn Fn(&T) -> Box<dyn DataFactory>>>,
         on_connect_ext: Option<Rc<ConnectCallback<T>>>,
     ) -> H1ServiceHandler<T, S, B, X, U> {
         H1ServiceHandler {
@@ -413,7 +394,6 @@ where
             expect: CloneableService::new(expect),
             upgrade: upgrade.map(CloneableService::new),
             cfg,
-            on_connect,
             on_connect_ext,
             _t: PhantomData,
         }
@@ -480,8 +460,6 @@ where
     }
 
     fn call(&mut self, (io, addr): Self::Request) -> Self::Future {
-        let deprecated_on_connect = self.on_connect.as_ref().map(|handler| handler(&io));
-
         let mut connect_extensions = Extensions::new();
         if let Some(ref handler) = self.on_connect_ext {
             // run on_connect_ext callback, populating connect extensions
@@ -494,7 +472,6 @@ where
             self.srv.clone(),
             self.expect.clone(),
             self.upgrade.clone(),
-            deprecated_on_connect,
             connect_extensions,
             addr,
         )

--- a/actix-http/src/h2/dispatcher.rs
+++ b/actix-http/src/h2/dispatcher.rs
@@ -18,7 +18,6 @@ use crate::body::{BodySize, MessageBody, ResponseBody};
 use crate::cloneable::CloneableService;
 use crate::config::ServiceConfig;
 use crate::error::{DispatchError, Error};
-use crate::helpers::DataFactory;
 use crate::httpmessage::HttpMessage;
 use crate::message::ResponseHead;
 use crate::payload::Payload;
@@ -36,7 +35,6 @@ where
 {
     service: CloneableService<S>,
     connection: Connection<T, Bytes>,
-    on_connect: Option<Box<dyn DataFactory>>,
     on_connect_data: Extensions,
     config: ServiceConfig,
     peer_addr: Option<net::SocketAddr>,
@@ -57,7 +55,6 @@ where
     pub(crate) fn new(
         service: CloneableService<S>,
         connection: Connection<T, Bytes>,
-        on_connect: Option<Box<dyn DataFactory>>,
         on_connect_data: Extensions,
         config: ServiceConfig,
         timeout: Option<Delay>,
@@ -84,7 +81,6 @@ where
             config,
             peer_addr,
             connection,
-            on_connect,
             on_connect_data,
             ka_expire,
             ka_timer,
@@ -133,12 +129,6 @@ where
                     head.version = parts.version;
                     head.headers = parts.headers.into();
                     head.peer_addr = this.peer_addr;
-
-                    // DEPRECATED
-                    // set on_connect data
-                    if let Some(ref on_connect) = this.on_connect {
-                        on_connect.set(&mut req.extensions_mut());
-                    }
 
                     // merge on_connect_ext data into request extensions
                     req.extensions_mut().drain_from(&mut this.on_connect_data);

--- a/actix-http/src/helpers.rs
+++ b/actix-http/src/helpers.rs
@@ -3,8 +3,6 @@ use std::io;
 use bytes::{BufMut, BytesMut};
 use http::Version;
 
-use crate::extensions::Extensions;
-
 const DIGITS_START: u8 = b'0';
 
 pub(crate) fn write_status_line(version: Version, n: u16, bytes: &mut BytesMut) {
@@ -53,18 +51,6 @@ impl<'a> io::Write for Writer<'a> {
 
     fn flush(&mut self) -> io::Result<()> {
         Ok(())
-    }
-}
-
-pub(crate) trait DataFactory {
-    fn set(&self, ext: &mut Extensions);
-}
-
-pub(crate) struct Data<T>(pub(crate) T);
-
-impl<T: Clone + 'static> DataFactory for Data<T> {
-    fn set(&self, ext: &mut Extensions) {
-        ext.insert(self.0.clone())
     }
 }
 

--- a/actix-http/tests/test_openssl.rs
+++ b/actix-http/tests/test_openssl.rs
@@ -410,10 +410,8 @@ async fn test_h2_service_error() {
 async fn test_h2_on_connect() {
     let srv = test_server(move || {
         HttpService::build()
-            .on_connect(|_| 10usize)
             .on_connect_ext(|_, data| data.insert(20isize))
             .h2(|req: Request| {
-                assert!(req.extensions().contains::<usize>());
                 assert!(req.extensions().contains::<isize>());
                 ok::<_, ()>(Response::Ok().finish())
             })

--- a/actix-http/tests/test_server.rs
+++ b/actix-http/tests/test_server.rs
@@ -662,10 +662,8 @@ async fn test_h1_service_error() {
 async fn test_h1_on_connect() {
     let srv = test_server(|| {
         HttpService::build()
-            .on_connect(|_| 10usize)
             .on_connect_ext(|_, data| data.insert(20isize))
             .h1(|req: Request| {
-                assert!(req.extensions().contains::<usize>());
                 assert!(req.extensions().contains::<isize>());
                 future::ok::<_, ()>(Response::Ok().finish())
             })


### PR DESCRIPTION
## PR Type
Deprecation Removal


## PR Checklist
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
- Remove deprecated on_connect methods from actix-http and associated fields.
- Remove DataFactory trait that only existed to support the old on_connect setup.