### PR TITLE
use sync method on Responder trait

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,11 @@
 # Changes
 
 ## Unreleased - 2021-xx-xx
-
+### Changed
+* Rework `Responder` trait to be sync and returns `Response`/`HttpResponse` directly.
+  Making it more simple and performant. [#1891]
+  
+[#1891]: https://github.com/actix/actix-web/pull/1891
 
 ## 4.0.0-beta.1 - 2021-01-07
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,3 +139,7 @@ harness = false
 [[bench]]
 name = "service"
 harness = false
+
+[[bench]]
+name = "responder"
+harness = false

--- a/actix-files/src/named.rs
+++ b/actix-files/src/named.rs
@@ -19,7 +19,6 @@ use actix_web::{
     Error, HttpMessage, HttpRequest, HttpResponse, Responder,
 };
 use bitflags::bitflags;
-use futures_util::future::{ready, Ready};
 use mime_guess::from_path;
 
 use crate::ChunkedReadFile;
@@ -495,10 +494,8 @@ fn none_match(etag: Option<&header::EntityTag>, req: &HttpRequest) -> bool {
 }
 
 impl Responder for NamedFile {
-    type Error = Error;
-    type Future = Ready<Result<HttpResponse, Error>>;
-
-    fn respond_to(self, req: &HttpRequest) -> Self::Future {
-        ready(self.into_response(req))
+    fn respond_to(self, req: &HttpRequest) -> HttpResponse {
+        self.into_response(req)
+            .unwrap_or_else(|e| HttpResponse::from_error(e))
     }
 }

--- a/actix-files/src/service.rs
+++ b/actix-files/src/service.rs
@@ -120,10 +120,8 @@ impl Service<ServiceRequest> for FilesService {
                         named_file.flags = self.file_flags;
 
                         let (req, _) = req.into_parts();
-                        Either::Left(ok(match named_file.into_response(&req) {
-                            Ok(item) => ServiceResponse::new(req, item),
-                            Err(e) => ServiceResponse::from_err(e, req),
-                        }))
+                        let res = named_file.into_response(&req);
+                        Either::Left(ok(ServiceResponse::new(req, res)))
                     }
                     Err(e) => self.handle_err(e, req),
                 }
@@ -154,12 +152,8 @@ impl Service<ServiceRequest> for FilesService {
                     named_file.flags = self.file_flags;
 
                     let (req, _) = req.into_parts();
-                    match named_file.into_response(&req) {
-                        Ok(item) => {
-                            Either::Left(ok(ServiceResponse::new(req.clone(), item)))
-                        }
-                        Err(e) => Either::Left(ok(ServiceResponse::from_err(e, req))),
-                    }
+                    let res = named_file.into_response(&req);
+                    Either::Left(ok(ServiceResponse::new(req, res)))
                 }
                 Err(e) => self.handle_err(e, req),
             }

--- a/benches/responder.rs
+++ b/benches/responder.rs
@@ -1,0 +1,113 @@
+use std::future::Future;
+use std::time::Instant;
+
+use actix_http::Response;
+use actix_web::http::StatusCode;
+use actix_web::test::TestRequest;
+use actix_web::{error, Error, HttpRequest, HttpResponse, Responder};
+use criterion::{criterion_group, criterion_main, Criterion};
+use futures_util::future::{ready, Either, Ready};
+
+// responder simulate the old responder trait.
+trait FutureResponder {
+    type Error;
+    type Future: Future<Output = Result<HttpResponse, Self::Error>>;
+
+    fn future_respond_to(self, req: &HttpRequest) -> Self::Future;
+}
+
+// a simple option responder type.
+struct OptionResponder<T>(Option<T>);
+
+// a simple wrapper type around string
+struct StringResponder(String);
+
+impl FutureResponder for StringResponder {
+    type Error = Error;
+    type Future = Ready<Result<Response, Self::Error>>;
+
+    fn future_respond_to(self, _: &HttpRequest) -> Self::Future {
+        // this is default builder for string response in both new and old responder trait.
+        ready(Ok(Response::build(StatusCode::OK)
+            .content_type("text/plain; charset=utf-8")
+            .body(self.0)))
+    }
+}
+
+impl<T> FutureResponder for OptionResponder<T>
+where
+    T: FutureResponder,
+    T::Future: Future<Output = Result<Response, Error>>,
+{
+    type Error = Error;
+    type Future = Either<T::Future, Ready<Result<HttpResponse, Self::Error>>>;
+
+    fn future_respond_to(self, req: &HttpRequest) -> Self::Future {
+        match self.0 {
+            Some(t) => Either::Left(t.future_respond_to(req)),
+            None => Either::Right(ready(Err(error::ErrorInternalServerError("err")))),
+        }
+    }
+}
+
+impl Responder for StringResponder {
+    fn respond_to(self, _: &HttpRequest) -> HttpResponse {
+        Response::build(StatusCode::OK)
+            .content_type("text/plain; charset=utf-8")
+            .body(self.0)
+    }
+}
+
+impl<T: Responder> Responder for OptionResponder<T> {
+    fn respond_to(self, req: &HttpRequest) -> HttpResponse {
+        match self.0 {
+            Some(t) => t.respond_to(req),
+            None => Response::from_error(error::ErrorInternalServerError("err")),
+        }
+    }
+}
+
+fn future_responder(c: &mut Criterion) {
+    let rt = actix_rt::System::new("test");
+    let req = TestRequest::default().to_http_request();
+
+    c.bench_function("future_responder", move |b| {
+        b.iter_custom(|_| {
+            let futs = (0..100_000).map(|_| async {
+                StringResponder(String::from("Hello World!!"))
+                    .future_respond_to(&req)
+                    .await
+            });
+
+            let futs = futures_util::future::join_all(futs);
+
+            let start = Instant::now();
+
+            let _res = rt.block_on(async { futs.await });
+
+            start.elapsed()
+        })
+    });
+}
+
+fn responder(c: &mut Criterion) {
+    let rt = actix_rt::System::new("test");
+    let req = TestRequest::default().to_http_request();
+    c.bench_function("responder", move |b| {
+        b.iter_custom(|_| {
+            let responders =
+                (0..100_000).map(|_| StringResponder(String::from("Hello World!!")));
+
+            let start = Instant::now();
+            let _res = rt.block_on(async {
+                // don't need runtime block on but to be fair.
+                responders.map(|r| r.respond_to(&req)).collect::<Vec<_>>()
+            });
+
+            start.elapsed()
+        })
+    });
+}
+
+criterion_group!(responder_bench, future_responder, responder);
+criterion_main!(responder_bench);

--- a/src/responder.rs
+++ b/src/responder.rs
@@ -1,8 +1,4 @@
 use std::convert::TryFrom;
-use std::future::Future;
-use std::marker::PhantomData;
-use std::pin::Pin;
-use std::task::{Context, Poll};
 
 use actix_http::error::InternalError;
 use actix_http::http::{
@@ -10,9 +6,6 @@ use actix_http::http::{
 };
 use actix_http::{Error, Response, ResponseBuilder};
 use bytes::{Bytes, BytesMut};
-use futures_util::future::{err, ok, Either as EitherFuture, Ready};
-use futures_util::ready;
-use pin_project::pin_project;
 
 use crate::request::HttpRequest;
 
@@ -20,14 +13,8 @@ use crate::request::HttpRequest;
 ///
 /// Types that implement this trait can be used as the return type of a handler.
 pub trait Responder {
-    /// The associated error which can be returned.
-    type Error: Into<Error>;
-
-    /// The future response value.
-    type Future: Future<Output = Result<Response, Self::Error>>;
-
-    /// Convert itself to `AsyncResult` or `Error`.
-    fn respond_to(self, req: &HttpRequest) -> Self::Future;
+    /// Convert self to `Response`.
+    fn respond_to(self, req: &HttpRequest) -> Response;
 
     /// Override a status code for a Responder.
     ///
@@ -77,28 +64,17 @@ pub trait Responder {
 }
 
 impl Responder for Response {
-    type Error = Error;
-    type Future = Ready<Result<Response, Error>>;
-
     #[inline]
-    fn respond_to(self, _: &HttpRequest) -> Self::Future {
-        ok(self)
+    fn respond_to(self, _: &HttpRequest) -> Response {
+        self
     }
 }
 
-impl<T> Responder for Option<T>
-where
-    T: Responder,
-{
-    type Error = T::Error;
-    type Future = EitherFuture<T::Future, Ready<Result<Response, T::Error>>>;
-
-    fn respond_to(self, req: &HttpRequest) -> Self::Future {
+impl<T: Responder> Responder for Option<T> {
+    fn respond_to(self, req: &HttpRequest) -> Response {
         match self {
-            Some(t) => EitherFuture::Left(t.respond_to(req)),
-            None => {
-                EitherFuture::Right(ok(Response::build(StatusCode::NOT_FOUND).finish()))
-            }
+            Some(t) => t.respond_to(req),
+            None => Response::build(StatusCode::NOT_FOUND).finish(),
         }
     }
 }
@@ -108,109 +84,74 @@ where
     T: Responder,
     E: Into<Error>,
 {
-    type Error = Error;
-    type Future = EitherFuture<
-        ResponseFuture<T::Future, T::Error>,
-        Ready<Result<Response, Error>>,
-    >;
-
-    fn respond_to(self, req: &HttpRequest) -> Self::Future {
+    fn respond_to(self, req: &HttpRequest) -> Response {
         match self {
-            Ok(val) => EitherFuture::Left(ResponseFuture::new(val.respond_to(req))),
-            Err(e) => EitherFuture::Right(err(e.into())),
+            Ok(val) => val.respond_to(req),
+            Err(e) => Response::from_error(e.into()),
         }
     }
 }
 
 impl Responder for ResponseBuilder {
-    type Error = Error;
-    type Future = Ready<Result<Response, Error>>;
-
     #[inline]
-    fn respond_to(mut self, _: &HttpRequest) -> Self::Future {
-        ok(self.finish())
+    fn respond_to(mut self, _: &HttpRequest) -> Response {
+        self.finish()
     }
 }
 
-impl<T> Responder for (T, StatusCode)
-where
-    T: Responder,
-{
-    type Error = T::Error;
-    type Future = CustomResponderFut<T>;
-
-    fn respond_to(self, req: &HttpRequest) -> Self::Future {
-        CustomResponderFut {
-            fut: self.0.respond_to(req),
-            status: Some(self.1),
-            headers: None,
-        }
+impl<T: Responder> Responder for (T, StatusCode) {
+    fn respond_to(self, req: &HttpRequest) -> Response {
+        let mut res = self.0.respond_to(req);
+        *res.status_mut() = self.1;
+        res
     }
 }
 
 impl Responder for &'static str {
-    type Error = Error;
-    type Future = Ready<Result<Response, Error>>;
-
-    fn respond_to(self, _: &HttpRequest) -> Self::Future {
-        ok(Response::build(StatusCode::OK)
+    fn respond_to(self, _: &HttpRequest) -> Response {
+        Response::build(StatusCode::OK)
             .content_type("text/plain; charset=utf-8")
-            .body(self))
+            .body(self)
     }
 }
 
 impl Responder for &'static [u8] {
-    type Error = Error;
-    type Future = Ready<Result<Response, Error>>;
-
-    fn respond_to(self, _: &HttpRequest) -> Self::Future {
-        ok(Response::build(StatusCode::OK)
+    fn respond_to(self, _: &HttpRequest) -> Response {
+        Response::build(StatusCode::OK)
             .content_type("application/octet-stream")
-            .body(self))
+            .body(self)
     }
 }
 
 impl Responder for String {
-    type Error = Error;
-    type Future = Ready<Result<Response, Error>>;
-
-    fn respond_to(self, _: &HttpRequest) -> Self::Future {
-        ok(Response::build(StatusCode::OK)
+    fn respond_to(self, _: &HttpRequest) -> Response {
+        Response::build(StatusCode::OK)
             .content_type("text/plain; charset=utf-8")
-            .body(self))
+            .body(self)
     }
 }
 
 impl<'a> Responder for &'a String {
-    type Error = Error;
-    type Future = Ready<Result<Response, Error>>;
-
-    fn respond_to(self, _: &HttpRequest) -> Self::Future {
-        ok(Response::build(StatusCode::OK)
+    fn respond_to(self, _: &HttpRequest) -> Response {
+        Response::build(StatusCode::OK)
             .content_type("text/plain; charset=utf-8")
-            .body(self))
+            .body(self)
     }
 }
 
 impl Responder for Bytes {
-    type Error = Error;
-    type Future = Ready<Result<Response, Error>>;
-
-    fn respond_to(self, _: &HttpRequest) -> Self::Future {
-        ok(Response::build(StatusCode::OK)
+    fn respond_to(self, _: &HttpRequest) -> Response {
+        Response::build(StatusCode::OK)
             .content_type("application/octet-stream")
-            .body(self))
+            .body(self)
     }
 }
 
 impl Responder for BytesMut {
-    type Error = Error;
-    type Future = Ready<Result<Response, Error>>;
-
-    fn respond_to(self, _: &HttpRequest) -> Self::Future {
-        ok(Response::build(StatusCode::OK)
+    fn respond_to(self, _: &HttpRequest) -> Response {
+        Response::build(StatusCode::OK)
             .content_type("application/octet-stream")
-            .body(self))
+            .body(self)
     }
 }
 
@@ -290,45 +231,20 @@ impl<T: Responder> CustomResponder<T> {
 }
 
 impl<T: Responder> Responder for CustomResponder<T> {
-    type Error = T::Error;
-    type Future = CustomResponderFut<T>;
+    fn respond_to(self, req: &HttpRequest) -> Response {
+        let mut res = self.responder.respond_to(req);
 
-    fn respond_to(self, req: &HttpRequest) -> Self::Future {
-        CustomResponderFut {
-            fut: self.responder.respond_to(req),
-            status: self.status,
-            headers: self.headers,
-        }
-    }
-}
-
-#[pin_project]
-pub struct CustomResponderFut<T: Responder> {
-    #[pin]
-    fut: T::Future,
-    status: Option<StatusCode>,
-    headers: Option<HeaderMap>,
-}
-
-impl<T: Responder> Future for CustomResponderFut<T> {
-    type Output = Result<Response, T::Error>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let this = self.project();
-
-        let mut res = match ready!(this.fut.poll(cx)) {
-            Ok(res) => res,
-            Err(e) => return Poll::Ready(Err(e)),
-        };
-        if let Some(status) = this.status.take() {
+        if let Some(status) = self.status {
             *res.status_mut() = status;
         }
-        if let Some(ref headers) = this.headers {
+
+        if let Some(ref headers) = self.headers {
             for (k, v) in headers {
                 res.headers_mut().insert(k.clone(), v.clone());
             }
         }
-        Poll::Ready(Ok(res))
+
+        res
     }
 }
 
@@ -336,40 +252,8 @@ impl<T> Responder for InternalError<T>
 where
     T: std::fmt::Debug + std::fmt::Display + 'static,
 {
-    type Error = Error;
-    type Future = Ready<Result<Response, Error>>;
-
-    fn respond_to(self, _: &HttpRequest) -> Self::Future {
-        let err: Error = self.into();
-        ok(err.into())
-    }
-}
-
-#[pin_project]
-pub struct ResponseFuture<T, E> {
-    #[pin]
-    fut: T,
-    _phantom: PhantomData<E>,
-}
-
-impl<T, E> ResponseFuture<T, E> {
-    pub fn new(fut: T) -> Self {
-        ResponseFuture {
-            fut,
-            _phantom: PhantomData,
-        }
-    }
-}
-
-impl<T, E> Future for ResponseFuture<T, E>
-where
-    T: Future<Output = Result<Response, E>>,
-    E: Into<Error>,
-{
-    type Output = Result<Response, Error>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        Poll::Ready(ready!(self.project().fut.poll(cx)).map_err(|e| e.into()))
+    fn respond_to(self, _: &HttpRequest) -> Response {
+        Response::from_error(self.into())
     }
 }
 
@@ -382,7 +266,7 @@ pub(crate) mod tests {
     use crate::dev::{Body, ResponseBody};
     use crate::http::{header::CONTENT_TYPE, HeaderValue, StatusCode};
     use crate::test::{init_service, TestRequest};
-    use crate::{error, web, App, HttpResponse};
+    use crate::{error, web, App};
 
     #[actix_rt::test]
     async fn test_option_responder() {
@@ -441,7 +325,7 @@ pub(crate) mod tests {
     async fn test_responder() {
         let req = TestRequest::default().to_http_request();
 
-        let resp: HttpResponse = "test".respond_to(&req).await.unwrap();
+        let resp = "test".respond_to(&req);
         assert_eq!(resp.status(), StatusCode::OK);
         assert_eq!(resp.body().bin_ref(), b"test");
         assert_eq!(
@@ -449,7 +333,7 @@ pub(crate) mod tests {
             HeaderValue::from_static("text/plain; charset=utf-8")
         );
 
-        let resp: HttpResponse = b"test".respond_to(&req).await.unwrap();
+        let resp = b"test".respond_to(&req);
         assert_eq!(resp.status(), StatusCode::OK);
         assert_eq!(resp.body().bin_ref(), b"test");
         assert_eq!(
@@ -457,7 +341,7 @@ pub(crate) mod tests {
             HeaderValue::from_static("application/octet-stream")
         );
 
-        let resp: HttpResponse = "test".to_string().respond_to(&req).await.unwrap();
+        let resp = "test".to_string().respond_to(&req);
         assert_eq!(resp.status(), StatusCode::OK);
         assert_eq!(resp.body().bin_ref(), b"test");
         assert_eq!(
@@ -465,7 +349,7 @@ pub(crate) mod tests {
             HeaderValue::from_static("text/plain; charset=utf-8")
         );
 
-        let resp: HttpResponse = (&"test".to_string()).respond_to(&req).await.unwrap();
+        let resp = (&"test".to_string()).respond_to(&req);
         assert_eq!(resp.status(), StatusCode::OK);
         assert_eq!(resp.body().bin_ref(), b"test");
         assert_eq!(
@@ -473,8 +357,7 @@ pub(crate) mod tests {
             HeaderValue::from_static("text/plain; charset=utf-8")
         );
 
-        let resp: HttpResponse =
-            Bytes::from_static(b"test").respond_to(&req).await.unwrap();
+        let resp = Bytes::from_static(b"test").respond_to(&req);
         assert_eq!(resp.status(), StatusCode::OK);
         assert_eq!(resp.body().bin_ref(), b"test");
         assert_eq!(
@@ -482,10 +365,7 @@ pub(crate) mod tests {
             HeaderValue::from_static("application/octet-stream")
         );
 
-        let resp: HttpResponse = BytesMut::from(b"test".as_ref())
-            .respond_to(&req)
-            .await
-            .unwrap();
+        let resp = BytesMut::from(b"test".as_ref()).respond_to(&req);
         assert_eq!(resp.status(), StatusCode::OK);
         assert_eq!(resp.body().bin_ref(), b"test");
         assert_eq!(
@@ -494,11 +374,8 @@ pub(crate) mod tests {
         );
 
         // InternalError
-        let resp: HttpResponse =
-            error::InternalError::new("err", StatusCode::BAD_REQUEST)
-                .respond_to(&req)
-                .await
-                .unwrap();
+        let resp =
+            error::InternalError::new("err", StatusCode::BAD_REQUEST).respond_to(&req);
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     }
 
@@ -507,10 +384,7 @@ pub(crate) mod tests {
         let req = TestRequest::default().to_http_request();
 
         // Result<I, E>
-        let resp: HttpResponse = Ok::<_, Error>("test".to_string())
-            .respond_to(&req)
-            .await
-            .unwrap();
+        let resp = Ok::<_, Error>("test".to_string()).respond_to(&req);
         assert_eq!(resp.status(), StatusCode::OK);
         assert_eq!(resp.body().bin_ref(), b"test");
         assert_eq!(
@@ -520,9 +394,9 @@ pub(crate) mod tests {
 
         let res =
             Err::<String, _>(error::InternalError::new("err", StatusCode::BAD_REQUEST))
-                .respond_to(&req)
-                .await;
-        assert!(res.is_err());
+                .respond_to(&req);
+
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST);
     }
 
     #[actix_rt::test]
@@ -531,18 +405,15 @@ pub(crate) mod tests {
         let res = "test"
             .to_string()
             .with_status(StatusCode::BAD_REQUEST)
-            .respond_to(&req)
-            .await
-            .unwrap();
+            .respond_to(&req);
+
         assert_eq!(res.status(), StatusCode::BAD_REQUEST);
         assert_eq!(res.body().bin_ref(), b"test");
 
         let res = "test"
             .to_string()
             .with_header("content-type", "json")
-            .respond_to(&req)
-            .await
-            .unwrap();
+            .respond_to(&req);
 
         assert_eq!(res.status(), StatusCode::OK);
         assert_eq!(res.body().bin_ref(), b"test");
@@ -555,19 +426,14 @@ pub(crate) mod tests {
     #[actix_rt::test]
     async fn test_tuple_responder_with_status_code() {
         let req = TestRequest::default().to_http_request();
-        let res = ("test".to_string(), StatusCode::BAD_REQUEST)
-            .respond_to(&req)
-            .await
-            .unwrap();
+        let res = ("test".to_string(), StatusCode::BAD_REQUEST).respond_to(&req);
         assert_eq!(res.status(), StatusCode::BAD_REQUEST);
         assert_eq!(res.body().bin_ref(), b"test");
 
         let req = TestRequest::default().to_http_request();
         let res = ("test".to_string(), StatusCode::OK)
             .with_header("content-type", "json")
-            .respond_to(&req)
-            .await
-            .unwrap();
+            .respond_to(&req);
         assert_eq!(res.status(), StatusCode::OK);
         assert_eq!(res.body().bin_ref(), b"test");
         assert_eq!(


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Refactor


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Through out `actix-web` `actix-extras` and `examples` repo there isn't a single instance where `Responder` returns a truely future type. They are all types wrapped in future types for an illusion of async.

This adds a little bit overhead(almost non measurable though) and complicated `Responder` trait with two associated types and future wrappers to deal with the difference of various future types.

This PR address this by making the trait sync and returns only `Response<Body>` type. It makes the trait more simple and performant(in theory).

This is a breaking change for people using futures inside custom `Responder` trait but it would be fairly easy to move these async code into handler function where async code should be ran. 

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
