### PR TITLE
refactor Scope

### DIFF
--- a/src/app_service.rs
+++ b/src/app_service.rs
@@ -62,7 +62,8 @@ where
     type Future = LocalBoxFuture<'static, Result<Self::Service, Self::InitError>>;
 
     fn new_service(&self, config: AppConfig) -> Self::Future {
-        // update resource default service
+        // set AppService's default service to 404 NotFound
+        // if no user defined default service exists.
         let default = self.default.clone().unwrap_or_else(|| {
             Rc::new(boxed::factory(fn_service(|req: ServiceRequest| async {
                 Ok(req.into_response(Response::NotFound().finish()))


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Refactor


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Documentation comments have been added / updated.
- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Remove unused _ready field from `ScopeService`. 

Simplify default service type and fallback default service logic. Reduce one heap allocation when it's manually set. 

Rename data field to app_data to be consistent with other types that treat `Extensions` type as app data container.

Simplify new_service method with async block to improve readability and reduce LOC.


<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
