### PR TITLE
actix-files: Fix If-(Un)Modified to not consider sub-seconds

### DIFF
--- a/actix-files/CHANGES.md
+++ b/actix-files/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased - 2021-xx-xx
 
+* Fix If-Modified-Since and If-Unmodified-Since to not compare using sub-second timestamps.
 
 ## 0.6.0-beta.1 - 2021-01-07
 * `HttpRange::parse` now has its own error type.

--- a/actix-files/CHANGES.md
+++ b/actix-files/CHANGES.md
@@ -1,8 +1,9 @@
 # Changes
 
 ## Unreleased - 2021-xx-xx
+* Fix If-Modified-Since and If-Unmodified-Since to not compare using sub-second timestamps. [#1887]
 
-* Fix If-Modified-Since and If-Unmodified-Since to not compare using sub-second timestamps.
+[#1887]: https://github.com/actix/actix-web/pull/1887
 
 ## 0.6.0-beta.1 - 2021-01-07
 * `HttpRange::parse` now has its own error type.

--- a/actix-files/src/lib.rs
+++ b/actix-files/src/lib.rs
@@ -117,6 +117,18 @@ mod tests {
     }
 
     #[actix_rt::test]
+    async fn test_if_modified_since_without_if_none_match_same() {
+        let file = NamedFile::open("Cargo.toml").unwrap();
+        let since = file.last_modified().unwrap();
+
+        let req = TestRequest::default()
+            .header(header::IF_MODIFIED_SINCE, since)
+            .to_http_request();
+        let resp = file.respond_to(&req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_MODIFIED);
+    }
+
+    #[actix_rt::test]
     async fn test_if_modified_since_with_if_none_match() {
         let file = NamedFile::open("Cargo.toml").unwrap();
         let since =
@@ -128,6 +140,30 @@ mod tests {
             .to_http_request();
         let resp = file.respond_to(&req).await.unwrap();
         assert_ne!(resp.status(), StatusCode::NOT_MODIFIED);
+    }
+
+    #[actix_rt::test]
+    async fn test_if_unmodified_since() {
+        let file = NamedFile::open("Cargo.toml").unwrap();
+        let since = file.last_modified().unwrap();
+
+        let req = TestRequest::default()
+            .header(header::IF_UNMODIFIED_SINCE, since)
+            .to_http_request();
+        let resp = file.respond_to(&req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[actix_rt::test]
+    async fn test_if_unmodified_since_failed() {
+        let file = NamedFile::open("Cargo.toml").unwrap();
+        let since = header::HttpDate::from(SystemTime::UNIX_EPOCH);
+
+        let req = TestRequest::default()
+            .header(header::IF_UNMODIFIED_SINCE, since)
+            .to_http_request();
+        let resp = file.respond_to(&req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::PRECONDITION_FAILED);
     }
 
     #[actix_rt::test]

--- a/actix-files/src/named.rs
+++ b/actix-files/src/named.rs
@@ -332,7 +332,7 @@ impl NamedFile {
             let t2: SystemTime = since.clone().into();
 
             match (t1.duration_since(UNIX_EPOCH), t2.duration_since(UNIX_EPOCH)) {
-                (Ok(t1), Ok(t2)) => t1 > t2,
+                (Ok(t1), Ok(t2)) => t1.as_secs() > t2.as_secs(),
                 _ => false,
             }
         } else {
@@ -351,7 +351,7 @@ impl NamedFile {
             let t2: SystemTime = since.clone().into();
 
             match (t1.duration_since(UNIX_EPOCH), t2.duration_since(UNIX_EPOCH)) {
-                (Ok(t1), Ok(t2)) => t1 <= t2,
+                (Ok(t1), Ok(t2)) => t1.as_secs() <= t2.as_secs(),
                 _ => false,
             }
         } else {


### PR DESCRIPTION
## PR Type
Bug Fix

## PR Checklist
- [x] Tests for the changes have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt

## Overview

Fix If-Modified-Since and If-Unmodified-Since to not compare using sub-second values.

If you have a filesystem with sub-second precision on modified time, If-Modified-Since will fail to work properly.  The browser will be providing a timestamp that is truncated (since http dates don't use microseconds so it gets lost in the conversion), but actix-files will compare using a timestamp that is less than a second later, since it is checking the timestamp untruncated.

This bug doesn't typically come up with default behavior because If-None-Match has precedence over If-Modified-Since.  I'm not sure when If-Unmodified-Since would be used in practice, but I updated it too.

I looked at changing HttpDate instead (since it shouldn't contain sub-second values anyway), but the underlying type doesn't have a good way to truncate it that I could see.