### PR TITLE
remove copyless dependency

### DIFF
--- a/actix-http/Cargo.toml
+++ b/actix-http/Cargo.toml
@@ -53,7 +53,6 @@ bitflags = "1.2"
 bytes = "1"
 bytestring = "1"
 cookie = { version = "0.14.1", features = ["percent-encode"] }
-copyless = "0.1.4"
 derive_more = "0.99.5"
 either = "1.5.3"
 encoding_rs = "0.8"

--- a/actix-http/src/message.rs
+++ b/actix-http/src/message.rs
@@ -387,6 +387,12 @@ impl BoxedResponseHead {
     pub fn new(status: StatusCode) -> Self {
         RESPONSE_POOL.with(|p| p.get_message(status))
     }
+
+    pub(crate) fn take(&mut self) -> Self {
+        BoxedResponseHead {
+            head: self.head.take(),
+        }
+    }
 }
 
 impl std::ops::Deref for BoxedResponseHead {

--- a/actix-http/src/message.rs
+++ b/actix-http/src/message.rs
@@ -3,7 +3,6 @@ use std::net;
 use std::rc::Rc;
 
 use bitflags::bitflags;
-use copyless::BoxHelper;
 
 use crate::extensions::Extensions;
 use crate::header::HeaderMap;
@@ -388,12 +387,6 @@ impl BoxedResponseHead {
     pub fn new(status: StatusCode) -> Self {
         RESPONSE_POOL.with(|p| p.get_message(status))
     }
-
-    pub(crate) fn take(&mut self) -> Self {
-        BoxedResponseHead {
-            head: self.head.take(),
-        }
-    }
 }
 
 impl std::ops::Deref for BoxedResponseHead {
@@ -480,17 +473,17 @@ impl BoxedResponsePool {
             BoxedResponseHead { head: Some(head) }
         } else {
             BoxedResponseHead {
-                head: Some(Box::alloc().init(ResponseHead::new(status))),
+                head: Some(Box::new(ResponseHead::new(status))),
             }
         }
     }
 
     #[inline]
     /// Release request instance
-    fn release(&self, msg: Box<ResponseHead>) {
+    fn release(&self, mut msg: Box<ResponseHead>) {
         let v = &mut self.0.borrow_mut();
         if v.len() < 128 {
-            msg.extensions.borrow_mut().clear();
+            msg.extensions.get_mut().clear();
             v.push(msg);
         }
     }

--- a/actix-http/src/response.rs
+++ b/actix-http/src/response.rs
@@ -1,9 +1,6 @@
 //! Http response
 use std::cell::{Ref, RefMut};
 use std::convert::TryFrom;
-use std::future::Future;
-use std::pin::Pin;
-use std::task::{Context, Poll};
 use std::{fmt, str};
 
 use bytes::{Bytes, BytesMut};
@@ -278,18 +275,6 @@ impl<B: MessageBody> fmt::Debug for Response<B> {
         }
         let _ = writeln!(f, "  body: {:?}", self.body.size());
         res
-    }
-}
-
-impl Future for Response {
-    type Output = Result<Response, Error>;
-
-    fn poll(mut self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Self::Output> {
-        Poll::Ready(Ok(Response {
-            head: self.head.take(),
-            body: self.body.take_body(),
-            error: self.error.take(),
-        }))
     }
 }
 
@@ -753,14 +738,6 @@ impl<'a> From<&'a ResponseHead> for ResponseBuilder {
             err: None,
             cookies: jar,
         }
-    }
-}
-
-impl Future for ResponseBuilder {
-    type Output = Result<Response, Error>;
-
-    fn poll(mut self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Self::Output> {
-        Poll::Ready(Ok(self.finish()))
     }
 }
 


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Refactor


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->
- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Remove `copyless` from dependency. There is only one instance of usage and the benefit is not impactful to make it worth. Use `Box::new` instead for heap allocation.

Clear `ResponseHead`'s extensions by mut reference to reduce runtime borrow check.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
