### PR TITLE
don't run awc doctests that rely on external public endpoints

### DIFF
--- a/awc/src/lib.rs
+++ b/awc/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! ## Making a GET request
 //!
-//! ```rust
+//! ```no_run
 //! # #[actix_rt::main]
 //! # async fn main() -> Result<(), awc::error::SendRequestError> {
 //! let mut client = awc::Client::default();
@@ -20,7 +20,7 @@
 //!
 //! ### Raw body contents
 //!
-//! ```rust
+//! ```no_run
 //! # #[actix_rt::main]
 //! # async fn main() -> Result<(), awc::error::SendRequestError> {
 //! let mut client = awc::Client::default();
@@ -33,7 +33,7 @@
 //!
 //! ### Forms
 //!
-//! ```rust
+//! ```no_run
 //! # #[actix_rt::main]
 //! # async fn main() -> Result<(), awc::error::SendRequestError> {
 //! let params = [("foo", "bar"), ("baz", "quux")];
@@ -48,7 +48,7 @@
 //!
 //! ### JSON
 //!
-//! ```rust
+//! ```no_run
 //! # #[actix_rt::main]
 //! # async fn main() -> Result<(), awc::error::SendRequestError> {
 //! let request = serde_json::json!({
@@ -66,7 +66,7 @@
 //!
 //! ## WebSocket support
 //!
-//! ```
+//! ```no_run
 //! # #[actix_rt::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! use futures_util::{sink::SinkExt, stream::StreamExt};

--- a/awc/src/ws.rs
+++ b/awc/src/ws.rs
@@ -4,7 +4,7 @@
 //!
 //! # Example
 //!
-//! ```
+//! ```no_run
 //! use awc::{Client, ws};
 //! use futures_util::{sink::SinkExt, stream::StreamExt};
 //!


### PR DESCRIPTION
## PR Type
Fix


## PR Checklist
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Format code with the latest stable rustfmt


## Overview
These tests frequently fail in CI so set them to `no_run`.