### PR TITLE
fix bug where upgrade future is not reset properly

### DIFF
--- a/actix-http/src/body.rs
+++ b/actix-http/src/body.rs
@@ -3,8 +3,7 @@ use std::task::{Context, Poll};
 use std::{fmt, mem};
 
 use bytes::{Bytes, BytesMut};
-use futures_core::Stream;
-use futures_util::ready;
+use futures_core::{ready, Stream};
 use pin_project::pin_project;
 
 use crate::error::Error;

--- a/actix-http/src/h1/service.rs
+++ b/actix-http/src/h1/service.rs
@@ -338,7 +338,7 @@ where
                 .map_err(|e| log::error!("Init http service error: {:?}", e)))?;
             this = self.as_mut().project();
             *this.upgrade = Some(upgrade);
-            this.fut_ex.set(None);
+            this.fut_upg.set(None);
         }
 
         let result = ready!(this

--- a/actix-http/src/h2/service.rs
+++ b/actix-http/src/h2/service.rs
@@ -291,15 +291,11 @@ where
     type Future = H2ServiceHandlerResponse<T, S, B>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.flow
-            .borrow_mut()
-            .service
-            .poll_ready(cx)
-            .map_err(|e| {
-                let e = e.into();
-                error!("Service readiness error: {:?}", e);
-                DispatchError::Service(e)
-            })
+        self.flow.borrow_mut().service.poll_ready(cx).map_err(|e| {
+            let e = e.into();
+            error!("Service readiness error: {:?}", e);
+            DispatchError::Service(e)
+        })
     }
 
     fn call(&mut self, (io, addr): (T, Option<net::SocketAddr>)) -> Self::Future {


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Bug Fix


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Fix two instances of bug where upgrade future is not reset properly and future could be polled after resolve.

Remove the indirection method `State::poll`.

Remove some import from `futures_util` and offload some to `futures_core`.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
