### PR TITLE
Remove HttpResponseBuilder::json2()

### DIFF
--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -14,6 +14,8 @@
 * Renamed `IntoHeaderValue::{try_into => try_into_value}` to avoid ambiguity with std
   `TryInto` trait. [#1894]
 * `Extensions::insert` returns Option of replaced item. [#1904]
+* Remove `HttpResponseBuilder::json2()` and make `HttpResponseBuilder::json()` take a value by
+  reference. [#1903]
 
 ### Removed
 * `ResponseBuilder::set`; use `ResponseBuilder::insert_header`. [#1869]
@@ -24,6 +26,7 @@
 
 [#1869]: https://github.com/actix/actix-web/pull/1869
 [#1894]: https://github.com/actix/actix-web/pull/1894
+[#1903]: https://github.com/actix/actix-web/pull/1903
 [#1904]: https://github.com/actix/actix-web/pull/1904
 [#1912]: https://github.com/actix/actix-web/pull/1912
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -239,7 +239,7 @@ where
 ///             web::resource("/people")
 ///                 .route(web::post().to(|person: web::Json<Person>| async {
 ///                     HttpResponse::Ok()
-///                         .json(person.into_inner())})
+///                         .json(person)})
 ///                     ))
 ///     ).await;
 ///
@@ -299,7 +299,7 @@ where
 ///             web::resource("/people")
 ///                 .route(web::post().to(|person: web::Json<Person>| async {
 ///                     HttpResponse::Ok()
-///                         .json(person.into_inner())})
+///                         .json(person)})
 ///                     ))
 ///     ).await;
 ///
@@ -1121,9 +1121,7 @@ mod tests {
     #[actix_rt::test]
     async fn test_response_json() {
         let mut app = init_service(App::new().service(web::resource("/people").route(
-            web::post().to(|person: web::Json<Person>| {
-                HttpResponse::Ok().json(person.into_inner())
-            }),
+            web::post().to(|person: web::Json<Person>| HttpResponse::Ok().json(person)),
         )))
         .await;
 
@@ -1142,9 +1140,7 @@ mod tests {
     #[actix_rt::test]
     async fn test_body_json() {
         let mut app = init_service(App::new().service(web::resource("/people").route(
-            web::post().to(|person: web::Json<Person>| {
-                HttpResponse::Ok().json(person.into_inner())
-            }),
+            web::post().to(|person: web::Json<Person>| HttpResponse::Ok().json(person)),
         )))
         .await;
 
@@ -1164,9 +1160,7 @@ mod tests {
     #[actix_rt::test]
     async fn test_request_response_form() {
         let mut app = init_service(App::new().service(web::resource("/people").route(
-            web::post().to(|person: web::Form<Person>| {
-                HttpResponse::Ok().json(person.into_inner())
-            }),
+            web::post().to(|person: web::Form<Person>| HttpResponse::Ok().json(person)),
         )))
         .await;
 
@@ -1190,9 +1184,7 @@ mod tests {
     #[actix_rt::test]
     async fn test_request_response_json() {
         let mut app = init_service(App::new().service(web::resource("/people").route(
-            web::post().to(|person: web::Json<Person>| {
-                HttpResponse::Ok().json(person.into_inner())
-            }),
+            web::post().to(|person: web::Json<Person>| HttpResponse::Ok().json(person)),
         )))
         .await;
 


### PR DESCRIPTION
## PR Type
Refactor

## PR Checklist
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
It's not necessary to keep both json() and json2() around since the
former reduces the ownership of its parameter to a borrow only to pass
the reference to the latter. Users can instead borrow themselves when
passing an owned value: there doesn't need to be two separate functions.

This change also makes HttpResponseBuilder::json() take a value by
reference since it's cheaper to convert from an owned value to a
borrowed one rather than the other way around.

**This is a breaking change**