### PR TITLE
implement `App::data` as `App::app_data(Data::new(T)))`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,15 +12,22 @@
   `ServiceRequest::from_request` would not fail and no payload would be generated [#1893]
 * Our `Either` type now uses `Left`/`Right` variants (instead of `A`/`B`) [#1894]
 
+### Fixed
+* Multiple calls `App::data` with the same type now keeps the latest call's data. [#1906]
+
 ### Removed
 * Public field of `web::Path` has been made private. [#1894]
 * Public field of `web::Query` has been made private. [#1894]
 * `TestRequest::with_header`; use `TestRequest::default().insert_header()`. [#1869]
+* `AppService::set_service_data`; for custom HTTP service factories adding application data, use the
+  layered data model by calling `ServiceRequest::add_data_container` when handling
+  requests instead. [#1906]
 
 [#1891]: https://github.com/actix/actix-web/pull/1891
 [#1893]: https://github.com/actix/actix-web/pull/1893
 [#1894]: https://github.com/actix/actix-web/pull/1894
 [#1869]: https://github.com/actix/actix-web/pull/1869
+[#1906]: https://github.com/actix/actix-web/pull/1906
 
 
 ## 4.0.0-beta.1 - 2021-01-07

--- a/src/data.rs
+++ b/src/data.rs
@@ -10,8 +10,9 @@ use crate::dev::Payload;
 use crate::extract::FromRequest;
 use crate::request::HttpRequest;
 
-/// Application data factory
+/// Data factory.
 pub(crate) trait DataFactory {
+    /// Return true if modifications were made to extensions map.
     fn create(&self, extensions: &mut Extensions) -> bool;
 }
 
@@ -126,12 +127,8 @@ impl<T: ?Sized + 'static> FromRequest for Data<T> {
 
 impl<T: ?Sized + 'static> DataFactory for Data<T> {
     fn create(&self, extensions: &mut Extensions) -> bool {
-        if !extensions.contains::<Data<T>>() {
-            extensions.insert(Data(self.0.clone()));
-            true
-        } else {
-            false
-        }
+        extensions.insert(Data(self.0.clone()));
+        true
     }
 }
 
@@ -167,6 +164,24 @@ mod tests {
         let req = TestRequest::default().to_request();
         let resp = srv.call(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+
+        let mut srv = init_service(
+            App::new()
+                .data(10u32)
+                .data(13u32)
+                .app_data(12u64)
+                .app_data(15u64)
+                .default_service(web::to(|n: web::Data<u32>, req: HttpRequest| {
+                    // in each case, the latter insertion should be preserved
+                    assert_eq!(*req.app_data::<u64>().unwrap(), 15);
+                    assert_eq!(*n.into_inner(), 13);
+                    HttpResponse::Ok()
+                })),
+        )
+        .await;
+        let req = TestRequest::default().to_request();
+        let resp = srv.call(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
     }
 
     #[actix_rt::test]

--- a/src/service.rs
+++ b/src/service.rs
@@ -231,8 +231,10 @@ impl ServiceRequest {
         self.payload = payload;
     }
 
-    #[doc(hidden)]
-    /// Add app data container to request's resolution set.
+    /// Add data container to request's resolution set.
+    ///
+    /// In middleware, prefer [`extensions_mut`](ServiceRequest::extensions_mut) for request-local
+    /// data since it is assumed that the same app data is presented for every request.
     pub fn add_data_container(&mut self, extensions: Rc<Extensions>) {
         Rc::get_mut(&mut (self.req).inner)
             .unwrap()


### PR DESCRIPTION
## PR Type
Refactor / Fix


## PR Checklist
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt
- [x] (Team) Label with affected crates and semver status.


## Overview
Removes some code in `AppService` that has been redundant since the introduction of layered data containers.

Implements `App::data` in the logical way.

Fixes bug where multiple calls to `App::data` would not retain the latest call's data, unlike `App::app_data`. A test was added for it.

Adds some docs to `ServiceConfig`.