### PR TITLE
replace tinyvec with smallvec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,7 +107,7 @@ time = { version = "0.2.7", default-features = false, features = ["std"] }
 url = "2.1"
 open-ssl = { package = "openssl", version = "0.10", optional = true }
 rust-tls = { package = "rustls", version = "0.18.0", optional = true }
-tinyvec = { version = "1", features = ["alloc"] }
+smallvec = "1.6"
 
 [dev-dependencies]
 actix = "0.10.0"

--- a/src/app_service.rs
+++ b/src/app_service.rs
@@ -10,7 +10,6 @@ use actix_router::{Path, ResourceDef, ResourceInfo, Router, Url};
 use actix_service::boxed::{self, BoxService, BoxServiceFactory};
 use actix_service::{fn_service, Service, ServiceFactory};
 use futures_util::future::{join_all, ok, FutureExt, LocalBoxFuture};
-use tinyvec::tiny_vec;
 
 use crate::config::{AppConfig, AppService};
 use crate::data::{DataFactory, FnDataFactory};
@@ -246,7 +245,6 @@ where
             inner.path.reset();
             inner.head = head;
             inner.payload = payload;
-            inner.app_data = tiny_vec![self.data.clone()];
             req
         } else {
             HttpRequest::new(


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Dependency


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Replace tinyvec with smallvec.
This would reduce 3 heap allocation with every service call (on reused HttpRequest object).

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
