### PR TITLE
simplify h1 dispatcher

### DIFF
--- a/actix-http/src/h1/dispatcher.rs
+++ b/actix-http/src/h1/dispatcher.rs
@@ -287,42 +287,38 @@ where
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Result<bool, DispatchError> {
-        if self.write_buf.is_empty() {
+        let len = self.write_buf.len();
+        if len == 0 {
             return Ok(false);
         }
 
-        let len = self.write_buf.len();
-        let mut written = 0;
         let InnerDispatcherProj { io, write_buf, .. } = self.project();
         let mut io = Pin::new(io.as_mut().unwrap());
+
+        let mut written = 0;
         while written < len {
             match io.as_mut().poll_write(cx, &write_buf[written..]) {
-                Poll::Ready(Ok(0)) => {
-                    return Err(DispatchError::Io(io::Error::new(
-                        io::ErrorKind::WriteZero,
-                        "",
-                    )));
-                }
                 Poll::Ready(Ok(n)) => {
-                    written += n;
+                    if n == 0 {
+                        return Err(DispatchError::Io(io::Error::new(
+                            io::ErrorKind::WriteZero,
+                            "",
+                        )));
+                    } else {
+                        written += n;
+                    }
                 }
                 Poll::Pending => {
-                    if written > 0 {
-                        write_buf.advance(written);
-                    }
+                    write_buf.advance(written);
                     return Ok(true);
                 }
                 Poll::Ready(Err(err)) => return Err(DispatchError::Io(err)),
             }
         }
 
-        if written == write_buf.len() {
-            // SAFETY: setting length to 0 is safe
-            // skips one length check vs truncate
-            unsafe { write_buf.set_len(0) }
-        } else {
-            write_buf.advance(written);
-        }
+        // SAFETY: setting length to 0 is safe
+        // skips one length check vs truncate
+        unsafe { write_buf.set_len(0) }
 
         Ok(false)
     }
@@ -766,19 +762,12 @@ where
                     } else {
                         // flush buffer
                         inner.as_mut().poll_flush(cx)?;
-                        if !inner.write_buf.is_empty() || inner.io.is_none() {
+                        if !inner.write_buf.is_empty() {
                             Poll::Pending
                         } else {
-                            match Pin::new(inner.project().io)
-                                .as_pin_mut()
-                                .unwrap()
+                            Pin::new(inner.project().io.as_mut().unwrap())
                                 .poll_shutdown(cx)
-                            {
-                                Poll::Ready(res) => {
-                                    Poll::Ready(res.map_err(DispatchError::from))
-                                }
-                                Poll::Pending => Poll::Pending,
-                            }
+                                .map_err(DispatchError::from)
                         }
                     }
                 } else {
@@ -920,7 +909,7 @@ where
             buf.reserve(HW_BUFFER_SIZE - remaining);
         }
 
-        match read(cx, io, buf) {
+        match actix_codec::poll_read_buf(Pin::new(io), cx, buf) {
             Poll::Pending => {
                 return if read_some { Ok(Some(false)) } else { Ok(None) };
             }
@@ -946,17 +935,6 @@ where
             }
         }
     }
-}
-
-fn read<T>(
-    cx: &mut Context<'_>,
-    io: &mut T,
-    buf: &mut BytesMut,
-) -> Poll<Result<usize, io::Error>>
-where
-    T: AsyncRead + Unpin,
-{
-    actix_codec::poll_read_buf(Pin::new(io), cx, buf)
 }
 
 #[cfg(test)]

--- a/actix-http/src/h1/dispatcher.rs
+++ b/actix-http/src/h1/dispatcher.rs
@@ -298,16 +298,13 @@ where
         let mut written = 0;
         while written < len {
             match io.as_mut().poll_write(cx, &write_buf[written..]) {
-                Poll::Ready(Ok(n)) => {
-                    if n == 0 {
-                        return Err(DispatchError::Io(io::Error::new(
-                            io::ErrorKind::WriteZero,
-                            "",
-                        )));
-                    } else {
-                        written += n;
-                    }
+                Poll::Ready(Ok(0)) => {
+                    return Err(DispatchError::Io(io::Error::new(
+                        io::ErrorKind::WriteZero,
+                        "",
+                    )))
                 }
+                Poll::Ready(Ok(n)) => written += n,
                 Poll::Pending => {
                     write_buf.advance(written);
                     return Ok(true);


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Refactor


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Reduce branches in hot path of `poll_flush`. `BytesMut::advance` internally would check on 0 len case.
`BytesMut::set_len(0)` only reachable when `written == len`.

Reomve a redendent `Option::is_none` check for `InnerDispatcher.io`. The only case when io field is none is when the `DispatcherState` enters `Upgrade` variant. Where it would never switch to `Normal` variant until it's resolved.

Simplify `poll_shutdown`.

Remove one time usage free function `read`.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
