### PR TITLE
Rename `HttpResponse` httpcode methods using snake_case

### DIFF
--- a/actix-files/src/directory.rs
+++ b/actix-files/src/directory.rs
@@ -107,7 +107,7 @@ pub(crate) fn directory_listing(
     );
     Ok(ServiceResponse::new(
         req.clone(),
-        HttpResponse::Ok()
+        HttpResponse::ok()
             .content_type("text/html; charset=utf-8")
             .body(html),
     ))

--- a/actix-files/src/lib.rs
+++ b/actix-files/src/lib.rs
@@ -674,7 +674,7 @@ mod tests {
     async fn test_default_handler_file_missing() {
         let mut st = Files::new("/", ".")
             .default_handler(|req: ServiceRequest| {
-                ok(req.into_response(HttpResponse::Ok().body("default content")))
+                ok(req.into_response(HttpResponse::ok().body("default content")))
             })
             .new_service(())
             .await

--- a/actix-files/src/service.rs
+++ b/actix-files/src/service.rs
@@ -77,7 +77,7 @@ impl Service<ServiceRequest> for FilesService {
 
         if !is_method_valid {
             return Either::Left(ok(req.into_response(
-                actix_web::HttpResponse::MethodNotAllowed()
+                actix_web::HttpResponse::method_not_allowed()
                     .insert_header(header::ContentType(mime::TEXT_PLAIN_UTF_8))
                     .body("Request did not meet this resource's requirements."),
             )));
@@ -101,7 +101,7 @@ impl Service<ServiceRequest> for FilesService {
                     let redirect_to = format!("{}/", req.path());
 
                     return Either::Left(ok(req.into_response(
-                        HttpResponse::Found()
+                        HttpResponse::found()
                             .insert_header((header::LOCATION, redirect_to))
                             .body("")
                             .into_body(),

--- a/actix-http-test/src/lib.rs
+++ b/actix-http-test/src/lib.rs
@@ -29,7 +29,7 @@ use socket2::{Domain, Protocol, Socket, Type};
 /// use actix_web::{web, App, HttpResponse, Error};
 ///
 /// async fn my_handler() -> Result<HttpResponse, Error> {
-///     Ok(HttpResponse::Ok().into())
+///     Ok(HttpResponse::ok().into())
 /// }
 ///
 /// #[actix_rt::test]

--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -13,6 +13,7 @@
 * Renamed `IntoHeaderValue::{try_into => try_into_value}` to avoid ambiguity with std
   `TryInto` trait. [#1894]
 * `Extensions::insert` returns Option of replaced item. [#1904]
+* Rename `HttpResponse` httpcode methods from PascalCase to snake_case
 
 ### Removed
 * `ResponseBuilder::set`; use `ResponseBuilder::insert_header`. [#1869]

--- a/actix-http/README.md
+++ b/actix-http/README.md
@@ -37,7 +37,7 @@ async fn main() -> io::Result<()> {
                 .client_disconnect(1000)
                 .finish(|_req| {
                     info!("{:?}", _req);
-                    let mut res = Response::Ok();
+                    let mut res = Response::ok();
                     res.header("x-head", HeaderValue::from_static("dummy value!"));
                     future::ok::<_, ()>(res.body("Hello world!"))
                 })

--- a/actix-http/examples/echo.rs
+++ b/actix-http/examples/echo.rs
@@ -25,7 +25,7 @@ async fn main() -> io::Result<()> {
 
                     info!("request body: {:?}", body);
                     Ok::<_, Error>(
-                        Response::Ok()
+                        Response::ok()
                             .insert_header((
                                 "x-head",
                                 HeaderValue::from_static("dummy value!"),

--- a/actix-http/examples/echo2.rs
+++ b/actix-http/examples/echo2.rs
@@ -14,7 +14,7 @@ async fn handle_request(mut req: Request) -> Result<Response, Error> {
     }
 
     info!("request body: {:?}", body);
-    Ok(Response::Ok()
+    Ok(Response::ok()
         .insert_header(("x-head", HeaderValue::from_static("dummy value!")))
         .body(body))
 }

--- a/actix-http/examples/hello-world.rs
+++ b/actix-http/examples/hello-world.rs
@@ -18,7 +18,7 @@ async fn main() -> io::Result<()> {
                 .client_disconnect(1000)
                 .finish(|_req| {
                     info!("{:?}", _req);
-                    let mut res = Response::Ok();
+                    let mut res = Response::ok();
                     res.insert_header((
                         "x-head",
                         HeaderValue::from_static("dummy value!"),

--- a/actix-http/src/error.rs
+++ b/actix-http/src/error.rs
@@ -1079,7 +1079,7 @@ mod tests {
     #[test]
     fn test_internal_error() {
         let err =
-            InternalError::from_response(ParseError::Method, Response::Ok().into());
+            InternalError::from_response(ParseError::Method, Response::ok().into());
         let resp: Response = err.error_response();
         assert_eq!(resp.status(), StatusCode::OK);
     }

--- a/actix-http/src/h1/dispatcher.rs
+++ b/actix-http/src/h1/dispatcher.rs
@@ -587,7 +587,9 @@ where
                                 );
                                 this.flags.insert(Flags::READ_DISCONNECT);
                                 this.messages.push_back(DispatcherMessage::Error(
-                                    Response::InternalServerError().finish().drop_body(),
+                                    Response::internal_server_error()
+                                        .finish()
+                                        .drop_body(),
                                 ));
                                 *this.error = Some(DispatchError::InternalError);
                                 break;
@@ -600,7 +602,9 @@ where
                                 error!("Internal server error: unexpected eof");
                                 this.flags.insert(Flags::READ_DISCONNECT);
                                 this.messages.push_back(DispatcherMessage::Error(
-                                    Response::InternalServerError().finish().drop_body(),
+                                    Response::internal_server_error()
+                                        .finish()
+                                        .drop_body(),
                                 ));
                                 *this.error = Some(DispatchError::InternalError);
                                 break;
@@ -622,7 +626,7 @@ where
 
                     // Malformed requests should be responded with 400
                     this.messages.push_back(DispatcherMessage::Error(
-                        Response::BadRequest().finish().drop_body(),
+                        Response::bad_request().finish().drop_body(),
                     ));
                     this.flags.insert(Flags::READ_DISCONNECT);
                     *this.error = Some(e.into());
@@ -696,7 +700,7 @@ where
                             if !this.flags.contains(Flags::STARTED) {
                                 trace!("Slow request timeout");
                                 let _ = self.as_mut().send_response(
-                                    Response::RequestTimeout().finish().drop_body(),
+                                    Response::request_timeout().finish().drop_body(),
                                     ResponseBody::Other(Body::Empty),
                                 );
                                 this = self.as_mut().project();
@@ -966,13 +970,13 @@ mod tests {
     }
 
     fn ok_service() -> impl Service<Request, Response = Response, Error = Error> {
-        fn_service(|_req: Request| ready(Ok::<_, Error>(Response::Ok().finish())))
+        fn_service(|_req: Request| ready(Ok::<_, Error>(Response::ok().finish())))
     }
 
     fn echo_path_service() -> impl Service<Request, Response = Response, Error = Error> {
         fn_service(|req: Request| {
             let path = req.path().as_bytes();
-            ready(Ok::<_, Error>(Response::Ok().body(Body::from_slice(path))))
+            ready(Ok::<_, Error>(Response::ok().body(Body::from_slice(path))))
         })
     }
 
@@ -988,7 +992,7 @@ mod tests {
                     body.extend_from_slice(chunk.unwrap().chunk())
                 }
 
-                Ok::<_, Error>(Response::Ok().body(body))
+                Ok::<_, Error>(Response::ok().body(body))
             })
         })
     }

--- a/actix-http/src/header/common/accept.rs
+++ b/actix-http/src/header/common/accept.rs
@@ -36,7 +36,7 @@ header! {
     /// use actix_http::Response;
     /// use actix_http::http::header::{Accept, qitem};
     ///
-    /// let mut builder = Response::Ok();
+    /// let mut builder = Response::ok();
     /// builder.insert_header(
     ///     Accept(vec![
     ///         qitem(mime::TEXT_HTML),
@@ -48,7 +48,7 @@ header! {
     /// use actix_http::Response;
     /// use actix_http::http::header::{Accept, qitem};
     ///
-    /// let mut builder = Response::Ok();
+    /// let mut builder = Response::ok();
     /// builder.insert_header(
     ///     Accept(vec![
     ///         qitem(mime::APPLICATION_JSON),
@@ -60,7 +60,7 @@ header! {
     /// use actix_http::Response;
     /// use actix_http::http::header::{Accept, QualityItem, q, qitem};
     ///
-    /// let mut builder = Response::Ok();
+    /// let mut builder = Response::ok();
     /// builder.insert_header(
     ///     Accept(vec![
     ///         qitem(mime::TEXT_HTML),

--- a/actix-http/src/header/common/accept_charset.rs
+++ b/actix-http/src/header/common/accept_charset.rs
@@ -25,7 +25,7 @@ header! {
     /// use actix_http::Response;
     /// use actix_http::http::header::{AcceptCharset, Charset, qitem};
     ///
-    /// let mut builder = Response::Ok();
+    /// let mut builder = Response::ok();
     /// builder.insert_header(
     ///     AcceptCharset(vec![qitem(Charset::Us_Ascii)])
     /// );
@@ -35,7 +35,7 @@ header! {
     /// use actix_http::Response;
     /// use actix_http::http::header::{AcceptCharset, Charset, q, QualityItem};
     ///
-    /// let mut builder = Response::Ok();
+    /// let mut builder = Response::ok();
     /// builder.insert_header(
     ///     AcceptCharset(vec![
     ///         QualityItem::new(Charset::Us_Ascii, q(900)),
@@ -48,7 +48,7 @@ header! {
     /// use actix_http::Response;
     /// use actix_http::http::header::{AcceptCharset, Charset, qitem};
     ///
-    /// let mut builder = Response::Ok();
+    /// let mut builder = Response::ok();
     /// builder.insert_header(
     ///     AcceptCharset(vec![qitem(Charset::Ext("utf-8".to_owned()))])
     /// );

--- a/actix-http/src/header/common/accept_language.rs
+++ b/actix-http/src/header/common/accept_language.rs
@@ -27,7 +27,7 @@ header! {
     /// use actix_http::Response;
     /// use actix_http::http::header::{AcceptLanguage, LanguageTag, qitem};
     ///
-    /// let mut builder = Response::Ok();
+    /// let mut builder = Response::ok();
     /// let mut langtag: LanguageTag = Default::default();
     /// langtag.language = Some("en".to_owned());
     /// langtag.region = Some("US".to_owned());
@@ -43,7 +43,7 @@ header! {
     /// use actix_http::Response;
     /// use actix_http::http::header::{AcceptLanguage, QualityItem, q, qitem};
     ///
-    /// let mut builder = Response::Ok();
+    /// let mut builder = Response::ok();
     /// builder.insert_header(
     ///     AcceptLanguage(vec![
     ///         qitem(langtag!(da)),

--- a/actix-http/src/header/common/allow.rs
+++ b/actix-http/src/header/common/allow.rs
@@ -26,7 +26,7 @@ header! {
     /// use actix_http::Response;
     /// use actix_http::http::{header::Allow, Method};
     ///
-    /// let mut builder = Response::Ok();
+    /// let mut builder = Response::ok();
     /// builder.insert_header(
     ///     Allow(vec![Method::GET])
     /// );
@@ -36,7 +36,7 @@ header! {
     /// use actix_http::Response;
     /// use actix_http::http::{header::Allow, Method};
     ///
-    /// let mut builder = Response::Ok();
+    /// let mut builder = Response::ok();
     /// builder.insert_header(
     ///     Allow(vec![
     ///         Method::GET,

--- a/actix-http/src/header/common/cache_control.rs
+++ b/actix-http/src/header/common/cache_control.rs
@@ -32,7 +32,7 @@ use crate::header::{
 /// use actix_http::Response;
 /// use actix_http::http::header::{CacheControl, CacheDirective};
 ///
-/// let mut builder = Response::Ok();
+/// let mut builder = Response::ok();
 /// builder.insert_header(CacheControl(vec![CacheDirective::MaxAge(86400u32)]));
 /// ```
 ///
@@ -40,7 +40,7 @@ use crate::header::{
 /// use actix_http::Response;
 /// use actix_http::http::header::{CacheControl, CacheDirective};
 ///
-/// let mut builder = Response::Ok();
+/// let mut builder = Response::ok();
 /// builder.insert_header(CacheControl(vec![
 ///     CacheDirective::NoCache,
 ///     CacheDirective::Private,

--- a/actix-http/src/header/common/content_language.rs
+++ b/actix-http/src/header/common/content_language.rs
@@ -28,7 +28,7 @@ header! {
     /// use actix_http::Response;
     /// use actix_http::http::header::{ContentLanguage, qitem};
     ///
-    /// let mut builder = Response::Ok();
+    /// let mut builder = Response::ok();
     /// builder.insert_header(
     ///     ContentLanguage(vec![
     ///         qitem(langtag!(en)),
@@ -41,7 +41,7 @@ header! {
     /// use actix_http::Response;
     /// use actix_http::http::header::{ContentLanguage, qitem};
     ///
-    /// let mut builder = Response::Ok();
+    /// let mut builder = Response::ok();
     /// builder.insert_header(
     ///     ContentLanguage(vec![
     ///         qitem(langtag!(da)),

--- a/actix-http/src/header/common/content_type.rs
+++ b/actix-http/src/header/common/content_type.rs
@@ -34,7 +34,7 @@ header! {
     /// use actix_http::Response;
     /// use actix_http::http::header::ContentType;
     ///
-    /// let mut builder = Response::Ok();
+    /// let mut builder = Response::ok();
     /// builder.insert_header(
     ///     ContentType::json()
     /// );
@@ -44,7 +44,7 @@ header! {
     /// use actix_http::Response;
     /// use actix_http::http::header::ContentType;
     ///
-    /// let mut builder = Response::Ok();
+    /// let mut builder = Response::ok();
     /// builder.insert_header(
     ///     ContentType(mime::TEXT_HTML)
     /// );

--- a/actix-http/src/header/common/date.rs
+++ b/actix-http/src/header/common/date.rs
@@ -24,7 +24,7 @@ header! {
     /// use actix_http::Response;
     /// use actix_http::http::header::Date;
     ///
-    /// let mut builder = Response::Ok();
+    /// let mut builder = Response::ok();
     /// builder.insert_header(
     ///     Date(SystemTime::now().into())
     /// );

--- a/actix-http/src/header/common/etag.rs
+++ b/actix-http/src/header/common/etag.rs
@@ -31,7 +31,7 @@ header! {
     /// use actix_http::Response;
     /// use actix_http::http::header::{ETag, EntityTag};
     ///
-    /// let mut builder = Response::Ok();
+    /// let mut builder = Response::ok();
     /// builder.insert_header(
     ///     ETag(EntityTag::new(false, "xyzzy".to_owned()))
     /// );
@@ -41,7 +41,7 @@ header! {
     /// use actix_http::Response;
     /// use actix_http::http::header::{ETag, EntityTag};
     ///
-    /// let mut builder = Response::Ok();
+    /// let mut builder = Response::ok();
     /// builder.insert_header(
     ///     ETag(EntityTag::new(true, "xyzzy".to_owned()))
     /// );

--- a/actix-http/src/header/common/expires.rs
+++ b/actix-http/src/header/common/expires.rs
@@ -26,7 +26,7 @@ header! {
     /// use actix_http::Response;
     /// use actix_http::http::header::Expires;
     ///
-    /// let mut builder = Response::Ok();
+    /// let mut builder = Response::ok();
     /// let expiration = SystemTime::now() + Duration::from_secs(60 * 60 * 24);
     /// builder.insert_header(
     ///     Expires(expiration.into())

--- a/actix-http/src/header/common/if_match.rs
+++ b/actix-http/src/header/common/if_match.rs
@@ -33,7 +33,7 @@ header! {
     /// use actix_http::Response;
     /// use actix_http::http::header::IfMatch;
     ///
-    /// let mut builder = Response::Ok();
+    /// let mut builder = Response::ok();
     /// builder.insert_header(IfMatch::Any);
     /// ```
     ///
@@ -41,7 +41,7 @@ header! {
     /// use actix_http::Response;
     /// use actix_http::http::header::{IfMatch, EntityTag};
     ///
-    /// let mut builder = Response::Ok();
+    /// let mut builder = Response::ok();
     /// builder.insert_header(
     ///     IfMatch::Items(vec![
     ///         EntityTag::new(false, "xyzzy".to_owned()),

--- a/actix-http/src/header/common/if_modified_since.rs
+++ b/actix-http/src/header/common/if_modified_since.rs
@@ -26,7 +26,7 @@ header! {
     /// use actix_http::Response;
     /// use actix_http::http::header::IfModifiedSince;
     ///
-    /// let mut builder = Response::Ok();
+    /// let mut builder = Response::ok();
     /// let modified = SystemTime::now() - Duration::from_secs(60 * 60 * 24);
     /// builder.insert_header(
     ///     IfModifiedSince(modified.into())

--- a/actix-http/src/header/common/if_none_match.rs
+++ b/actix-http/src/header/common/if_none_match.rs
@@ -35,7 +35,7 @@ header! {
     /// use actix_http::Response;
     /// use actix_http::http::header::IfNoneMatch;
     ///
-    /// let mut builder = Response::Ok();
+    /// let mut builder = Response::ok();
     /// builder.insert_header(IfNoneMatch::Any);
     /// ```
     ///
@@ -43,7 +43,7 @@ header! {
     /// use actix_http::Response;
     /// use actix_http::http::header::{IfNoneMatch, EntityTag};
     ///
-    /// let mut builder = Response::Ok();
+    /// let mut builder = Response::ok();
     /// builder.insert_header(
     ///     IfNoneMatch::Items(vec![
     ///         EntityTag::new(false, "xyzzy".to_owned()),

--- a/actix-http/src/header/common/if_range.rs
+++ b/actix-http/src/header/common/if_range.rs
@@ -39,7 +39,7 @@ use crate::httpmessage::HttpMessage;
 /// use actix_http::Response;
 /// use actix_http::http::header::{EntityTag, IfRange};
 ///
-/// let mut builder = Response::Ok();
+/// let mut builder = Response::ok();
 /// builder.insert_header(
 ///     IfRange::EntityTag(
 ///         EntityTag::new(false, "abc".to_owned())
@@ -51,7 +51,7 @@ use crate::httpmessage::HttpMessage;
 /// use std::time::{Duration, SystemTime};
 /// use actix_http::{http::header::IfRange, Response};
 ///
-/// let mut builder = Response::Ok();
+/// let mut builder = Response::ok();
 /// let fetched = SystemTime::now() - Duration::from_secs(60 * 60 * 24);
 /// builder.insert_header(
 ///     IfRange::Date(fetched.into())

--- a/actix-http/src/header/common/if_unmodified_since.rs
+++ b/actix-http/src/header/common/if_unmodified_since.rs
@@ -27,7 +27,7 @@ header! {
     /// use actix_http::Response;
     /// use actix_http::http::header::IfUnmodifiedSince;
     ///
-    /// let mut builder = Response::Ok();
+    /// let mut builder = Response::ok();
     /// let modified = SystemTime::now() - Duration::from_secs(60 * 60 * 24);
     /// builder.insert_header(
     ///     IfUnmodifiedSince(modified.into())

--- a/actix-http/src/header/common/last_modified.rs
+++ b/actix-http/src/header/common/last_modified.rs
@@ -26,7 +26,7 @@ header! {
     /// use actix_http::Response;
     /// use actix_http::http::header::LastModified;
     ///
-    /// let mut builder = Response::Ok();
+    /// let mut builder = Response::ok();
     /// let modified = SystemTime::now() - Duration::from_secs(60 * 60 * 24);
     /// builder.insert_header(
     ///     LastModified(modified.into())

--- a/actix-http/src/httpcodes.rs
+++ b/actix-http/src/httpcodes.rs
@@ -8,7 +8,7 @@ use crate::response::{Response, ResponseBuilder};
 
 macro_rules! static_resp {
     ($name:ident, $status:expr) => {
-        #[allow(non_snake_case, missing_docs)]
+        #[allow(missing_docs)]
         pub fn $name() -> ResponseBuilder {
             ResponseBuilder::new($status)
         }
@@ -16,67 +16,70 @@ macro_rules! static_resp {
 }
 
 impl Response {
-    static_resp!(Continue, StatusCode::CONTINUE);
-    static_resp!(SwitchingProtocols, StatusCode::SWITCHING_PROTOCOLS);
-    static_resp!(Processing, StatusCode::PROCESSING);
+    static_resp!(kontinue, StatusCode::CONTINUE);
+    static_resp!(switching_protocols, StatusCode::SWITCHING_PROTOCOLS);
+    static_resp!(processing, StatusCode::PROCESSING);
 
-    static_resp!(Ok, StatusCode::OK);
-    static_resp!(Created, StatusCode::CREATED);
-    static_resp!(Accepted, StatusCode::ACCEPTED);
+    static_resp!(ok, StatusCode::OK);
+    static_resp!(created, StatusCode::CREATED);
+    static_resp!(accepted, StatusCode::ACCEPTED);
     static_resp!(
-        NonAuthoritativeInformation,
+        non_authoritative_information,
         StatusCode::NON_AUTHORITATIVE_INFORMATION
     );
 
-    static_resp!(NoContent, StatusCode::NO_CONTENT);
-    static_resp!(ResetContent, StatusCode::RESET_CONTENT);
-    static_resp!(PartialContent, StatusCode::PARTIAL_CONTENT);
-    static_resp!(MultiStatus, StatusCode::MULTI_STATUS);
-    static_resp!(AlreadyReported, StatusCode::ALREADY_REPORTED);
+    static_resp!(no_content, StatusCode::NO_CONTENT);
+    static_resp!(reset_content, StatusCode::RESET_CONTENT);
+    static_resp!(partial_content, StatusCode::PARTIAL_CONTENT);
+    static_resp!(multi_status, StatusCode::MULTI_STATUS);
+    static_resp!(already_reported, StatusCode::ALREADY_REPORTED);
 
-    static_resp!(MultipleChoices, StatusCode::MULTIPLE_CHOICES);
-    static_resp!(MovedPermanently, StatusCode::MOVED_PERMANENTLY);
-    static_resp!(Found, StatusCode::FOUND);
-    static_resp!(SeeOther, StatusCode::SEE_OTHER);
-    static_resp!(NotModified, StatusCode::NOT_MODIFIED);
-    static_resp!(UseProxy, StatusCode::USE_PROXY);
-    static_resp!(TemporaryRedirect, StatusCode::TEMPORARY_REDIRECT);
-    static_resp!(PermanentRedirect, StatusCode::PERMANENT_REDIRECT);
+    static_resp!(multiple_choices, StatusCode::MULTIPLE_CHOICES);
+    static_resp!(moved_permanently, StatusCode::MOVED_PERMANENTLY);
+    static_resp!(found, StatusCode::FOUND);
+    static_resp!(see_other, StatusCode::SEE_OTHER);
+    static_resp!(not_modified, StatusCode::NOT_MODIFIED);
+    static_resp!(use_proxy, StatusCode::USE_PROXY);
+    static_resp!(temporary_redirect, StatusCode::TEMPORARY_REDIRECT);
+    static_resp!(permanent_redirect, StatusCode::PERMANENT_REDIRECT);
 
-    static_resp!(BadRequest, StatusCode::BAD_REQUEST);
-    static_resp!(NotFound, StatusCode::NOT_FOUND);
-    static_resp!(Unauthorized, StatusCode::UNAUTHORIZED);
-    static_resp!(PaymentRequired, StatusCode::PAYMENT_REQUIRED);
-    static_resp!(Forbidden, StatusCode::FORBIDDEN);
-    static_resp!(MethodNotAllowed, StatusCode::METHOD_NOT_ALLOWED);
-    static_resp!(NotAcceptable, StatusCode::NOT_ACCEPTABLE);
+    static_resp!(bad_request, StatusCode::BAD_REQUEST);
+    static_resp!(not_found, StatusCode::NOT_FOUND);
+    static_resp!(unauthorized, StatusCode::UNAUTHORIZED);
+    static_resp!(payment_required, StatusCode::PAYMENT_REQUIRED);
+    static_resp!(forbidden, StatusCode::FORBIDDEN);
+    static_resp!(method_not_allowed, StatusCode::METHOD_NOT_ALLOWED);
+    static_resp!(not_acceptable, StatusCode::NOT_ACCEPTABLE);
     static_resp!(
-        ProxyAuthenticationRequired,
+        proxy_authentication_required,
         StatusCode::PROXY_AUTHENTICATION_REQUIRED
     );
-    static_resp!(RequestTimeout, StatusCode::REQUEST_TIMEOUT);
-    static_resp!(Conflict, StatusCode::CONFLICT);
-    static_resp!(Gone, StatusCode::GONE);
-    static_resp!(LengthRequired, StatusCode::LENGTH_REQUIRED);
-    static_resp!(PreconditionFailed, StatusCode::PRECONDITION_FAILED);
-    static_resp!(PreconditionRequired, StatusCode::PRECONDITION_REQUIRED);
-    static_resp!(PayloadTooLarge, StatusCode::PAYLOAD_TOO_LARGE);
-    static_resp!(UriTooLong, StatusCode::URI_TOO_LONG);
-    static_resp!(UnsupportedMediaType, StatusCode::UNSUPPORTED_MEDIA_TYPE);
-    static_resp!(RangeNotSatisfiable, StatusCode::RANGE_NOT_SATISFIABLE);
-    static_resp!(ExpectationFailed, StatusCode::EXPECTATION_FAILED);
-    static_resp!(UnprocessableEntity, StatusCode::UNPROCESSABLE_ENTITY);
-    static_resp!(TooManyRequests, StatusCode::TOO_MANY_REQUESTS);
+    static_resp!(request_timeout, StatusCode::REQUEST_TIMEOUT);
+    static_resp!(conflict, StatusCode::CONFLICT);
+    static_resp!(gone, StatusCode::GONE);
+    static_resp!(length_required, StatusCode::LENGTH_REQUIRED);
+    static_resp!(precondition_failed, StatusCode::PRECONDITION_FAILED);
+    static_resp!(precondition_required, StatusCode::PRECONDITION_REQUIRED);
+    static_resp!(payload_too_large, StatusCode::PAYLOAD_TOO_LARGE);
+    static_resp!(uri_too_long, StatusCode::URI_TOO_LONG);
+    static_resp!(unsupported_media_type, StatusCode::UNSUPPORTED_MEDIA_TYPE);
+    static_resp!(range_not_satisfiable, StatusCode::RANGE_NOT_SATISFIABLE);
+    static_resp!(expectation_failed, StatusCode::EXPECTATION_FAILED);
+    static_resp!(unprocessable_entity, StatusCode::UNPROCESSABLE_ENTITY);
+    static_resp!(too_many_requests, StatusCode::TOO_MANY_REQUESTS);
 
-    static_resp!(InternalServerError, StatusCode::INTERNAL_SERVER_ERROR);
-    static_resp!(NotImplemented, StatusCode::NOT_IMPLEMENTED);
-    static_resp!(BadGateway, StatusCode::BAD_GATEWAY);
-    static_resp!(ServiceUnavailable, StatusCode::SERVICE_UNAVAILABLE);
-    static_resp!(GatewayTimeout, StatusCode::GATEWAY_TIMEOUT);
-    static_resp!(VersionNotSupported, StatusCode::HTTP_VERSION_NOT_SUPPORTED);
-    static_resp!(VariantAlsoNegotiates, StatusCode::VARIANT_ALSO_NEGOTIATES);
-    static_resp!(InsufficientStorage, StatusCode::INSUFFICIENT_STORAGE);
-    static_resp!(LoopDetected, StatusCode::LOOP_DETECTED);
+    static_resp!(internal_server_error, StatusCode::INTERNAL_SERVER_ERROR);
+    static_resp!(not_implemented, StatusCode::NOT_IMPLEMENTED);
+    static_resp!(bad_gateway, StatusCode::BAD_GATEWAY);
+    static_resp!(service_unavailable, StatusCode::SERVICE_UNAVAILABLE);
+    static_resp!(gateway_timeout, StatusCode::GATEWAY_TIMEOUT);
+    static_resp!(
+        version_not_supported,
+        StatusCode::HTTP_VERSION_NOT_SUPPORTED
+    );
+    static_resp!(variant_also_negotiates, StatusCode::VARIANT_ALSO_NEGOTIATES);
+    static_resp!(insufficient_storage, StatusCode::INSUFFICIENT_STORAGE);
+    static_resp!(loop_detected, StatusCode::LOOP_DETECTED);
 }
 
 #[cfg(test)]
@@ -87,7 +90,7 @@ mod tests {
 
     #[test]
     fn test_build() {
-        let resp = Response::Ok().body(Body::Empty);
+        let resp = Response::ok().body(Body::Empty);
         assert_eq!(resp.status(), StatusCode::OK);
     }
 }

--- a/actix-http/src/response.rs
+++ b/actix-http/src/response.rs
@@ -351,7 +351,7 @@ impl ResponseBuilder {
     /// # use actix_http::Response;
     /// use actix_http::http::header::ContentType;
     ///
-    /// Response::Ok()
+    /// Response::ok()
     ///     .insert_header(ContentType(mime::APPLICATION_JSON))
     ///     .insert_header(("X-TEST", "value"))
     ///     .finish();
@@ -376,7 +376,7 @@ impl ResponseBuilder {
     /// # use actix_http::Response;
     /// use actix_http::http::header::ContentType;
     ///
-    /// Response::Ok()
+    /// Response::ok()
     ///     .append_header(ContentType(mime::APPLICATION_JSON))
     ///     .append_header(("X-TEST", "value1"))
     ///     .append_header(("X-TEST", "value2"))
@@ -516,7 +516,7 @@ impl ResponseBuilder {
     /// use actix_http::{http, Request, Response};
     ///
     /// fn index(req: Request) -> Response {
-    ///     Response::Ok()
+    ///     Response::ok()
     ///         .cookie(
     ///             http::Cookie::build("name", "value")
     ///                 .domain("www.rust-lang.org")
@@ -545,7 +545,7 @@ impl ResponseBuilder {
     /// use actix_http::{http, Request, Response, HttpMessage};
     ///
     /// fn index(req: Request) -> Response {
-    ///     let mut builder = Response::Ok();
+    ///     let mut builder = Response::ok();
     ///
     ///     if let Some(ref cookie) = req.cookie("name") {
     ///         builder.del_cookie(cookie);
@@ -813,7 +813,7 @@ impl From<ResponseBuilder> for Response {
 
 impl From<&'static str> for Response {
     fn from(val: &'static str) -> Self {
-        Response::Ok()
+        Response::ok()
             .content_type(mime::TEXT_PLAIN_UTF_8)
             .body(val)
     }
@@ -821,7 +821,7 @@ impl From<&'static str> for Response {
 
 impl From<&'static [u8]> for Response {
     fn from(val: &'static [u8]) -> Self {
-        Response::Ok()
+        Response::ok()
             .content_type(mime::APPLICATION_OCTET_STREAM)
             .body(val)
     }
@@ -829,7 +829,7 @@ impl From<&'static [u8]> for Response {
 
 impl From<String> for Response {
     fn from(val: String) -> Self {
-        Response::Ok()
+        Response::ok()
             .content_type(mime::TEXT_PLAIN_UTF_8)
             .body(val)
     }
@@ -837,7 +837,7 @@ impl From<String> for Response {
 
 impl<'a> From<&'a String> for Response {
     fn from(val: &'a String) -> Self {
-        Response::Ok()
+        Response::ok()
             .content_type(mime::TEXT_PLAIN_UTF_8)
             .body(val)
     }
@@ -845,7 +845,7 @@ impl<'a> From<&'a String> for Response {
 
 impl From<Bytes> for Response {
     fn from(val: Bytes) -> Self {
-        Response::Ok()
+        Response::ok()
             .content_type(mime::APPLICATION_OCTET_STREAM)
             .body(val)
     }
@@ -853,7 +853,7 @@ impl From<Bytes> for Response {
 
 impl From<BytesMut> for Response {
     fn from(val: BytesMut) -> Self {
-        Response::Ok()
+        Response::ok()
             .content_type(mime::APPLICATION_OCTET_STREAM)
             .body(val)
     }
@@ -869,7 +869,7 @@ mod tests {
 
     #[test]
     fn test_debug() {
-        let resp = Response::Ok()
+        let resp = Response::ok()
             .append_header((COOKIE, HeaderValue::from_static("cookie1=value1; ")))
             .append_header((COOKIE, HeaderValue::from_static("cookie2=value2; ")))
             .finish();
@@ -887,7 +887,7 @@ mod tests {
             .finish();
         let cookies = req.cookies().unwrap();
 
-        let resp = Response::Ok()
+        let resp = Response::ok()
             .cookie(
                 crate::http::Cookie::build("name", "value")
                     .domain("www.rust-lang.org")
@@ -914,7 +914,7 @@ mod tests {
 
     #[test]
     fn test_update_response_cookies() {
-        let mut r = Response::Ok()
+        let mut r = Response::ok()
             .cookie(crate::http::Cookie::new("original", "val100"))
             .finish();
 
@@ -937,7 +937,7 @@ mod tests {
 
     #[test]
     fn test_basic_builder() {
-        let resp = Response::Ok().insert_header(("X-TEST", "value")).finish();
+        let resp = Response::ok().insert_header(("X-TEST", "value")).finish();
         assert_eq!(resp.status(), StatusCode::OK);
     }
 
@@ -1099,7 +1099,7 @@ mod tests {
 
     #[test]
     fn response_builder_header_insert_kv() {
-        let mut res = Response::Ok();
+        let mut res = Response::ok();
         res.insert_header(("Content-Type", "application/octet-stream"));
         let res = res.finish();
 
@@ -1111,7 +1111,7 @@ mod tests {
 
     #[test]
     fn response_builder_header_insert_typed() {
-        let mut res = Response::Ok();
+        let mut res = Response::ok();
         res.insert_header(header::ContentType(mime::APPLICATION_OCTET_STREAM));
         let res = res.finish();
 
@@ -1123,7 +1123,7 @@ mod tests {
 
     #[test]
     fn response_builder_header_append_kv() {
-        let mut res = Response::Ok();
+        let mut res = Response::ok();
         res.append_header(("Content-Type", "application/octet-stream"));
         res.append_header(("Content-Type", "application/json"));
         let res = res.finish();
@@ -1136,7 +1136,7 @@ mod tests {
 
     #[test]
     fn response_builder_header_append_typed() {
-        let mut res = Response::Ok();
+        let mut res = Response::ok();
         res.append_header(header::ContentType(mime::APPLICATION_OCTET_STREAM));
         res.append_header(header::ContentType(mime::APPLICATION_JSON));
         let res = res.finish();

--- a/actix-http/src/test.rs
+++ b/actix-http/src/test.rs
@@ -32,9 +32,9 @@ use crate::{
 ///
 /// fn index(req: &HttpRequest) -> Response {
 ///     if let Some(hdr) = req.headers().get(header::CONTENT_TYPE) {
-///         Response::Ok().into()
+///         Response::ok().into()
 ///     } else {
-///         Response::BadRequest().into()
+///         Response::bad_request().into()
 ///     }
 /// }
 ///

--- a/actix-http/src/ws/mod.rs
+++ b/actix-http/src/ws/mod.rs
@@ -100,28 +100,28 @@ pub enum HandshakeError {
 impl ResponseError for HandshakeError {
     fn error_response(&self) -> Response {
         match self {
-            HandshakeError::GetMethodRequired => Response::MethodNotAllowed()
+            HandshakeError::GetMethodRequired => Response::method_not_allowed()
                 .insert_header((header::ALLOW, "GET"))
                 .finish(),
 
-            HandshakeError::NoWebsocketUpgrade => Response::BadRequest()
+            HandshakeError::NoWebsocketUpgrade => Response::bad_request()
                 .reason("No WebSocket UPGRADE header found")
                 .finish(),
 
-            HandshakeError::NoConnectionUpgrade => Response::BadRequest()
+            HandshakeError::NoConnectionUpgrade => Response::bad_request()
                 .reason("No CONNECTION upgrade")
                 .finish(),
 
-            HandshakeError::NoVersionHeader => Response::BadRequest()
+            HandshakeError::NoVersionHeader => Response::bad_request()
                 .reason("Websocket version header is required")
                 .finish(),
 
-            HandshakeError::UnsupportedVersion => Response::BadRequest()
+            HandshakeError::UnsupportedVersion => Response::bad_request()
                 .reason("Unsupported version")
                 .finish(),
 
             HandshakeError::BadWebsocketKey => {
-                Response::BadRequest().reason("Handshake error").finish()
+                Response::bad_request().reason("Handshake error").finish()
             }
         }
     }

--- a/actix-http/tests/test_client.rs
+++ b/actix-http/tests/test_client.rs
@@ -30,7 +30,7 @@ const STR: &str = "Hello World Hello World Hello World Hello World Hello World \
 async fn test_h1_v2() {
     let srv = test_server(move || {
         HttpService::build()
-            .finish(|_| future::ok::<_, ()>(Response::Ok().body(STR)))
+            .finish(|_| future::ok::<_, ()>(Response::ok().body(STR)))
             .tcp()
     })
     .await;
@@ -58,7 +58,7 @@ async fn test_h1_v2() {
 async fn test_connection_close() {
     let srv = test_server(move || {
         HttpService::build()
-            .finish(|_| ok::<_, ()>(Response::Ok().body(STR)))
+            .finish(|_| ok::<_, ()>(Response::ok().body(STR)))
             .tcp()
             .map(|_| ())
     })
@@ -74,9 +74,9 @@ async fn test_with_query_parameter() {
         HttpService::build()
             .finish(|req: Request| {
                 if req.uri().query().unwrap().contains("qp=") {
-                    ok::<_, ()>(Response::Ok().finish())
+                    ok::<_, ()>(Response::ok().finish())
                 } else {
-                    ok::<_, ()>(Response::BadRequest().finish())
+                    ok::<_, ()>(Response::bad_request().finish())
                 }
             })
             .tcp()

--- a/actix-http/tests/test_openssl.rs
+++ b/actix-http/tests/test_openssl.rs
@@ -62,7 +62,7 @@ fn ssl_acceptor() -> SslAcceptor {
 async fn test_h2() -> io::Result<()> {
     let srv = test_server(move || {
         HttpService::build()
-            .h2(|_| ok::<_, Error>(Response::Ok().finish()))
+            .h2(|_| ok::<_, Error>(Response::ok().finish()))
             .openssl(ssl_acceptor())
             .map_err(|_| ())
     })
@@ -80,7 +80,7 @@ async fn test_h2_1() -> io::Result<()> {
             .finish(|req: Request| {
                 assert!(req.peer_addr().is_some());
                 assert_eq!(req.version(), Version::HTTP_2);
-                ok::<_, Error>(Response::Ok().finish())
+                ok::<_, Error>(Response::ok().finish())
             })
             .openssl(ssl_acceptor())
             .map_err(|_| ())
@@ -99,7 +99,7 @@ async fn test_h2_body() -> io::Result<()> {
         HttpService::build()
             .h2(|mut req: Request<_>| async move {
                 let body = load_body(req.take_payload()).await?;
-                Ok::<_, Error>(Response::Ok().body(body))
+                Ok::<_, Error>(Response::ok().body(body))
             })
             .openssl(ssl_acceptor())
             .map_err(|_| ())
@@ -171,7 +171,7 @@ async fn test_h2_headers() {
     let mut srv = test_server(move || {
         let data = data.clone();
         HttpService::build().h2(move |_| {
-            let mut builder = Response::Ok();
+            let mut builder = Response::ok();
             for idx in 0..90 {
                 builder.insert_header(
                     (format!("X-TEST-{}", idx).as_str(),
@@ -230,7 +230,7 @@ const STR: &str = "Hello World Hello World Hello World Hello World Hello World \
 async fn test_h2_body2() {
     let mut srv = test_server(move || {
         HttpService::build()
-            .h2(|_| ok::<_, ()>(Response::Ok().body(STR)))
+            .h2(|_| ok::<_, ()>(Response::ok().body(STR)))
             .openssl(ssl_acceptor())
             .map_err(|_| ())
     })
@@ -248,7 +248,7 @@ async fn test_h2_body2() {
 async fn test_h2_head_empty() {
     let mut srv = test_server(move || {
         HttpService::build()
-            .finish(|_| ok::<_, ()>(Response::Ok().body(STR)))
+            .finish(|_| ok::<_, ()>(Response::ok().body(STR)))
             .openssl(ssl_acceptor())
             .map_err(|_| ())
     })
@@ -272,7 +272,7 @@ async fn test_h2_head_empty() {
 async fn test_h2_head_binary() {
     let mut srv = test_server(move || {
         HttpService::build()
-            .h2(|_| ok::<_, ()>(Response::Ok().body(STR)))
+            .h2(|_| ok::<_, ()>(Response::ok().body(STR)))
             .openssl(ssl_acceptor())
             .map_err(|_| ())
     })
@@ -295,7 +295,7 @@ async fn test_h2_head_binary() {
 async fn test_h2_head_binary2() {
     let srv = test_server(move || {
         HttpService::build()
-            .h2(|_| ok::<_, ()>(Response::Ok().body(STR)))
+            .h2(|_| ok::<_, ()>(Response::ok().body(STR)))
             .openssl(ssl_acceptor())
             .map_err(|_| ())
     })
@@ -317,7 +317,7 @@ async fn test_h2_body_length() {
             .h2(|_| {
                 let body = once(ok(Bytes::from_static(STR.as_ref())));
                 ok::<_, ()>(
-                    Response::Ok().body(body::SizedStream::new(STR.len() as u64, body)),
+                    Response::ok().body(body::SizedStream::new(STR.len() as u64, body)),
                 )
             })
             .openssl(ssl_acceptor())
@@ -340,7 +340,7 @@ async fn test_h2_body_chunked_explicit() {
             .h2(|_| {
                 let body = once(ok::<_, Error>(Bytes::from_static(STR.as_ref())));
                 ok::<_, ()>(
-                    Response::Ok()
+                    Response::ok()
                         .insert_header((header::TRANSFER_ENCODING, "chunked"))
                         .streaming(body),
                 )
@@ -368,7 +368,7 @@ async fn test_h2_response_http_error_handling() {
             .h2(fn_service(|_| {
                 let broken_header = Bytes::from_static(b"\0\0\0");
                 ok::<_, ()>(
-                    Response::Ok()
+                    Response::ok()
                         .insert_header((header::CONTENT_TYPE, broken_header))
                         .body(STR),
                 )
@@ -413,7 +413,7 @@ async fn test_h2_on_connect() {
             })
             .h2(|req: Request| {
                 assert!(req.extensions().contains::<isize>());
-                ok::<_, ()>(Response::Ok().finish())
+                ok::<_, ()>(Response::ok().finish())
             })
             .openssl(ssl_acceptor())
             .map_err(|_| ())

--- a/actix-http/tests/test_rustls.rs
+++ b/actix-http/tests/test_rustls.rs
@@ -43,7 +43,7 @@ fn ssl_acceptor() -> RustlsServerConfig {
 async fn test_h1() -> io::Result<()> {
     let srv = test_server(move || {
         HttpService::build()
-            .h1(|_| future::ok::<_, Error>(Response::Ok().finish()))
+            .h1(|_| future::ok::<_, Error>(Response::ok().finish()))
             .rustls(ssl_acceptor())
     })
     .await;
@@ -57,7 +57,7 @@ async fn test_h1() -> io::Result<()> {
 async fn test_h2() -> io::Result<()> {
     let srv = test_server(move || {
         HttpService::build()
-            .h2(|_| future::ok::<_, Error>(Response::Ok().finish()))
+            .h2(|_| future::ok::<_, Error>(Response::ok().finish()))
             .rustls(ssl_acceptor())
     })
     .await;
@@ -74,7 +74,7 @@ async fn test_h1_1() -> io::Result<()> {
             .h1(|req: Request| {
                 assert!(req.peer_addr().is_some());
                 assert_eq!(req.version(), Version::HTTP_11);
-                future::ok::<_, Error>(Response::Ok().finish())
+                future::ok::<_, Error>(Response::ok().finish())
             })
             .rustls(ssl_acceptor())
     })
@@ -92,7 +92,7 @@ async fn test_h2_1() -> io::Result<()> {
             .finish(|req: Request| {
                 assert!(req.peer_addr().is_some());
                 assert_eq!(req.version(), Version::HTTP_2);
-                future::ok::<_, Error>(Response::Ok().finish())
+                future::ok::<_, Error>(Response::ok().finish())
             })
             .rustls(ssl_acceptor())
     })
@@ -110,7 +110,7 @@ async fn test_h2_body1() -> io::Result<()> {
         HttpService::build()
             .h2(|mut req: Request<_>| async move {
                 let body = load_body(req.take_payload()).await?;
-                Ok::<_, Error>(Response::Ok().body(body))
+                Ok::<_, Error>(Response::ok().body(body))
             })
             .rustls(ssl_acceptor())
     })
@@ -179,7 +179,7 @@ async fn test_h2_headers() {
     let mut srv = test_server(move || {
         let data = data.clone();
         HttpService::build().h2(move |_| {
-            let mut config = Response::Ok();
+            let mut config = Response::ok();
             for idx in 0..90 {
                 config.insert_header((
                     format!("X-TEST-{}", idx).as_str(),
@@ -237,7 +237,7 @@ const STR: &str = "Hello World Hello World Hello World Hello World Hello World \
 async fn test_h2_body2() {
     let mut srv = test_server(move || {
         HttpService::build()
-            .h2(|_| future::ok::<_, ()>(Response::Ok().body(STR)))
+            .h2(|_| future::ok::<_, ()>(Response::ok().body(STR)))
             .rustls(ssl_acceptor())
     })
     .await;
@@ -254,7 +254,7 @@ async fn test_h2_body2() {
 async fn test_h2_head_empty() {
     let mut srv = test_server(move || {
         HttpService::build()
-            .finish(|_| ok::<_, ()>(Response::Ok().body(STR)))
+            .finish(|_| ok::<_, ()>(Response::ok().body(STR)))
             .rustls(ssl_acceptor())
     })
     .await;
@@ -280,7 +280,7 @@ async fn test_h2_head_empty() {
 async fn test_h2_head_binary() {
     let mut srv = test_server(move || {
         HttpService::build()
-            .h2(|_| ok::<_, ()>(Response::Ok().body(STR)))
+            .h2(|_| ok::<_, ()>(Response::ok().body(STR)))
             .rustls(ssl_acceptor())
     })
     .await;
@@ -305,7 +305,7 @@ async fn test_h2_head_binary() {
 async fn test_h2_head_binary2() {
     let srv = test_server(move || {
         HttpService::build()
-            .h2(|_| ok::<_, ()>(Response::Ok().body(STR)))
+            .h2(|_| ok::<_, ()>(Response::ok().body(STR)))
             .rustls(ssl_acceptor())
     })
     .await;
@@ -329,7 +329,7 @@ async fn test_h2_body_length() {
             .h2(|_| {
                 let body = once(ok(Bytes::from_static(STR.as_ref())));
                 ok::<_, ()>(
-                    Response::Ok().body(body::SizedStream::new(STR.len() as u64, body)),
+                    Response::ok().body(body::SizedStream::new(STR.len() as u64, body)),
                 )
             })
             .rustls(ssl_acceptor())
@@ -351,7 +351,7 @@ async fn test_h2_body_chunked_explicit() {
             .h2(|_| {
                 let body = once(ok::<_, Error>(Bytes::from_static(STR.as_ref())));
                 ok::<_, ()>(
-                    Response::Ok()
+                    Response::ok()
                         .insert_header((header::TRANSFER_ENCODING, "chunked"))
                         .streaming(body),
                 )
@@ -379,7 +379,7 @@ async fn test_h2_response_http_error_handling() {
                 ok::<_, ()>(fn_service(|_| {
                     let broken_header = Bytes::from_static(b"\0\0\0");
                     ok::<_, ()>(
-                        Response::Ok()
+                        Response::ok()
                             .insert_header((http::header::CONTENT_TYPE, broken_header))
                             .body(STR),
                     )

--- a/actix-http/tests/test_server.rs
+++ b/actix-http/tests/test_server.rs
@@ -24,7 +24,7 @@ async fn test_h1() {
             .client_disconnect(1000)
             .h1(|req: Request| {
                 assert!(req.peer_addr().is_some());
-                future::ok::<_, ()>(Response::Ok().finish())
+                future::ok::<_, ()>(Response::ok().finish())
             })
             .tcp()
     })
@@ -44,7 +44,7 @@ async fn test_h1_2() {
             .finish(|req: Request| {
                 assert!(req.peer_addr().is_some());
                 assert_eq!(req.version(), http::Version::HTTP_11);
-                future::ok::<_, ()>(Response::Ok().finish())
+                future::ok::<_, ()>(Response::ok().finish())
             })
             .tcp()
     })
@@ -65,7 +65,7 @@ async fn test_expect_continue() {
                     err(error::ErrorPreconditionFailed("error"))
                 }
             }))
-            .finish(|_| future::ok::<_, ()>(Response::Ok().finish()))
+            .finish(|_| future::ok::<_, ()>(Response::ok().finish()))
             .tcp()
     })
     .await;
@@ -96,7 +96,7 @@ async fn test_expect_continue_h1() {
                     }
                 })
             }))
-            .h1(fn_service(|_| future::ok::<_, ()>(Response::Ok().finish())))
+            .h1(fn_service(|_| future::ok::<_, ()>(Response::ok().finish())))
             .tcp()
     })
     .await;
@@ -130,7 +130,7 @@ async fn test_chunked_payload() {
                     })
                     .fold(0usize, |acc, chunk| ready(acc + chunk.len()))
                     .map(|req_size| {
-                        Ok::<_, Error>(Response::Ok().body(format!("size={}", req_size)))
+                        Ok::<_, Error>(Response::ok().body(format!("size={}", req_size)))
                     })
             }))
             .tcp()
@@ -175,7 +175,7 @@ async fn test_slow_request() {
     let srv = test_server(|| {
         HttpService::build()
             .client_timeout(100)
-            .finish(|_| future::ok::<_, ()>(Response::Ok().finish()))
+            .finish(|_| future::ok::<_, ()>(Response::ok().finish()))
             .tcp()
     })
     .await;
@@ -191,7 +191,7 @@ async fn test_slow_request() {
 async fn test_http1_malformed_request() {
     let srv = test_server(|| {
         HttpService::build()
-            .h1(|_| future::ok::<_, ()>(Response::Ok().finish()))
+            .h1(|_| future::ok::<_, ()>(Response::ok().finish()))
             .tcp()
     })
     .await;
@@ -207,7 +207,7 @@ async fn test_http1_malformed_request() {
 async fn test_http1_keepalive() {
     let srv = test_server(|| {
         HttpService::build()
-            .h1(|_| future::ok::<_, ()>(Response::Ok().finish()))
+            .h1(|_| future::ok::<_, ()>(Response::ok().finish()))
             .tcp()
     })
     .await;
@@ -229,7 +229,7 @@ async fn test_http1_keepalive_timeout() {
     let srv = test_server(|| {
         HttpService::build()
             .keep_alive(1)
-            .h1(|_| future::ok::<_, ()>(Response::Ok().finish()))
+            .h1(|_| future::ok::<_, ()>(Response::ok().finish()))
             .tcp()
     })
     .await;
@@ -250,7 +250,7 @@ async fn test_http1_keepalive_timeout() {
 async fn test_http1_keepalive_close() {
     let srv = test_server(|| {
         HttpService::build()
-            .h1(|_| future::ok::<_, ()>(Response::Ok().finish()))
+            .h1(|_| future::ok::<_, ()>(Response::ok().finish()))
             .tcp()
     })
     .await;
@@ -271,7 +271,7 @@ async fn test_http1_keepalive_close() {
 async fn test_http10_keepalive_default_close() {
     let srv = test_server(|| {
         HttpService::build()
-            .h1(|_| future::ok::<_, ()>(Response::Ok().finish()))
+            .h1(|_| future::ok::<_, ()>(Response::ok().finish()))
             .tcp()
     })
     .await;
@@ -291,7 +291,7 @@ async fn test_http10_keepalive_default_close() {
 async fn test_http10_keepalive() {
     let srv = test_server(|| {
         HttpService::build()
-            .h1(|_| future::ok::<_, ()>(Response::Ok().finish()))
+            .h1(|_| future::ok::<_, ()>(Response::ok().finish()))
             .tcp()
     })
     .await;
@@ -319,7 +319,7 @@ async fn test_http1_keepalive_disabled() {
     let srv = test_server(|| {
         HttpService::build()
             .keep_alive(KeepAlive::Disabled)
-            .h1(|_| future::ok::<_, ()>(Response::Ok().finish()))
+            .h1(|_| future::ok::<_, ()>(Response::ok().finish()))
             .tcp()
     })
     .await;
@@ -390,7 +390,7 @@ async fn test_h1_headers() {
     let mut srv = test_server(move || {
         let data = data.clone();
         HttpService::build().h1(move |_| {
-            let mut builder = Response::Ok();
+            let mut builder = Response::ok();
             for idx in 0..90 {
                 builder.insert_header((
                     format!("X-TEST-{}", idx).as_str(),
@@ -447,7 +447,7 @@ const STR: &str = "Hello World Hello World Hello World Hello World Hello World \
 async fn test_h1_body() {
     let mut srv = test_server(|| {
         HttpService::build()
-            .h1(|_| ok::<_, ()>(Response::Ok().body(STR)))
+            .h1(|_| ok::<_, ()>(Response::ok().body(STR)))
             .tcp()
     })
     .await;
@@ -464,7 +464,7 @@ async fn test_h1_body() {
 async fn test_h1_head_empty() {
     let mut srv = test_server(|| {
         HttpService::build()
-            .h1(|_| ok::<_, ()>(Response::Ok().body(STR)))
+            .h1(|_| ok::<_, ()>(Response::ok().body(STR)))
             .tcp()
     })
     .await;
@@ -489,7 +489,7 @@ async fn test_h1_head_empty() {
 async fn test_h1_head_binary() {
     let mut srv = test_server(|| {
         HttpService::build()
-            .h1(|_| ok::<_, ()>(Response::Ok().body(STR)))
+            .h1(|_| ok::<_, ()>(Response::ok().body(STR)))
             .tcp()
     })
     .await;
@@ -514,7 +514,7 @@ async fn test_h1_head_binary() {
 async fn test_h1_head_binary2() {
     let srv = test_server(|| {
         HttpService::build()
-            .h1(|_| ok::<_, ()>(Response::Ok().body(STR)))
+            .h1(|_| ok::<_, ()>(Response::ok().body(STR)))
             .tcp()
     })
     .await;
@@ -538,7 +538,7 @@ async fn test_h1_body_length() {
             .h1(|_| {
                 let body = once(ok(Bytes::from_static(STR.as_ref())));
                 ok::<_, ()>(
-                    Response::Ok().body(body::SizedStream::new(STR.len() as u64, body)),
+                    Response::ok().body(body::SizedStream::new(STR.len() as u64, body)),
                 )
             })
             .tcp()
@@ -560,7 +560,7 @@ async fn test_h1_body_chunked_explicit() {
             .h1(|_| {
                 let body = once(ok::<_, Error>(Bytes::from_static(STR.as_ref())));
                 ok::<_, ()>(
-                    Response::Ok()
+                    Response::ok()
                         .insert_header((header::TRANSFER_ENCODING, "chunked"))
                         .streaming(body),
                 )
@@ -594,7 +594,7 @@ async fn test_h1_body_chunked_implicit() {
         HttpService::build()
             .h1(|_| {
                 let body = once(ok::<_, Error>(Bytes::from_static(STR.as_ref())));
-                ok::<_, ()>(Response::Ok().streaming(body))
+                ok::<_, ()>(Response::ok().streaming(body))
             })
             .tcp()
     })
@@ -624,7 +624,7 @@ async fn test_h1_response_http_error_handling() {
             .h1(fn_service(|_| {
                 let broken_header = Bytes::from_static(b"\0\0\0");
                 ok::<_, ()>(
-                    Response::Ok()
+                    Response::ok()
                         .insert_header((http::header::CONTENT_TYPE, broken_header))
                         .body(STR),
                 )
@@ -667,7 +667,7 @@ async fn test_h1_on_connect() {
             })
             .h1(|req: Request| {
                 assert!(req.extensions().contains::<isize>());
-                future::ok::<_, ()>(Response::Ok().finish())
+                future::ok::<_, ()>(Response::ok().finish())
             })
             .tcp()
     })

--- a/actix-http/tests/test_ws.rs
+++ b/actix-http/tests/test_ws.rs
@@ -93,7 +93,7 @@ async fn test_simple() {
             let ws_service = ws_service.clone();
             HttpService::build()
                 .upgrade(fn_factory(move || future::ok::<_, ()>(ws_service.clone())))
-                .finish(|_| future::ok::<_, ()>(Response::NotFound()))
+                .finish(|_| future::ok::<_, ()>(Response::not_found()))
                 .tcp()
         }
     })

--- a/actix-multipart/src/extractor.rs
+++ b/actix-multipart/src/extractor.rs
@@ -25,7 +25,7 @@ use crate::server::Multipart;
 ///                println!("-- CHUNK: \n{:?}", std::str::from_utf8(&chunk?));
 ///            }
 ///     }
-///     Ok(HttpResponse::Ok().into())
+///     Ok(HttpResponse::ok().into())
 /// }
 /// # fn main() {}
 /// ```

--- a/actix-web-actors/src/context.rs
+++ b/actix-web-actors/src/context.rs
@@ -235,7 +235,7 @@ mod tests {
     async fn test_default_resource() {
         let mut srv =
             init_service(App::new().service(web::resource("/test").to(|| {
-                HttpResponse::Ok().streaming(HttpContext::create(MyActor { count: 0 }))
+                HttpResponse::ok().streaming(HttpContext::create(MyActor { count: 0 }))
             })))
             .await;
 

--- a/actix-web-codegen/src/lib.rs
+++ b/actix-web-codegen/src/lib.rs
@@ -28,7 +28,7 @@
 //! # use actix_web_codegen::get;
 //! #[get("/test")]
 //! async fn get_handler() -> HttpResponse {
-//!     HttpResponse::Ok().finish()
+//!     HttpResponse::ok().finish()
 //! }
 //! ```
 //!
@@ -41,7 +41,7 @@
 //! # use actix_web_codegen::route;
 //! #[route("/test", method="GET", method="HEAD")]
 //! async fn get_and_head_handler() -> HttpResponse {
-//!     HttpResponse::Ok().finish()
+//!     HttpResponse::ok().finish()
 //! }
 //! ```
 //!
@@ -86,7 +86,7 @@ mod route;
 /// # use actix_web_codegen::route;
 /// #[route("/test", method="GET", method="HEAD")]
 /// async fn example() -> HttpResponse {
-///     HttpResponse::Ok().finish()
+///     HttpResponse::ok().finish()
 /// }
 /// ```
 #[proc_macro_attribute]
@@ -130,7 +130,7 @@ code, e.g `my_guard` or `my_module::my_guard`.
 # use actix_web_codegen::"#, stringify!($method), ";
 #[", stringify!($method), r#"("/")]
 async fn example() -> HttpResponse {
-    HttpResponse::Ok().finish()
+    HttpResponse::ok().finish()
 }
 ```
 "#);

--- a/actix-web-codegen/tests/test_macro.rs
+++ b/actix-web-codegen/tests/test_macro.rs
@@ -13,77 +13,77 @@ use futures_util::future;
 // Make sure that we can name function as 'config'
 #[get("/config")]
 async fn config() -> impl Responder {
-    HttpResponse::Ok()
+    HttpResponse::ok()
 }
 
 #[get("/test")]
 async fn test_handler() -> impl Responder {
-    HttpResponse::Ok()
+    HttpResponse::ok()
 }
 
 #[put("/test")]
 async fn put_test() -> impl Responder {
-    HttpResponse::Created()
+    HttpResponse::created()
 }
 
 #[patch("/test")]
 async fn patch_test() -> impl Responder {
-    HttpResponse::Ok()
+    HttpResponse::ok()
 }
 
 #[post("/test")]
 async fn post_test() -> impl Responder {
-    HttpResponse::NoContent()
+    HttpResponse::no_content()
 }
 
 #[head("/test")]
 async fn head_test() -> impl Responder {
-    HttpResponse::Ok()
+    HttpResponse::ok()
 }
 
 #[connect("/test")]
 async fn connect_test() -> impl Responder {
-    HttpResponse::Ok()
+    HttpResponse::ok()
 }
 
 #[options("/test")]
 async fn options_test() -> impl Responder {
-    HttpResponse::Ok()
+    HttpResponse::ok()
 }
 
 #[trace("/test")]
 async fn trace_test() -> impl Responder {
-    HttpResponse::Ok()
+    HttpResponse::ok()
 }
 
 #[get("/test")]
 fn auto_async() -> impl Future<Output = Result<HttpResponse, actix_web::Error>> {
-    future::ok(HttpResponse::Ok().finish())
+    future::ok(HttpResponse::ok().finish())
 }
 
 #[get("/test")]
 fn auto_sync() -> impl Future<Output = Result<HttpResponse, actix_web::Error>> {
-    future::ok(HttpResponse::Ok().finish())
+    future::ok(HttpResponse::ok().finish())
 }
 
 #[put("/test/{param}")]
 async fn put_param_test(_: Path<String>) -> impl Responder {
-    HttpResponse::Created()
+    HttpResponse::created()
 }
 
 #[delete("/test/{param}")]
 async fn delete_param_test(_: Path<String>) -> impl Responder {
-    HttpResponse::NoContent()
+    HttpResponse::no_content()
 }
 
 #[get("/test/{param}")]
 async fn get_param_test(_: Path<String>) -> impl Responder {
-    HttpResponse::Ok()
+    HttpResponse::ok()
 }
 
 #[route("/multi", method = "GET", method = "POST", method = "HEAD")]
 async fn route_test() -> impl Responder {
-    HttpResponse::Ok()
+    HttpResponse::ok()
 }
 
 pub struct ChangeStatusCode;
@@ -140,7 +140,7 @@ where
 
 #[get("/test/wrap", wrap = "ChangeStatusCode")]
 async fn get_wrap(_: Path<String>) -> impl Responder {
-    HttpResponse::Ok()
+    HttpResponse::ok()
 }
 
 #[actix_rt::test]

--- a/actix-web-codegen/tests/trybuild/simple.rs
+++ b/actix-web-codegen/tests/trybuild/simple.rs
@@ -3,7 +3,7 @@ use actix_web_codegen::*;
 
 #[get("/config")]
 async fn config() -> impl Responder {
-    HttpResponse::Ok()
+    HttpResponse::ok()
 }
 
 #[actix_web::main]

--- a/awc/tests/test_client.rs
+++ b/awc/tests/test_client.rs
@@ -49,7 +49,7 @@ const STR: &str = "Hello World Hello World Hello World Hello World Hello World \
 async fn test_simple() {
     let srv = test::start(|| {
         App::new()
-            .service(web::resource("/").route(web::to(|| HttpResponse::Ok().body(STR))))
+            .service(web::resource("/").route(web::to(|| HttpResponse::ok().body(STR))))
     });
 
     let request = srv.get("/").insert_header(("x-test", "111")).send();
@@ -76,7 +76,7 @@ async fn test_simple() {
 async fn test_json() {
     let srv = test::start(|| {
         App::new().service(
-            web::resource("/").route(web::to(|_: web::Json<String>| HttpResponse::Ok())),
+            web::resource("/").route(web::to(|_: web::Json<String>| HttpResponse::ok())),
         )
     });
 
@@ -92,7 +92,7 @@ async fn test_json() {
 async fn test_form() {
     let srv = test::start(|| {
         App::new().service(web::resource("/").route(web::to(
-            |_: web::Form<HashMap<String, String>>| HttpResponse::Ok(),
+            |_: web::Form<HashMap<String, String>>| HttpResponse::ok(),
         )))
     });
 
@@ -112,7 +112,7 @@ async fn test_timeout() {
     let srv = test::start(|| {
         App::new().service(web::resource("/").route(web::to(|| async {
             actix_rt::time::sleep(Duration::from_millis(200)).await;
-            Ok::<_, Error>(HttpResponse::Ok().body(STR))
+            Ok::<_, Error>(HttpResponse::ok().body(STR))
         })))
     });
 
@@ -140,7 +140,7 @@ async fn test_timeout_override() {
     let srv = test::start(|| {
         App::new().service(web::resource("/").route(web::to(|| async {
             actix_rt::time::sleep(Duration::from_millis(200)).await;
-            Ok::<_, Error>(HttpResponse::Ok().body(STR))
+            Ok::<_, Error>(HttpResponse::ok().body(STR))
         })))
     });
 
@@ -170,7 +170,7 @@ async fn test_connection_reuse() {
         })
         .and_then(
             HttpService::new(map_config(
-                App::new().service(web::resource("/").route(web::to(HttpResponse::Ok))),
+                App::new().service(web::resource("/").route(web::to(HttpResponse::ok))),
                 |_| AppConfig::default(),
             ))
             .tcp(),
@@ -207,7 +207,7 @@ async fn test_connection_force_close() {
         })
         .and_then(
             HttpService::new(map_config(
-                App::new().service(web::resource("/").route(web::to(HttpResponse::Ok))),
+                App::new().service(web::resource("/").route(web::to(HttpResponse::ok))),
                 |_| AppConfig::default(),
             ))
             .tcp(),
@@ -246,7 +246,7 @@ async fn test_connection_server_close() {
             HttpService::new(map_config(
                 App::new().service(
                     web::resource("/")
-                        .route(web::to(|| HttpResponse::Ok().force_close().finish())),
+                        .route(web::to(|| HttpResponse::ok().force_close().finish())),
                 ),
                 |_| AppConfig::default(),
             ))
@@ -285,7 +285,7 @@ async fn test_connection_wait_queue() {
         .and_then(
             HttpService::new(map_config(
                 App::new().service(
-                    web::resource("/").route(web::to(|| HttpResponse::Ok().body(STR))),
+                    web::resource("/").route(web::to(|| HttpResponse::ok().body(STR))),
                 ),
                 |_| AppConfig::default(),
             ))
@@ -334,7 +334,7 @@ async fn test_connection_wait_queue_force_close() {
             HttpService::new(map_config(
                 App::new().service(
                     web::resource("/")
-                        .route(web::to(|| HttpResponse::Ok().force_close().body(STR))),
+                        .route(web::to(|| HttpResponse::ok().force_close().body(STR))),
                 ),
                 |_| AppConfig::default(),
             ))
@@ -373,9 +373,9 @@ async fn test_with_query_parameter() {
     let srv = test::start(|| {
         App::new().service(web::resource("/").to(|req: HttpRequest| {
             if req.query_string().contains("qp") {
-                HttpResponse::Ok()
+                HttpResponse::ok()
             } else {
-                HttpResponse::BadRequest()
+                HttpResponse::bad_request()
             }
         }))
     });
@@ -394,7 +394,7 @@ async fn test_no_decompress() {
         App::new()
             .wrap(Compress::default())
             .service(web::resource("/").route(web::to(|| {
-                let mut res = HttpResponse::Ok().body(STR);
+                let mut res = HttpResponse::ok().body(STR);
                 res.encoding(header::ContentEncoding::Gzip);
                 res
             })))
@@ -440,7 +440,7 @@ async fn test_client_gzip_encoding() {
             e.write_all(STR.as_ref()).unwrap();
             let data = e.finish().unwrap();
 
-            HttpResponse::Ok()
+            HttpResponse::ok()
                 .insert_header(("content-encoding", "gzip"))
                 .body(data)
         })))
@@ -463,7 +463,7 @@ async fn test_client_gzip_encoding_large() {
             e.write_all(STR.repeat(10).as_ref()).unwrap();
             let data = e.finish().unwrap();
 
-            HttpResponse::Ok()
+            HttpResponse::ok()
                 .insert_header(("content-encoding", "gzip"))
                 .body(data)
         })))
@@ -491,7 +491,7 @@ async fn test_client_gzip_encoding_large_random() {
             let mut e = GzEncoder::new(Vec::new(), Compression::default());
             e.write_all(&data).unwrap();
             let data = e.finish().unwrap();
-            HttpResponse::Ok()
+            HttpResponse::ok()
                 .insert_header(("content-encoding", "gzip"))
                 .body(data)
         })))
@@ -513,7 +513,7 @@ async fn test_client_brotli_encoding() {
             let mut e = BrotliEncoder::new(Vec::new(), 5);
             e.write_all(&data).unwrap();
             let data = e.finish().unwrap();
-            HttpResponse::Ok()
+            HttpResponse::ok()
                 .insert_header(("content-encoding", "br"))
                 .body(data)
         })))
@@ -541,7 +541,7 @@ async fn test_client_brotli_encoding_large_random() {
             let mut e = BrotliEncoder::new(Vec::new(), 5);
             e.write_all(&data).unwrap();
             let data = e.finish().unwrap();
-            HttpResponse::Ok()
+            HttpResponse::ok()
                 .insert_header(("content-encoding", "br"))
                 .body(data)
         })))
@@ -564,7 +564,7 @@ async fn test_client_brotli_encoding_large_random() {
 //         app.handler(|req: &HttpRequest| {
 //             req.body()
 //                 .and_then(|bytes: Bytes| {
-//                     Ok(HttpResponse::Ok()
+//                     Ok(HttpResponse::ok()
 //                         .content_encoding(http::ContentEncoding::Br)
 //                         .body(bytes))
 //                 })
@@ -598,7 +598,7 @@ async fn test_client_brotli_encoding_large_random() {
 //         app.handler(|req: &HttpRequest| {
 //             req.body()
 //                 .and_then(|bytes: Bytes| {
-//                     Ok(HttpResponse::Ok()
+//                     Ok(HttpResponse::ok()
 //                         .content_encoding(http::ContentEncoding::Br)
 //                         .body(bytes))
 //                 })
@@ -628,7 +628,7 @@ async fn test_client_brotli_encoding_large_random() {
 //             req.body()
 //                 .map_err(Error::from)
 //                 .and_then(|body| {
-//                     Ok(HttpResponse::Ok()
+//                     Ok(HttpResponse::ok()
 //                         .chunked()
 //                         .content_encoding(http::ContentEncoding::Identity)
 //                         .body(body))
@@ -654,7 +654,7 @@ async fn test_client_brotli_encoding_large_random() {
 //     let srv = test::TestServer::start(|app| {
 //         app.handler(|_| {
 //             let body = once(Ok(Bytes::from_static(STR.as_ref())));
-//             HttpResponse::Ok()
+//             HttpResponse::ok()
 //                 .content_encoding(http::ContentEncoding::Gzip)
 //                 .body(Body::Streaming(Box::new(body)))
 //         })
@@ -721,7 +721,7 @@ async fn test_client_cookie_handling() {
                     } else {
                         // Send some cookies back
                         Ok::<_, Error>(
-                            HttpResponse::Ok().cookie(cookie1).cookie(cookie2).finish(),
+                            HttpResponse::ok().cookie(cookie1).cookie(cookie2).finish(),
                         )
                     }
                 }
@@ -783,9 +783,9 @@ async fn client_basic_auth() {
                     .unwrap()
                     == "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
                 {
-                    HttpResponse::Ok()
+                    HttpResponse::ok()
                 } else {
-                    HttpResponse::BadRequest()
+                    HttpResponse::bad_request()
                 }
             }),
         )
@@ -811,9 +811,9 @@ async fn client_bearer_auth() {
                     .unwrap()
                     == "Bearer someS3cr3tAutht0k3n"
                 {
-                    HttpResponse::Ok()
+                    HttpResponse::ok()
                 } else {
-                    HttpResponse::BadRequest()
+                    HttpResponse::bad_request()
                 }
             }),
         )

--- a/awc/tests/test_connector.rs
+++ b/awc/tests/test_connector.rs
@@ -32,7 +32,7 @@ async fn test_connection_window_size() {
     let srv = test_server(move || {
         HttpService::build()
             .h2(map_config(
-                App::new().service(web::resource("/").route(web::to(HttpResponse::Ok))),
+                App::new().service(web::resource("/").route(web::to(HttpResponse::ok))),
                 |_| AppConfig::default(),
             ))
             .openssl(ssl_acceptor())

--- a/awc/tests/test_rustls_client.rs
+++ b/awc/tests/test_rustls_client.rs
@@ -66,7 +66,7 @@ async fn _test_connection_reuse_h2() {
             HttpService::build()
                 .h2(map_config(
                     App::new()
-                        .service(web::resource("/").route(web::to(HttpResponse::Ok))),
+                        .service(web::resource("/").route(web::to(HttpResponse::ok))),
                     |_| AppConfig::default(),
                 ))
                 .openssl(ssl_acceptor())

--- a/awc/tests/test_ssl_client.rs
+++ b/awc/tests/test_ssl_client.rs
@@ -46,7 +46,7 @@ async fn test_connection_reuse_h2() {
             HttpService::build()
                 .h2(map_config(
                     App::new()
-                        .service(web::resource("/").route(web::to(HttpResponse::Ok))),
+                        .service(web::resource("/").route(web::to(HttpResponse::ok))),
                     |_| AppConfig::default(),
                 ))
                 .openssl(ssl_acceptor())

--- a/awc/tests/test_ws.rs
+++ b/awc/tests/test_ws.rs
@@ -36,7 +36,7 @@ async fn test_simple() {
                     ws::Dispatcher::with(framed, ws_service).await
                 }
             })
-            .finish(|_| ok::<_, Error>(Response::NotFound()))
+            .finish(|_| ok::<_, Error>(Response::not_found()))
             .tcp()
     })
     .await;

--- a/benches/server.rs
+++ b/benches/server.rs
@@ -34,7 +34,7 @@ fn bench_async_burst(c: &mut Criterion) {
     let srv = rt.block_on(async {
         test::start(|| {
             App::new().service(
-                web::resource("/").route(web::to(|| HttpResponse::Ok().body(STR))),
+                web::resource("/").route(web::to(|| HttpResponse::ok().body(STR))),
             )
         })
     });

--- a/benches/service.rs
+++ b/benches/service.rs
@@ -59,7 +59,7 @@ where
 }
 
 async fn index(req: ServiceRequest) -> Result<ServiceResponse, Error> {
-    Ok(req.into_response(HttpResponse::Ok().finish()))
+    Ok(req.into_response(HttpResponse::ok().finish()))
 }
 
 // Benchmark basic WebService directly

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -33,7 +33,7 @@ async fn main() -> std::io::Result<()> {
                         middleware::DefaultHeaders::new().header("X-Version-R2", "0.3"),
                     )
                     .default_service(
-                        web::route().to(|| HttpResponse::MethodNotAllowed()),
+                        web::route().to(|| HttpResponse::method_not_allowed()),
                     )
                     .route(web::get().to(index_async)),
             )

--- a/examples/uds.rs
+++ b/examples/uds.rs
@@ -37,7 +37,7 @@ async fn main() -> std::io::Result<()> {
                         middleware::DefaultHeaders::new().header("X-Version-R2", "0.3"),
                     )
                     .default_service(
-                        web::route().to(|| HttpResponse::MethodNotAllowed()),
+                        web::route().to(|| HttpResponse::method_not_allowed()),
                     )
                     .route(web::get().to(index_async)),
             )

--- a/src/app.rs
+++ b/src/app.rs
@@ -92,7 +92,7 @@ where
     ///
     /// async fn index(data: web::Data<MyData>) -> impl Responder {
     ///     data.counter.set(data.counter.get() + 1);
-    ///     HttpResponse::Ok()
+    ///     HttpResponse::ok()
     /// }
     ///
     /// let app = App::new()
@@ -163,8 +163,8 @@ where
     /// // this function could be located in different module
     /// fn config(cfg: &mut web::ServiceConfig) {
     ///     cfg.service(web::resource("/test")
-    ///         .route(web::get().to(|| HttpResponse::Ok()))
-    ///         .route(web::head().to(|| HttpResponse::MethodNotAllowed()))
+    ///         .route(web::get().to(|| HttpResponse::ok()))
+    ///         .route(web::head().to(|| HttpResponse::method_not_allowed()))
     ///     );
     /// }
     ///
@@ -172,7 +172,7 @@ where
     ///     let app = App::new()
     ///         .wrap(middleware::Logger::default())
     ///         .configure(config)  // <- register resources
-    ///         .route("/index.html", web::get().to(|| HttpResponse::Ok()));
+    ///         .route("/index.html", web::get().to(|| HttpResponse::ok()));
     /// }
     /// ```
     pub fn configure<F>(mut self, f: F) -> Self
@@ -204,7 +204,7 @@ where
     /// fn main() {
     ///     let app = App::new()
     ///         .route("/test1", web::get().to(index))
-    ///         .route("/test2", web::post().to(|| HttpResponse::MethodNotAllowed()));
+    ///         .route("/test2", web::post().to(|| HttpResponse::method_not_allowed()));
     /// }
     /// ```
     pub fn route(self, path: &str, mut route: Route) -> Self {
@@ -249,7 +249,7 @@ where
     ///         .service(
     ///             web::resource("/index.html").route(web::get().to(index)))
     ///         .default_service(
-    ///             web::route().to(|| HttpResponse::NotFound()));
+    ///             web::route().to(|| HttpResponse::not_found()));
     /// }
     /// ```
     ///
@@ -261,9 +261,9 @@ where
     /// fn main() {
     ///     let app = App::new()
     ///         .service(
-    ///             web::resource("/index.html").to(|| HttpResponse::Ok()))
+    ///             web::resource("/index.html").to(|| HttpResponse::ok()))
     ///         .default_service(
-    ///             web::to(|| HttpResponse::NotFound())
+    ///             web::to(|| HttpResponse::not_found())
     ///         );
     /// }
     /// ```
@@ -298,7 +298,7 @@ where
     /// async fn index(req: HttpRequest) -> Result<HttpResponse> {
     ///     let url = req.url_for("youtube", &["asdlkjqme"])?;
     ///     assert_eq!(url.as_str(), "https://youtube.com/watch/asdlkjqme");
-    ///     Ok(HttpResponse::Ok().into())
+    ///     Ok(HttpResponse::ok().into())
     /// }
     ///
     /// fn main() {
@@ -492,7 +492,7 @@ mod tests {
     #[actix_rt::test]
     async fn test_default_resource() {
         let mut srv = init_service(
-            App::new().service(web::resource("/test").to(HttpResponse::Ok)),
+            App::new().service(web::resource("/test").to(HttpResponse::ok)),
         )
         .await;
         let req = TestRequest::with_uri("/test").to_request();
@@ -505,16 +505,16 @@ mod tests {
 
         let mut srv = init_service(
             App::new()
-                .service(web::resource("/test").to(HttpResponse::Ok))
+                .service(web::resource("/test").to(HttpResponse::ok))
                 .service(
                     web::resource("/test2")
                         .default_service(|r: ServiceRequest| {
-                            ok(r.into_response(HttpResponse::Created()))
+                            ok(r.into_response(HttpResponse::created()))
                         })
-                        .route(web::get().to(HttpResponse::Ok)),
+                        .route(web::get().to(HttpResponse::ok)),
                 )
                 .default_service(|r: ServiceRequest| {
-                    ok(r.into_response(HttpResponse::MethodNotAllowed()))
+                    ok(r.into_response(HttpResponse::method_not_allowed()))
                 }),
         )
         .await;
@@ -538,7 +538,7 @@ mod tests {
     async fn test_data_factory() {
         let mut srv =
             init_service(App::new().data_factory(|| ok::<_, ()>(10usize)).service(
-                web::resource("/").to(|_: web::Data<usize>| HttpResponse::Ok()),
+                web::resource("/").to(|_: web::Data<usize>| HttpResponse::ok()),
             ))
             .await;
         let req = TestRequest::default().to_request();
@@ -547,7 +547,7 @@ mod tests {
 
         let mut srv =
             init_service(App::new().data_factory(|| ok::<_, ()>(10u32)).service(
-                web::resource("/").to(|_: web::Data<usize>| HttpResponse::Ok()),
+                web::resource("/").to(|_: web::Data<usize>| HttpResponse::ok()),
             ))
             .await;
         let req = TestRequest::default().to_request();
@@ -559,7 +559,7 @@ mod tests {
     async fn test_data_factory_errors() {
         let srv =
             try_init_service(App::new().data_factory(|| err::<u32, _>(())).service(
-                web::resource("/").to(|_: web::Data<usize>| HttpResponse::Ok()),
+                web::resource("/").to(|_: web::Data<usize>| HttpResponse::ok()),
             ))
             .await;
 
@@ -571,7 +571,7 @@ mod tests {
         let mut srv = init_service(App::new().app_data(10usize).service(
             web::resource("/").to(|req: HttpRequest| {
                 assert_eq!(*req.app_data::<usize>().unwrap(), 10);
-                HttpResponse::Ok()
+                HttpResponse::ok()
             }),
         ))
         .await;
@@ -588,7 +588,7 @@ mod tests {
                     DefaultHeaders::new()
                         .header(header::CONTENT_TYPE, HeaderValue::from_static("0001")),
                 )
-                .route("/test", web::get().to(HttpResponse::Ok)),
+                .route("/test", web::get().to(HttpResponse::ok)),
         )
         .await;
         let req = TestRequest::with_uri("/test").to_request();
@@ -604,7 +604,7 @@ mod tests {
     async fn test_router_wrap() {
         let mut srv = init_service(
             App::new()
-                .route("/test", web::get().to(HttpResponse::Ok))
+                .route("/test", web::get().to(HttpResponse::ok))
                 .wrap(
                     DefaultHeaders::new()
                         .header(header::CONTENT_TYPE, HeaderValue::from_static("0001")),
@@ -635,7 +635,7 @@ mod tests {
                         Ok(res)
                     }
                 })
-                .service(web::resource("/test").to(HttpResponse::Ok)),
+                .service(web::resource("/test").to(HttpResponse::ok)),
         )
         .await;
         let req = TestRequest::with_uri("/test").to_request();
@@ -651,7 +651,7 @@ mod tests {
     async fn test_router_wrap_fn() {
         let mut srv = init_service(
             App::new()
-                .route("/test", web::get().to(HttpResponse::Ok))
+                .route("/test", web::get().to(HttpResponse::ok))
                 .wrap_fn(|req, srv| {
                     let fut = srv.call(req);
                     async {
@@ -682,7 +682,7 @@ mod tests {
                 .route(
                     "/test",
                     web::get().to(|req: HttpRequest| {
-                        HttpResponse::Ok().body(
+                        HttpResponse::ok().body(
                             req.url_for("youtube", &["12345"]).unwrap().to_string(),
                         )
                     }),

--- a/src/app_service.rs
+++ b/src/app_service.rs
@@ -66,7 +66,7 @@ where
         // if no user defined default service exists.
         let default = self.default.clone().unwrap_or_else(|| {
             Rc::new(boxed::factory(fn_service(|req: ServiceRequest| async {
-                Ok(req.into_response(Response::NotFound().finish()))
+                Ok(req.into_response(Response::not_found().finish()))
             })))
         });
 
@@ -364,7 +364,7 @@ mod tests {
             let mut app = init_service(
                 App::new()
                     .data(DropData(data.clone()))
-                    .service(web::resource("/test").to(HttpResponse::Ok)),
+                    .service(web::resource("/test").to(HttpResponse::ok)),
             )
             .await;
             let req = TestRequest::with_uri("/test").to_request();

--- a/src/config.rs
+++ b/src/config.rs
@@ -268,7 +268,7 @@ mod tests {
         let mut srv = init_service(App::new().configure(cfg).service(
             web::resource("/").to(|_: web::Data<usize>, req: HttpRequest| {
                 assert_eq!(*req.app_data::<u8>().unwrap(), 15u8);
-                HttpResponse::Ok()
+                HttpResponse::ok()
             }),
         ))
         .await;
@@ -290,7 +290,7 @@ mod tests {
 
     //     let mut srv =
     //         init_service(App::new().configure(cfg).service(
-    //             web::resource("/").to(|_: web::Data<usize>| HttpResponse::Ok()),
+    //             web::resource("/").to(|_: web::Data<usize>| HttpResponse::ok()),
     //         ));
     //     let req = TestRequest::default().to_request();
     //     let resp = srv.call(req).await.unwrap();
@@ -301,7 +301,7 @@ mod tests {
     //     };
     //     let mut srv = init_service(
     //         App::new()
-    //             .service(web::resource("/").to(|_: web::Data<usize>| HttpResponse::Ok()))
+    //             .service(web::resource("/").to(|_: web::Data<usize>| HttpResponse::ok()))
     //             .configure(cfg2),
     //     );
     //     let req = TestRequest::default().to_request();
@@ -322,7 +322,7 @@ mod tests {
                 .route(
                     "/test",
                     web::get().to(|req: HttpRequest| {
-                        HttpResponse::Ok().body(
+                        HttpResponse::ok().body(
                             req.url_for("youtube", &["12345"]).unwrap().to_string(),
                         )
                     }),
@@ -340,9 +340,9 @@ mod tests {
     async fn test_service() {
         let mut srv = init_service(App::new().configure(|cfg| {
             cfg.service(
-                web::resource("/test").route(web::get().to(HttpResponse::Created)),
+                web::resource("/test").route(web::get().to(HttpResponse::created)),
             )
-            .route("/index.html", web::get().to(HttpResponse::Ok));
+            .route("/index.html", web::get().to(HttpResponse::ok));
         }))
         .await;
 

--- a/src/data.rs
+++ b/src/data.rs
@@ -47,7 +47,7 @@ pub(crate) type FnDataFactory =
 /// async fn index(data: web::Data<Mutex<MyData>>) -> impl Responder {
 ///     let mut data = data.lock().unwrap();
 ///     data.counter += 1;
-///     HttpResponse::Ok()
+///     HttpResponse::ok()
 /// }
 ///
 /// fn main() {
@@ -150,7 +150,7 @@ mod tests {
         let mut srv = init_service(App::new().data("TEST".to_string()).service(
             web::resource("/").to(|data: web::Data<String>| {
                 assert_eq!(data.to_lowercase(), "test");
-                HttpResponse::Ok()
+                HttpResponse::ok()
             }),
         ))
         .await;
@@ -161,7 +161,7 @@ mod tests {
 
         let mut srv =
             init_service(App::new().data(10u32).service(
-                web::resource("/").to(|_: web::Data<usize>| HttpResponse::Ok()),
+                web::resource("/").to(|_: web::Data<usize>| HttpResponse::ok()),
             ))
             .await;
         let req = TestRequest::default().to_request();
@@ -173,7 +173,7 @@ mod tests {
     async fn test_app_data_extractor() {
         let mut srv =
             init_service(App::new().app_data(Data::new(10usize)).service(
-                web::resource("/").to(|_: web::Data<usize>| HttpResponse::Ok()),
+                web::resource("/").to(|_: web::Data<usize>| HttpResponse::ok()),
             ))
             .await;
 
@@ -183,7 +183,7 @@ mod tests {
 
         let mut srv =
             init_service(App::new().app_data(Data::new(10u32)).service(
-                web::resource("/").to(|_: web::Data<usize>| HttpResponse::Ok()),
+                web::resource("/").to(|_: web::Data<usize>| HttpResponse::ok()),
             ))
             .await;
         let req = TestRequest::default().to_request();
@@ -197,7 +197,7 @@ mod tests {
             App::new().service(
                 web::resource("/")
                     .data(10usize)
-                    .route(web::get().to(|_data: web::Data<usize>| HttpResponse::Ok())),
+                    .route(web::get().to(|_data: web::Data<usize>| HttpResponse::ok())),
             ),
         )
         .await;
@@ -211,7 +211,7 @@ mod tests {
             App::new().service(
                 web::resource("/")
                     .data(10u32)
-                    .route(web::get().to(|_: web::Data<usize>| HttpResponse::Ok())),
+                    .route(web::get().to(|_: web::Data<usize>| HttpResponse::ok())),
             ),
         )
         .await;
@@ -226,7 +226,7 @@ mod tests {
             web::resource("/").data(10usize).route(web::get().to(
                 |data: web::Data<usize>| {
                     assert_eq!(**data, 10);
-                    HttpResponse::Ok()
+                    HttpResponse::ok()
                 },
             )),
         ))

--- a/src/guard.rs
+++ b/src/guard.rs
@@ -20,7 +20,7 @@
 //!         web::route()
 //!              .guard(guard::Post())
 //!              .guard(guard::fn_guard(|head| head.method == http::Method::GET))
-//!              .to(|| HttpResponse::MethodNotAllowed()))
+//!              .to(|| HttpResponse::method_not_allowed()))
 //!     );
 //! }
 //! ```
@@ -52,7 +52,7 @@ pub trait Guard {
 ///                 guard::fn_guard(
 ///                     |req| req.headers()
 ///                              .contains_key("content-type")))
-///             .to(|| HttpResponse::MethodNotAllowed()))
+///             .to(|| HttpResponse::method_not_allowed()))
 ///     );
 /// }
 /// ```
@@ -92,7 +92,7 @@ where
 ///     App::new().service(web::resource("/index.html").route(
 ///         web::route()
 ///              .guard(guard::Any(guard::Get()).or(guard::Post()))
-///              .to(|| HttpResponse::MethodNotAllowed()))
+///              .to(|| HttpResponse::method_not_allowed()))
 ///     );
 /// }
 /// ```
@@ -132,7 +132,7 @@ impl Guard for AnyGuard {
 ///         web::route()
 ///             .guard(
 ///                 guard::All(guard::Get()).and(guard::Header("content-type", "text/plain")))
-///             .to(|| HttpResponse::MethodNotAllowed()))
+///             .to(|| HttpResponse::method_not_allowed()))
 ///     );
 /// }
 /// ```
@@ -266,7 +266,7 @@ impl Guard for HeaderGuard {
 ///     App::new().service(
 ///         web::resource("/index.html")
 ///             .guard(Host("www.rust-lang.org"))
-///             .to(|| HttpResponse::MethodNotAllowed())
+///             .to(|| HttpResponse::method_not_allowed())
 ///     );
 /// }
 /// ```

--- a/src/middleware/compat.rs
+++ b/src/middleware/compat.rs
@@ -144,7 +144,7 @@ mod tests {
                     .wrap(Compat::new(logger))
                     .wrap(Compat::new(compress))
                     .service(
-                        web::resource("/test").route(web::get().to(HttpResponse::Ok)),
+                        web::resource("/test").route(web::get().to(HttpResponse::ok)),
                     ),
             ),
         )
@@ -165,7 +165,7 @@ mod tests {
                 web::resource("app/test")
                     .wrap(Compat::new(logger))
                     .wrap(Compat::new(compress))
-                    .route(web::get().to(HttpResponse::Ok)),
+                    .route(web::get().to(HttpResponse::ok)),
             ),
         )
         .await;
@@ -179,7 +179,7 @@ mod tests {
     async fn test_condition_scope_middleware() {
         let srv = |req: ServiceRequest| {
             Box::pin(async move {
-                Ok(req.into_response(HttpResponse::InternalServerError().finish()))
+                Ok(req.into_response(HttpResponse::internal_server_error().finish()))
             })
         };
 

--- a/src/middleware/compress.rs
+++ b/src/middleware/compress.rs
@@ -35,7 +35,7 @@ use crate::{
 ///
 /// let app = App::new()
 ///     .wrap(middleware::Compress::default())
-///     .default_service(web::to(|| HttpResponse::NotFound()));
+///     .default_service(web::to(|| HttpResponse::not_found()));
 /// ```
 #[derive(Debug, Clone)]
 pub struct Compress(ContentEncoding);

--- a/src/middleware/condition.rs
+++ b/src/middleware/condition.rs
@@ -117,7 +117,7 @@ mod tests {
     #[actix_rt::test]
     async fn test_handler_enabled() {
         let srv = |req: ServiceRequest| {
-            ok(req.into_response(HttpResponse::InternalServerError().finish()))
+            ok(req.into_response(HttpResponse::internal_server_error().finish()))
         };
 
         let mw =
@@ -135,7 +135,7 @@ mod tests {
     #[actix_rt::test]
     async fn test_handler_disabled() {
         let srv = |req: ServiceRequest| {
-            ok(req.into_response(HttpResponse::InternalServerError().finish()))
+            ok(req.into_response(HttpResponse::internal_server_error().finish()))
         };
 
         let mw =

--- a/src/middleware/default_headers.rs
+++ b/src/middleware/default_headers.rs
@@ -37,8 +37,8 @@ use crate::{
 ///         .wrap(middleware::DefaultHeaders::new().header("X-Version", "0.2"))
 ///         .service(
 ///             web::resource("/test")
-///                 .route(web::get().to(|| HttpResponse::Ok()))
-///                 .route(web::method(http::Method::HEAD).to(|| HttpResponse::MethodNotAllowed()))
+///                 .route(web::get().to(|| HttpResponse::ok()))
+///                 .route(web::method(http::Method::HEAD).to(|| HttpResponse::method_not_allowed()))
 ///         );
 /// }
 /// ```
@@ -213,7 +213,7 @@ mod tests {
         let req = TestRequest::default().to_srv_request();
         let srv = |req: ServiceRequest| {
             ok(req.into_response(
-                HttpResponse::Ok()
+                HttpResponse::ok()
                     .insert_header((CONTENT_TYPE, "0002"))
                     .finish(),
             ))
@@ -230,7 +230,7 @@ mod tests {
     #[actix_rt::test]
     async fn test_content_type() {
         let srv =
-            |req: ServiceRequest| ok(req.into_response(HttpResponse::Ok().finish()));
+            |req: ServiceRequest| ok(req.into_response(HttpResponse::ok().finish()));
         let mut mw = DefaultHeaders::new()
             .add_content_type()
             .new_transform(srv.into_service())

--- a/src/middleware/err_handlers.rs
+++ b/src/middleware/err_handlers.rs
@@ -51,8 +51,8 @@ type ErrorHandler<B> = dyn Fn(ServiceResponse<B>) -> Result<ErrorHandlerResponse
 ///             .handler(http::StatusCode::INTERNAL_SERVER_ERROR, render_500),
 ///     )
 ///     .service(web::resource("/test")
-///         .route(web::get().to(|| HttpResponse::Ok()))
-///         .route(web::head().to(|| HttpResponse::MethodNotAllowed())
+///         .route(web::get().to(|| HttpResponse::ok()))
+///         .route(web::head().to(|| HttpResponse::method_not_allowed())
 ///     ));
 /// ```
 pub struct ErrorHandlers<B> {
@@ -193,7 +193,7 @@ mod tests {
     #[actix_rt::test]
     async fn test_handler() {
         let srv = |req: ServiceRequest| {
-            ok(req.into_response(HttpResponse::InternalServerError().finish()))
+            ok(req.into_response(HttpResponse::internal_server_error().finish()))
         };
 
         let mut mw = ErrorHandlers::new()
@@ -220,7 +220,7 @@ mod tests {
     #[actix_rt::test]
     async fn test_handler_async() {
         let srv = |req: ServiceRequest| {
-            ok(req.into_response(HttpResponse::InternalServerError().finish()))
+            ok(req.into_response(HttpResponse::internal_server_error().finish()))
         };
 
         let mut mw = ErrorHandlers::new()

--- a/src/middleware/normalize.rs
+++ b/src/middleware/normalize.rs
@@ -198,8 +198,8 @@ mod tests {
         let mut app = init_service(
             App::new()
                 .wrap(NormalizePath::default())
-                .service(web::resource("/").to(HttpResponse::Ok))
-                .service(web::resource("/v1/something").to(HttpResponse::Ok)),
+                .service(web::resource("/").to(HttpResponse::ok))
+                .service(web::resource("/v1/something").to(HttpResponse::ok)),
         )
         .await;
 
@@ -237,8 +237,8 @@ mod tests {
         let mut app = init_service(
             App::new()
                 .wrap(NormalizePath(TrailingSlash::Trim))
-                .service(web::resource("/").to(HttpResponse::Ok))
-                .service(web::resource("/v1/something").to(HttpResponse::Ok)),
+                .service(web::resource("/").to(HttpResponse::ok))
+                .service(web::resource("/v1/something").to(HttpResponse::ok)),
         )
         .await;
 
@@ -277,9 +277,9 @@ mod tests {
         let mut app = init_service(
             App::new()
                 .wrap(NormalizePath(TrailingSlash::MergeOnly))
-                .service(web::resource("/").to(HttpResponse::Ok))
-                .service(web::resource("/v1/something").to(HttpResponse::Ok))
-                .service(web::resource("/v1/").to(HttpResponse::Ok)),
+                .service(web::resource("/").to(HttpResponse::ok))
+                .service(web::resource("/v1/something").to(HttpResponse::ok))
+                .service(web::resource("/v1/").to(HttpResponse::ok)),
         )
         .await;
 
@@ -308,7 +308,7 @@ mod tests {
     async fn test_in_place_normalization() {
         let srv = |req: ServiceRequest| {
             assert_eq!("/v1/something", req.path());
-            ready(Ok(req.into_response(HttpResponse::Ok().finish())))
+            ready(Ok(req.into_response(HttpResponse::ok().finish())))
         };
 
         let mut normalize = NormalizePath::default()
@@ -339,7 +339,7 @@ mod tests {
 
         let srv = |req: ServiceRequest| {
             assert_eq!(URI, req.path());
-            ready(Ok(req.into_response(HttpResponse::Ok().finish())))
+            ready(Ok(req.into_response(HttpResponse::ok().finish())))
         };
 
         let mut normalize = NormalizePath::default()
@@ -356,7 +356,7 @@ mod tests {
     async fn should_normalize_no_trail() {
         let srv = |req: ServiceRequest| {
             assert_eq!("/v1/something", req.path());
-            ready(Ok(req.into_response(HttpResponse::Ok().finish())))
+            ready(Ok(req.into_response(HttpResponse::ok().finish())))
         };
 
         let mut normalize = NormalizePath::default()

--- a/src/request.rs
+++ b/src/request.rs
@@ -164,14 +164,14 @@ impl HttpRequest {
     /// #
     /// fn index(req: HttpRequest) -> HttpResponse {
     ///     let url = req.url_for("foo", &["1", "2", "3"]); // <- generate url for "foo" resource
-    ///     HttpResponse::Ok().into()
+    ///     HttpResponse::ok().into()
     /// }
     ///
     /// fn main() {
     ///     let app = App::new()
     ///         .service(web::resource("/test/{one}/{two}/{three}")
     ///              .name("foo")  // <- set resource name, then it could be used in `url_for`
-    ///              .route(web::get().to(|| HttpResponse::Ok()))
+    ///              .route(web::get().to(|| HttpResponse::ok()))
     ///         );
     /// }
     /// ```
@@ -558,7 +558,7 @@ mod tests {
     async fn test_drop_http_request_pool() {
         let mut srv = init_service(App::new().service(web::resource("/").to(
             |req: HttpRequest| {
-                HttpResponse::Ok()
+                HttpResponse::ok()
                     .insert_header(("pool_cap", req.app_state().pool().cap))
                     .finish()
             },
@@ -578,9 +578,9 @@ mod tests {
         let mut srv = init_service(App::new().app_data(10usize).service(
             web::resource("/").to(|req: HttpRequest| {
                 if req.app_data::<usize>().is_some() {
-                    HttpResponse::Ok()
+                    HttpResponse::ok()
                 } else {
-                    HttpResponse::BadRequest()
+                    HttpResponse::bad_request()
                 }
             }),
         ))
@@ -593,9 +593,9 @@ mod tests {
         let mut srv = init_service(App::new().app_data(10u32).service(
             web::resource("/").to(|req: HttpRequest| {
                 if req.app_data::<usize>().is_some() {
-                    HttpResponse::Ok()
+                    HttpResponse::ok()
                 } else {
-                    HttpResponse::BadRequest()
+                    HttpResponse::bad_request()
                 }
             }),
         ))
@@ -611,7 +611,7 @@ mod tests {
         #[allow(dead_code)]
         fn echo_usize(req: HttpRequest) -> HttpResponse {
             let num = req.app_data::<usize>().unwrap();
-            HttpResponse::Ok().body(num.to_string())
+            HttpResponse::ok().body(num.to_string())
         }
 
         let mut srv = init_service(
@@ -642,7 +642,7 @@ mod tests {
         #[allow(dead_code)]
         fn echo_usize(req: HttpRequest) -> HttpResponse {
             let num = req.app_data::<usize>().unwrap();
-            HttpResponse::Ok().body(num.to_string())
+            HttpResponse::ok().body(num.to_string())
         }
 
         let mut srv = init_service(
@@ -690,7 +690,7 @@ mod tests {
                     req.extensions_mut().insert(Foo {
                         tracker: Rc::clone(&tracker2),
                     });
-                    HttpResponse::Ok()
+                    HttpResponse::ok()
                 }),
             ))
             .await;
@@ -715,12 +715,12 @@ mod tests {
                                 Some("/user/{id}/profile".to_owned())
                             );
 
-                            HttpResponse::Ok().finish()
+                            HttpResponse::ok().finish()
                         },
                     )))
                     .default_service(web::to(move |req: HttpRequest| {
                         assert!(req.match_pattern().is_none());
-                        HttpResponse::Ok().finish()
+                        HttpResponse::ok().finish()
                     })),
             ),
         )
@@ -743,17 +743,17 @@ mod tests {
                     web::resource("").to(move |req: HttpRequest| {
                         assert_eq!(req.match_pattern(), Some("/user/{id}".to_owned()));
 
-                        HttpResponse::Ok().finish()
+                        HttpResponse::ok().finish()
                     }),
                 )))
                 .service(web::resource("/").to(move |req: HttpRequest| {
                     assert_eq!(req.match_pattern(), Some("/".to_owned()));
 
-                    HttpResponse::Ok().finish()
+                    HttpResponse::ok().finish()
                 }))
                 .default_service(web::to(move |req: HttpRequest| {
                     assert!(req.match_pattern().is_none());
-                    HttpResponse::Ok().finish()
+                    HttpResponse::ok().finish()
                 })),
         )
         .await;

--- a/src/request_data.rs
+++ b/src/request_data.rs
@@ -40,7 +40,7 @@ use crate::{dev::Payload, FromRequest, HttpRequest};
 ///         assert_eq!(&flag.into_inner(), req.extensions().get::<FlagFromMiddleware>().unwrap());
 ///     }
 ///     
-///     HttpResponse::Ok()
+///     HttpResponse::ok()
 /// }
 /// ```
 ///
@@ -125,7 +125,7 @@ mod tests {
                             );
                         }
 
-                        HttpResponse::Ok()
+                        HttpResponse::ok()
                     },
                 )),
         )
@@ -163,7 +163,7 @@ mod tests {
                     *data.borrow_mut() += 11;
                     assert_eq!(*data.borrow(), 53);
 
-                    HttpResponse::Ok()
+                    HttpResponse::ok()
                 })),
         )
         .await;

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -42,7 +42,7 @@ type HttpNewService = BoxServiceFactory<(), ServiceRequest, ServiceResponse, Err
 /// fn main() {
 ///     let app = App::new().service(
 ///         web::resource("/")
-///             .route(web::get().to(|| HttpResponse::Ok())));
+///             .route(web::get().to(|| HttpResponse::ok())));
 /// }
 /// ```
 ///
@@ -72,7 +72,7 @@ impl Resource {
             guards: Vec::new(),
             app_data: None,
             default: boxed::factory(fn_service(|req: ServiceRequest| async {
-                Ok(req.into_response(Response::MethodNotAllowed().finish()))
+                Ok(req.into_response(Response::method_not_allowed().finish()))
             })),
         }
     }
@@ -115,7 +115,7 @@ where
     ///         .service(
     ///             web::resource("/app")
     ///                 .guard(guard::Header("content-type", "text/json"))
-    ///                 .route(web::get().to(|| HttpResponse::MethodNotAllowed()))
+    ///                 .route(web::get().to(|| HttpResponse::method_not_allowed()))
     ///         );
     /// }
     /// ```
@@ -140,7 +140,7 @@ where
     ///             web::route()
     ///                 .guard(guard::Any(guard::Get()).or(guard::Put()))
     ///                 .guard(guard::Header("Content-Type", "text/plain"))
-    ///                 .to(|| HttpResponse::Ok()))
+    ///                 .to(|| HttpResponse::ok()))
     ///     );
     /// }
     /// ```
@@ -159,9 +159,9 @@ where
     ///              .route(web::delete().to(delete_handler))
     ///     );
     /// }
-    /// # async fn get_handler() -> impl actix_web::Responder { actix_web::HttpResponse::Ok() }
-    /// # async fn post_handler() -> impl actix_web::Responder { actix_web::HttpResponse::Ok() }
-    /// # async fn delete_handler() -> impl actix_web::Responder { actix_web::HttpResponse::Ok() }
+    /// # async fn get_handler() -> impl actix_web::Responder { actix_web::HttpResponse::ok() }
+    /// # async fn post_handler() -> impl actix_web::Responder { actix_web::HttpResponse::ok() }
+    /// # async fn delete_handler() -> impl actix_web::Responder { actix_web::HttpResponse::ok() }
     /// ```
     pub fn route(mut self, route: Route) -> Self {
         self.routes.push(route);
@@ -538,7 +538,7 @@ mod tests {
                             header::CONTENT_TYPE,
                             HeaderValue::from_static("0001"),
                         ))
-                        .route(web::get().to(HttpResponse::Ok)),
+                        .route(web::get().to(HttpResponse::ok)),
                 ),
             )
             .await;
@@ -568,7 +568,7 @@ mod tests {
                             })
                         }
                     })
-                    .route(web::get().to(HttpResponse::Ok)),
+                    .route(web::get().to(HttpResponse::ok)),
             ),
         )
         .await;
@@ -586,7 +586,7 @@ mod tests {
         let mut srv =
             init_service(App::new().service(web::resource("/test").to(|| async {
                 sleep(Duration::from_millis(100)).await;
-                Ok::<_, Error>(HttpResponse::Ok())
+                Ok::<_, Error>(HttpResponse::ok())
             })))
             .await;
         let req = TestRequest::with_uri("/test").to_request();
@@ -599,7 +599,7 @@ mod tests {
         let mut srv = init_service(
             App::new().service(
                 web::resource(["/test", "/test2"])
-                    .to(|| async { Ok::<_, Error>(HttpResponse::Ok()) }),
+                    .to(|| async { Ok::<_, Error>(HttpResponse::ok()) }),
             ),
         )
         .await;
@@ -615,9 +615,9 @@ mod tests {
     async fn test_default_resource() {
         let mut srv = init_service(
             App::new()
-                .service(web::resource("/test").route(web::get().to(HttpResponse::Ok)))
+                .service(web::resource("/test").route(web::get().to(HttpResponse::ok)))
                 .default_service(|r: ServiceRequest| {
-                    ok(r.into_response(HttpResponse::BadRequest()))
+                    ok(r.into_response(HttpResponse::bad_request()))
                 }),
         )
         .await;
@@ -634,9 +634,9 @@ mod tests {
         let mut srv = init_service(
             App::new().service(
                 web::resource("/test")
-                    .route(web::get().to(HttpResponse::Ok))
+                    .route(web::get().to(HttpResponse::ok))
                     .default_service(|r: ServiceRequest| {
-                        ok(r.into_response(HttpResponse::BadRequest()))
+                        ok(r.into_response(HttpResponse::bad_request()))
                     }),
             ),
         )
@@ -660,17 +660,17 @@ mod tests {
                 .service(
                     web::resource("/test/{p}")
                         .guard(guard::Get())
-                        .to(HttpResponse::Ok),
+                        .to(HttpResponse::ok),
                 )
                 .service(
                     web::resource("/test/{p}")
                         .guard(guard::Put())
-                        .to(HttpResponse::Created),
+                        .to(HttpResponse::created),
                 )
                 .service(
                     web::resource("/test/{p}")
                         .guard(guard::Delete())
-                        .to(HttpResponse::NoContent),
+                        .to(HttpResponse::no_content),
                 ),
         )
         .await;
@@ -714,7 +714,7 @@ mod tests {
                                 assert_eq!(**data2, '*');
                                 let error = std::f64::EPSILON;
                                 assert!((**data3 - 1.0).abs() < error);
-                                HttpResponse::Ok()
+                                HttpResponse::ok()
                             },
                         ),
                 ),
@@ -734,7 +734,7 @@ mod tests {
                     .data(10usize)
                     .default_service(web::to(|data: web::Data<usize>| {
                         assert_eq!(**data, 10);
-                        HttpResponse::Ok()
+                        HttpResponse::ok()
                     })),
             ),
         )

--- a/src/responder.rs
+++ b/src/responder.rs
@@ -105,7 +105,7 @@ impl<T: Responder> Responder for (T, StatusCode) {
 
 impl Responder for &'static str {
     fn respond_to(self, _: &HttpRequest) -> HttpResponse {
-        HttpResponse::Ok()
+        HttpResponse::ok()
             .content_type(mime::TEXT_PLAIN_UTF_8)
             .body(self)
     }
@@ -113,7 +113,7 @@ impl Responder for &'static str {
 
 impl Responder for &'static [u8] {
     fn respond_to(self, _: &HttpRequest) -> HttpResponse {
-        HttpResponse::Ok()
+        HttpResponse::ok()
             .content_type(mime::APPLICATION_OCTET_STREAM)
             .body(self)
     }
@@ -121,7 +121,7 @@ impl Responder for &'static [u8] {
 
 impl Responder for String {
     fn respond_to(self, _: &HttpRequest) -> HttpResponse {
-        HttpResponse::Ok()
+        HttpResponse::ok()
             .content_type(mime::TEXT_PLAIN_UTF_8)
             .body(self)
     }
@@ -129,7 +129,7 @@ impl Responder for String {
 
 impl<'a> Responder for &'a String {
     fn respond_to(self, _: &HttpRequest) -> HttpResponse {
-        HttpResponse::Ok()
+        HttpResponse::ok()
             .content_type(mime::TEXT_PLAIN_UTF_8)
             .body(self)
     }
@@ -137,7 +137,7 @@ impl<'a> Responder for &'a String {
 
 impl Responder for Bytes {
     fn respond_to(self, _: &HttpRequest) -> HttpResponse {
-        HttpResponse::Ok()
+        HttpResponse::ok()
             .content_type(mime::APPLICATION_OCTET_STREAM)
             .body(self)
     }
@@ -145,7 +145,7 @@ impl Responder for Bytes {
 
 impl Responder for BytesMut {
     fn respond_to(self, _: &HttpRequest) -> HttpResponse {
-        HttpResponse::Ok()
+        HttpResponse::ok()
             .content_type(mime::APPLICATION_OCTET_STREAM)
             .body(self)
     }

--- a/src/route.rs
+++ b/src/route.rs
@@ -52,7 +52,7 @@ impl Route {
     pub fn new() -> Route {
         Route {
             service: Box::new(RouteNewService::new(HandlerService::new(|| {
-                ready(HttpResponse::NotFound())
+                ready(HttpResponse::not_found())
             }))),
             guards: Rc::new(Vec::new()),
         }
@@ -140,7 +140,7 @@ impl Route {
     ///     web::get()
     ///         .method(http::Method::CONNECT)
     ///         .guard(guard::Header("content-type", "text/plain"))
-    ///         .to(|req: HttpRequest| HttpResponse::Ok()))
+    ///         .to(|req: HttpRequest| HttpResponse::ok()))
     /// );
     /// # }
     /// ```
@@ -160,7 +160,7 @@ impl Route {
     ///     web::route()
     ///         .guard(guard::Get())
     ///         .guard(guard::Header("content-type", "text/plain"))
-    ///         .to(|req: HttpRequest| HttpResponse::Ok()))
+    ///         .to(|req: HttpRequest| HttpResponse::ok()))
     /// );
     /// # }
     /// ```
@@ -331,13 +331,13 @@ mod tests {
             App::new()
                 .service(
                     web::resource("/test")
-                        .route(web::get().to(HttpResponse::Ok))
+                        .route(web::get().to(HttpResponse::ok))
                         .route(web::put().to(|| async {
                             Err::<HttpResponse, _>(error::ErrorBadRequest("err"))
                         }))
                         .route(web::post().to(|| async {
                             sleep(Duration::from_millis(100)).await;
-                            Ok::<_, ()>(HttpResponse::Created())
+                            Ok::<_, ()>(HttpResponse::created())
                         }))
                         .route(web::delete().to(|| async {
                             sleep(Duration::from_millis(100)).await;

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -47,9 +47,9 @@ type HttpNewService = BoxServiceFactory<(), ServiceRequest, ServiceResponse, Err
 /// fn main() {
 ///     let app = App::new().service(
 ///         web::scope("/{project_id}/")
-///             .service(web::resource("/path1").to(|| async { HttpResponse::Ok() }))
-///             .service(web::resource("/path2").route(web::get().to(|| HttpResponse::Ok())))
-///             .service(web::resource("/path3").route(web::head().to(|| HttpResponse::MethodNotAllowed())))
+///             .service(web::resource("/path1").to(|| async { HttpResponse::ok() }))
+///             .service(web::resource("/path2").route(web::get().to(|| HttpResponse::ok())))
+///             .service(web::resource("/path3").route(web::head().to(|| HttpResponse::method_not_allowed())))
 ///     );
 /// }
 /// ```
@@ -111,7 +111,7 @@ where
     ///             .guard(guard::Header("content-type", "text/plain"))
     ///             .route("/test1", web::get().to(index))
     ///             .route("/test2", web::post().to(|r: HttpRequest| {
-    ///                 HttpResponse::MethodNotAllowed()
+    ///                 HttpResponse::method_not_allowed()
     ///             }))
     ///     );
     /// }
@@ -134,7 +134,7 @@ where
     ///
     /// async fn index(data: web::Data<MyData>) -> impl Responder {
     ///     data.counter.set(data.counter.get() + 1);
-    ///     HttpResponse::Ok()
+    ///     HttpResponse::ok()
     /// }
     ///
     /// fn main() {
@@ -176,8 +176,8 @@ where
     /// // this function could be located in different module
     /// fn config(cfg: &mut web::ServiceConfig) {
     ///     cfg.service(web::resource("/test")
-    ///         .route(web::get().to(|| HttpResponse::Ok()))
-    ///         .route(web::head().to(|| HttpResponse::MethodNotAllowed()))
+    ///         .route(web::get().to(|| HttpResponse::ok()))
+    ///         .route(web::head().to(|| HttpResponse::method_not_allowed()))
     ///     );
     /// }
     ///
@@ -188,7 +188,7 @@ where
     ///             web::scope("/api")
     ///                 .configure(config)
     ///         )
-    ///         .route("/index.html", web::get().to(|| HttpResponse::Ok()));
+    ///         .route("/index.html", web::get().to(|| HttpResponse::ok()));
     /// }
     /// ```
     pub fn configure<F>(mut self, f: F) -> Self
@@ -268,7 +268,7 @@ where
     ///     let app = App::new().service(
     ///         web::scope("/app")
     ///             .route("/test1", web::get().to(index))
-    ///             .route("/test2", web::post().to(|| HttpResponse::MethodNotAllowed()))
+    ///             .route("/test2", web::post().to(|| HttpResponse::method_not_allowed()))
     ///     );
     /// }
     /// ```
@@ -604,7 +604,7 @@ mod tests {
     #[actix_rt::test]
     async fn test_scope() {
         let mut srv = init_service(App::new().service(
-            web::scope("/app").service(web::resource("/path1").to(HttpResponse::Ok)),
+            web::scope("/app").service(web::resource("/path1").to(HttpResponse::ok)),
         ))
         .await;
 
@@ -618,8 +618,8 @@ mod tests {
         let mut srv = init_service(
             App::new().service(
                 web::scope("/app")
-                    .service(web::resource("").to(HttpResponse::Ok))
-                    .service(web::resource("/").to(HttpResponse::Created)),
+                    .service(web::resource("").to(HttpResponse::ok))
+                    .service(web::resource("/").to(HttpResponse::created)),
             ),
         )
         .await;
@@ -636,7 +636,7 @@ mod tests {
     #[actix_rt::test]
     async fn test_scope_root2() {
         let mut srv = init_service(App::new().service(
-            web::scope("/app/").service(web::resource("").to(HttpResponse::Ok)),
+            web::scope("/app/").service(web::resource("").to(HttpResponse::ok)),
         ))
         .await;
 
@@ -652,7 +652,7 @@ mod tests {
     #[actix_rt::test]
     async fn test_scope_root3() {
         let mut srv = init_service(App::new().service(
-            web::scope("/app/").service(web::resource("/").to(HttpResponse::Ok)),
+            web::scope("/app/").service(web::resource("/").to(HttpResponse::ok)),
         ))
         .await;
 
@@ -670,8 +670,8 @@ mod tests {
         let mut srv = init_service(
             App::new().service(
                 web::scope("app")
-                    .route("/path1", web::get().to(HttpResponse::Ok))
-                    .route("/path1", web::delete().to(HttpResponse::Ok)),
+                    .route("/path1", web::get().to(HttpResponse::ok))
+                    .route("/path1", web::delete().to(HttpResponse::ok)),
             ),
         )
         .await;
@@ -699,8 +699,8 @@ mod tests {
             App::new().service(
                 web::scope("app").service(
                     web::resource("path1")
-                        .route(web::get().to(HttpResponse::Ok))
-                        .route(web::delete().to(HttpResponse::Ok)),
+                        .route(web::get().to(HttpResponse::ok))
+                        .route(web::delete().to(HttpResponse::ok)),
                 ),
             ),
         )
@@ -729,7 +729,7 @@ mod tests {
             App::new().service(
                 web::scope("/app")
                     .guard(guard::Get())
-                    .service(web::resource("/path1").to(HttpResponse::Ok)),
+                    .service(web::resource("/path1").to(HttpResponse::ok)),
             ),
         )
         .await;
@@ -752,7 +752,7 @@ mod tests {
         let mut srv =
             init_service(App::new().service(web::scope("/ab-{project}").service(
                 web::resource("/path1").to(|r: HttpRequest| {
-                    HttpResponse::Ok()
+                    HttpResponse::ok()
                         .body(format!("project: {}", &r.match_info()["project"]))
                 }),
             )))
@@ -778,7 +778,7 @@ mod tests {
     #[actix_rt::test]
     async fn test_nested_scope() {
         let mut srv = init_service(App::new().service(web::scope("/app").service(
-            web::scope("/t1").service(web::resource("/path1").to(HttpResponse::Created)),
+            web::scope("/t1").service(web::resource("/path1").to(HttpResponse::created)),
         )))
         .await;
 
@@ -790,7 +790,7 @@ mod tests {
     #[actix_rt::test]
     async fn test_nested_scope_no_slash() {
         let mut srv = init_service(App::new().service(web::scope("/app").service(
-            web::scope("t1").service(web::resource("/path1").to(HttpResponse::Created)),
+            web::scope("t1").service(web::resource("/path1").to(HttpResponse::created)),
         )))
         .await;
 
@@ -805,8 +805,8 @@ mod tests {
             App::new().service(
                 web::scope("/app").service(
                     web::scope("/t1")
-                        .service(web::resource("").to(HttpResponse::Ok))
-                        .service(web::resource("/").to(HttpResponse::Created)),
+                        .service(web::resource("").to(HttpResponse::ok))
+                        .service(web::resource("/").to(HttpResponse::created)),
                 ),
             ),
         )
@@ -828,7 +828,7 @@ mod tests {
                 web::scope("/app").service(
                     web::scope("/t1")
                         .guard(guard::Get())
-                        .service(web::resource("/path1").to(HttpResponse::Ok)),
+                        .service(web::resource("/path1").to(HttpResponse::ok)),
                 ),
             ),
         )
@@ -852,7 +852,7 @@ mod tests {
         let mut srv = init_service(App::new().service(web::scope("/app").service(
             web::scope("/{project_id}").service(web::resource("/path1").to(
                 |r: HttpRequest| {
-                    HttpResponse::Created()
+                    HttpResponse::created()
                         .body(format!("project: {}", &r.match_info()["project_id"]))
                 },
             )),
@@ -877,7 +877,7 @@ mod tests {
         let mut srv = init_service(App::new().service(web::scope("/app").service(
             web::scope("/{project}").service(web::scope("/{id}").service(
                 web::resource("/path1").to(|r: HttpRequest| {
-                    HttpResponse::Created().body(format!(
+                    HttpResponse::created().body(format!(
                         "project: {} - {}",
                         &r.match_info()["project"],
                         &r.match_info()["id"],
@@ -909,9 +909,9 @@ mod tests {
         let mut srv = init_service(
             App::new().service(
                 web::scope("/app")
-                    .service(web::resource("/path1").to(HttpResponse::Ok))
+                    .service(web::resource("/path1").to(HttpResponse::ok))
                     .default_service(|r: ServiceRequest| {
-                        ok(r.into_response(HttpResponse::BadRequest()))
+                        ok(r.into_response(HttpResponse::bad_request()))
                     }),
             ),
         )
@@ -928,18 +928,18 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_default_resource_propagation() {
-        let mut srv = init_service(
-            App::new()
-                .service(
-                    web::scope("/app1")
-                        .default_service(web::resource("").to(HttpResponse::BadRequest)),
-                )
-                .service(web::scope("/app2"))
-                .default_service(|r: ServiceRequest| {
-                    ok(r.into_response(HttpResponse::MethodNotAllowed()))
-                }),
-        )
-        .await;
+        let mut srv =
+            init_service(
+                App::new()
+                    .service(web::scope("/app1").default_service(
+                        web::resource("").to(HttpResponse::bad_request),
+                    ))
+                    .service(web::scope("/app2"))
+                    .default_service(|r: ServiceRequest| {
+                        ok(r.into_response(HttpResponse::method_not_allowed()))
+                    }),
+            )
+            .await;
 
         let req = TestRequest::with_uri("/non-exist").to_request();
         let resp = srv.call(req).await.unwrap();
@@ -966,7 +966,7 @@ mod tests {
                         ),
                     )
                     .service(
-                        web::resource("/test").route(web::get().to(HttpResponse::Ok)),
+                        web::resource("/test").route(web::get().to(HttpResponse::ok)),
                     ),
             ),
         )
@@ -997,7 +997,7 @@ mod tests {
                             Ok(res)
                         }
                     })
-                    .route("/test", web::get().to(HttpResponse::Ok)),
+                    .route("/test", web::get().to(HttpResponse::ok)),
             ),
         )
         .await;
@@ -1018,7 +1018,7 @@ mod tests {
                 "/t",
                 web::get().to(|data: web::Data<usize>| {
                     assert_eq!(**data, 10);
-                    HttpResponse::Ok()
+                    HttpResponse::ok()
                 }),
             ),
         ))
@@ -1035,7 +1035,7 @@ mod tests {
             web::scope("app").data(10usize).default_service(web::to(
                 |data: web::Data<usize>| {
                     assert_eq!(**data, 10);
-                    HttpResponse::Ok()
+                    HttpResponse::ok()
                 },
             )),
         ))
@@ -1053,7 +1053,7 @@ mod tests {
                 "/t",
                 web::get().to(|data: web::Data<usize>| {
                     assert_eq!(**data, 10);
-                    HttpResponse::Ok()
+                    HttpResponse::ok()
                 }),
             ),
         ))
@@ -1068,7 +1068,7 @@ mod tests {
     async fn test_scope_config() {
         let mut srv =
             init_service(App::new().service(web::scope("/app").configure(|s| {
-                s.route("/path1", web::get().to(HttpResponse::Ok));
+                s.route("/path1", web::get().to(HttpResponse::ok));
             })))
             .await;
 
@@ -1082,7 +1082,7 @@ mod tests {
         let mut srv =
             init_service(App::new().service(web::scope("/app").configure(|s| {
                 s.service(web::scope("/v1").configure(|s| {
-                    s.route("/", web::get().to(HttpResponse::Ok));
+                    s.route("/", web::get().to(HttpResponse::ok));
                 }));
             })))
             .await;
@@ -1104,7 +1104,7 @@ mod tests {
                     s.route(
                         "/",
                         web::get().to(|req: HttpRequest| {
-                            HttpResponse::Ok().body(
+                            HttpResponse::ok().body(
                                 req.url_for("youtube", &["xxxxxx"]).unwrap().to_string(),
                             )
                         }),
@@ -1125,7 +1125,7 @@ mod tests {
         let mut srv = init_service(App::new().service(web::scope("/a").service(
             web::scope("/b").service(web::resource("/c/{stuff}").name("c").route(
                 web::get().to(|req: HttpRequest| {
-                    HttpResponse::Ok()
+                    HttpResponse::ok()
                         .body(format!("{}", req.url_for("c", &["12345"]).unwrap()))
                 }),
             )),

--- a/src/server.rs
+++ b/src/server.rs
@@ -49,7 +49,7 @@ struct Config {
 /// async fn main() -> std::io::Result<()> {
 ///     HttpServer::new(
 ///         || App::new()
-///             .service(web::resource("/").to(|| HttpResponse::Ok())))
+///             .service(web::resource("/").to(|| HttpResponse::ok())))
 ///         .bind("127.0.0.1:59090")?
 ///         .run()
 ///         .await
@@ -623,7 +623,7 @@ where
     ///
     /// #[actix_rt::main]
     /// async fn main() -> io::Result<()> {
-    ///     HttpServer::new(|| App::new().service(web::resource("/").to(|| HttpResponse::Ok())))
+    ///     HttpServer::new(|| App::new().service(web::resource("/").to(|| HttpResponse::ok())))
     ///         .bind("127.0.0.1:0")?
     ///         .run()
     ///         .await

--- a/src/service.rs
+++ b/src/service.rs
@@ -456,7 +456,7 @@ impl WebService {
     /// use actix_web::{web, guard, dev, App, Error, HttpResponse};
     ///
     /// async fn index(req: dev::ServiceRequest) -> Result<dev::ServiceResponse, Error> {
-    ///     Ok(req.into_response(HttpResponse::Ok().finish()))
+    ///     Ok(req.into_response(HttpResponse::ok().finish()))
     /// }
     ///
     /// fn main() {
@@ -542,7 +542,7 @@ mod tests {
     async fn test_service() {
         let mut srv = init_service(
             App::new().service(web::service("/test").name("test").finish(
-                |req: ServiceRequest| ok(req.into_response(HttpResponse::Ok().finish())),
+                |req: ServiceRequest| ok(req.into_response(HttpResponse::ok().finish())),
             )),
         )
         .await;
@@ -552,7 +552,7 @@ mod tests {
 
         let mut srv = init_service(
             App::new().service(web::service("/test").guard(guard::Get()).finish(
-                |req: ServiceRequest| ok(req.into_response(HttpResponse::Ok().finish())),
+                |req: ServiceRequest| ok(req.into_response(HttpResponse::ok().finish())),
             )),
         )
         .await;
@@ -574,7 +574,7 @@ mod tests {
                             req.app_data::<web::Data<u32>>().unwrap().as_ref(),
                             &42
                         );
-                        ok(req.into_response(HttpResponse::Ok().finish()))
+                        ok(req.into_response(HttpResponse::ok().finish()))
                     },
                 )),
         )
@@ -595,7 +595,7 @@ mod tests {
         assert!(s.contains("test=1"));
         assert!(s.contains("x-test"));
 
-        let res = HttpResponse::Ok().insert_header(("x-test", "111")).finish();
+        let res = HttpResponse::ok().insert_header(("x-test", "111")).finish();
         let res = TestRequest::post()
             .uri("/index.html?test=1")
             .to_srv_response(res);

--- a/src/test.rs
+++ b/src/test.rs
@@ -35,7 +35,7 @@ use crate::rmap::ResourceMap;
 use crate::service::{ServiceRequest, ServiceResponse};
 use crate::{Error, HttpRequest, HttpResponse};
 
-/// Create service that always responds with `HttpResponse::Ok()`
+/// Create service that always responds with `HttpResponse::ok()`
 pub fn ok_service(
 ) -> impl Service<ServiceRequest, Response = ServiceResponse<Body>, Error = Error> {
     default_service(StatusCode::OK)
@@ -62,7 +62,7 @@ pub fn default_service(
 /// async fn test_init_service() {
 ///     let mut app = test::init_service(
 ///         App::new()
-///             .service(web::resource("/test").to(|| async { HttpResponse::Ok() }))
+///             .service(web::resource("/test").to(|| async { HttpResponse::ok() }))
 ///     ).await;
 ///
 ///     // Create request object
@@ -119,7 +119,7 @@ where
 ///     let mut app = test::init_service(
 ///         App::new()
 ///             .service(web::resource("/test").to(|| async {
-///                 HttpResponse::Ok()
+///                 HttpResponse::ok()
 ///             }))
 ///     ).await;
 ///
@@ -151,7 +151,7 @@ where
 ///         App::new().service(
 ///             web::resource("/index.html")
 ///                 .route(web::post().to(|| async {
-///                     HttpResponse::Ok().body("welcome!")
+///                     HttpResponse::ok().body("welcome!")
 ///                 })))
 ///     ).await;
 ///
@@ -194,7 +194,7 @@ where
 ///         App::new().service(
 ///             web::resource("/index.html")
 ///                 .route(web::post().to(|| async {
-///                     HttpResponse::Ok().body("welcome!")
+///                     HttpResponse::ok().body("welcome!")
 ///                 })))
 ///     ).await;
 ///
@@ -238,7 +238,7 @@ where
 ///         App::new().service(
 ///             web::resource("/people")
 ///                 .route(web::post().to(|person: web::Json<Person>| async {
-///                     HttpResponse::Ok()
+///                     HttpResponse::ok()
 ///                         .json(person.into_inner())})
 ///                     ))
 ///     ).await;
@@ -298,7 +298,7 @@ where
 ///         App::new().service(
 ///             web::resource("/people")
 ///                 .route(web::post().to(|person: web::Json<Person>| async {
-///                     HttpResponse::Ok()
+///                     HttpResponse::ok()
 ///                         .json(person.into_inner())})
 ///                     ))
 ///     ).await;
@@ -341,9 +341,9 @@ where
 ///
 /// async fn index(req: HttpRequest) -> HttpResponse {
 ///     if let Some(hdr) = req.headers().get(header::CONTENT_TYPE) {
-///         HttpResponse::Ok().into()
+///         HttpResponse::ok().into()
 ///     } else {
-///         HttpResponse::BadRequest().into()
+///         HttpResponse::bad_request().into()
 ///     }
 /// }
 ///
@@ -590,7 +590,7 @@ impl TestRequest {
 /// use actix_web::{web, test, App, HttpResponse, Error};
 ///
 /// async fn my_handler() -> Result<HttpResponse, Error> {
-///     Ok(HttpResponse::Ok().into())
+///     Ok(HttpResponse::ok().into())
 /// }
 ///
 /// #[actix_rt::test]
@@ -630,7 +630,7 @@ where
 /// use actix_web::{web, test, App, HttpResponse, Error};
 ///
 /// async fn my_handler() -> Result<HttpResponse, Error> {
-///     Ok(HttpResponse::Ok().into())
+///     Ok(HttpResponse::ok().into())
 /// }
 ///
 /// #[actix_rt::test]
@@ -1046,9 +1046,9 @@ mod tests {
         let mut app = init_service(
             App::new().service(
                 web::resource("/index.html")
-                    .route(web::put().to(|| HttpResponse::Ok().body("put!")))
-                    .route(web::patch().to(|| HttpResponse::Ok().body("patch!")))
-                    .route(web::delete().to(|| HttpResponse::Ok().body("delete!"))),
+                    .route(web::put().to(|| HttpResponse::ok().body("put!")))
+                    .route(web::patch().to(|| HttpResponse::ok().body("patch!")))
+                    .route(web::delete().to(|| HttpResponse::ok().body("delete!"))),
             ),
         )
         .await;
@@ -1079,7 +1079,7 @@ mod tests {
         let mut app = init_service(
             App::new().service(
                 web::resource("/index.html")
-                    .route(web::post().to(|| HttpResponse::Ok().body("welcome!"))),
+                    .route(web::post().to(|| HttpResponse::ok().body("welcome!"))),
             ),
         )
         .await;
@@ -1098,7 +1098,7 @@ mod tests {
         let mut app = init_service(
             App::new().service(
                 web::resource("/index.html")
-                    .route(web::get().to(|| HttpResponse::Ok().body("welcome!"))),
+                    .route(web::get().to(|| HttpResponse::ok().body("welcome!"))),
             ),
         )
         .await;
@@ -1122,7 +1122,7 @@ mod tests {
     async fn test_response_json() {
         let mut app = init_service(App::new().service(web::resource("/people").route(
             web::post().to(|person: web::Json<Person>| {
-                HttpResponse::Ok().json(person.into_inner())
+                HttpResponse::ok().json(person.into_inner())
             }),
         )))
         .await;
@@ -1143,7 +1143,7 @@ mod tests {
     async fn test_body_json() {
         let mut app = init_service(App::new().service(web::resource("/people").route(
             web::post().to(|person: web::Json<Person>| {
-                HttpResponse::Ok().json(person.into_inner())
+                HttpResponse::ok().json(person.into_inner())
             }),
         )))
         .await;
@@ -1165,7 +1165,7 @@ mod tests {
     async fn test_request_response_form() {
         let mut app = init_service(App::new().service(web::resource("/people").route(
             web::post().to(|person: web::Form<Person>| {
-                HttpResponse::Ok().json(person.into_inner())
+                HttpResponse::ok().json(person.into_inner())
             }),
         )))
         .await;
@@ -1191,7 +1191,7 @@ mod tests {
     async fn test_request_response_json() {
         let mut app = init_service(App::new().service(web::resource("/people").route(
             web::post().to(|person: web::Json<Person>| {
-                HttpResponse::Ok().json(person.into_inner())
+                HttpResponse::ok().json(person.into_inner())
             }),
         )))
         .await;
@@ -1219,7 +1219,7 @@ mod tests {
             let res = web::block(move || Some(4usize).ok_or("wrong")).await;
 
             match res {
-                Ok(value) => Ok(HttpResponse::Ok()
+                Ok(value) => Ok(HttpResponse::ok()
                     .content_type("text/plain")
                     .body(format!("Async with block value: {}", value))),
                 Err(_) => panic!("Unexpected"),
@@ -1240,7 +1240,7 @@ mod tests {
     async fn test_server_data() {
         async fn handler(data: web::Data<usize>) -> impl Responder {
             assert_eq!(**data, 10);
-            HttpResponse::Ok()
+            HttpResponse::ok()
         }
 
         let mut app = init_service(
@@ -1289,9 +1289,9 @@ mod tests {
             let res = addr.send(Num(1)).await?;
 
             if res == 1 {
-                Ok(HttpResponse::Ok())
+                Ok(HttpResponse::ok())
             } else {
-                Ok(HttpResponse::BadRequest())
+                Ok(HttpResponse::bad_request())
             }
         }
 

--- a/src/types/either.rs
+++ b/src/types/either.rs
@@ -59,7 +59,7 @@ use crate::{
 ///     } else {
 ///         // respond with Right variant
 ///         Either::Right(
-///             Ok(HttpResponse::Ok()
+///             Ok(HttpResponse::ok()
 ///                 .content_type(mime::TEXT_HTML)
 ///                 .body("<p>Hello!</p>"))
 ///         )

--- a/src/types/form.rs
+++ b/src/types/form.rs
@@ -156,7 +156,7 @@ impl<T: fmt::Display> fmt::Display for Form<T> {
 impl<T: Serialize> Responder for Form<T> {
     fn respond_to(self, _: &HttpRequest) -> HttpResponse {
         match serde_urlencoded::to_string(&self.0) {
-            Ok(body) => HttpResponse::Ok()
+            Ok(body) => HttpResponse::ok()
                 .content_type(mime::APPLICATION_WWW_FORM_URLENCODED)
                 .body(body),
             Err(err) => HttpResponse::from_error(err.into()),

--- a/src/types/json.rs
+++ b/src/types/json.rs
@@ -120,7 +120,7 @@ where
 impl<T: Serialize> Responder for Json<T> {
     fn respond_to(self, _: &HttpRequest) -> HttpResponse {
         match serde_json::to_string(&self.0) {
-            Ok(body) => HttpResponse::Ok()
+            Ok(body) => HttpResponse::ok()
                 .content_type(mime::APPLICATION_JSON)
                 .body(body),
             Err(err) => HttpResponse::from_error(err.into()),
@@ -221,7 +221,7 @@ where
 ///     .content_type(|mime| mime == mime::TEXT_PLAIN)
 ///     // use custom error handler
 ///     .error_handler(|err, req| {
-///         error::InternalError::from_response(err, HttpResponse::Conflict().finish()).into()
+///         error::InternalError::from_response(err, HttpResponse::conflict().finish()).into()
 ///     });
 ///
 /// App::new()
@@ -482,7 +482,7 @@ mod tests {
                 let msg = MyObject {
                     name: "invalid request".to_string(),
                 };
-                let resp = HttpResponse::BadRequest()
+                let resp = HttpResponse::bad_request()
                     .body(serde_json::to_string(&msg).unwrap());
                 InternalError::from_response(err, resp).into()
             }))

--- a/src/types/path.rs
+++ b/src/types/path.rs
@@ -155,7 +155,7 @@ where
 ///             .app_data(PathConfig::default().error_handler(|err, req| {
 ///                 error::InternalError::from_response(
 ///                     err,
-///                     HttpResponse::Conflict().finish(),
+///                     HttpResponse::conflict().finish(),
 ///                 )
 ///                 .into()
 ///             }))
@@ -302,7 +302,7 @@ mod tests {
             .app_data(PathConfig::default().error_handler(|err, _| {
                 error::InternalError::from_response(
                     err,
-                    HttpResponse::Conflict().finish(),
+                    HttpResponse::conflict().finish(),
                 )
                 .into()
             }))

--- a/src/types/query.rs
+++ b/src/types/query.rs
@@ -158,7 +158,7 @@ where
 /// let query_cfg = web::QueryConfig::default()
 ///     // use custom error handler
 ///     .error_handler(|err, req| {
-///         error::InternalError::from_response(err, HttpResponse::Conflict().finish()).into()
+///         error::InternalError::from_response(err, HttpResponse::conflict().finish()).into()
 ///     });
 ///
 /// App::new()
@@ -253,7 +253,7 @@ mod tests {
     async fn test_custom_error_responder() {
         let req = TestRequest::with_uri("/name/user1/")
             .app_data(QueryConfig::default().error_handler(|e, _| {
-                let resp = HttpResponse::UnprocessableEntity().finish();
+                let resp = HttpResponse::unprocessable_entity().finish();
                 InternalError::from_response(e, resp).into()
             }))
             .to_srv_request();

--- a/src/web.rs
+++ b/src/web.rs
@@ -47,8 +47,8 @@ pub use crate::types::*;
 ///
 /// let app = App::new().service(
 ///     web::resource("/users/{userid}/{friend}")
-///         .route(web::get().to(|| HttpResponse::Ok()))
-///         .route(web::head().to(|| HttpResponse::MethodNotAllowed()))
+///         .route(web::get().to(|| HttpResponse::ok()))
+///         .route(web::head().to(|| HttpResponse::method_not_allowed()))
 /// );
 /// ```
 pub fn resource<T: IntoPattern>(path: T) -> Resource {
@@ -65,9 +65,9 @@ pub fn resource<T: IntoPattern>(path: T) -> Resource {
 ///
 /// let app = App::new().service(
 ///     web::scope("/{project_id}")
-///         .service(web::resource("/path1").to(|| HttpResponse::Ok()))
-///         .service(web::resource("/path2").to(|| HttpResponse::Ok()))
-///         .service(web::resource("/path3").to(|| HttpResponse::MethodNotAllowed()))
+///         .service(web::resource("/path1").to(|| HttpResponse::ok()))
+///         .service(web::resource("/path2").to(|| HttpResponse::ok()))
+///         .service(web::resource("/path3").to(|| HttpResponse::method_not_allowed()))
 /// );
 /// ```
 ///
@@ -92,7 +92,7 @@ pub fn route() -> Route {
 ///
 /// let app = App::new().service(
 ///     web::resource("/{project_id}")
-///        .route(web::get().to(|| HttpResponse::Ok()))
+///        .route(web::get().to(|| HttpResponse::ok()))
 /// );
 /// ```
 ///
@@ -110,7 +110,7 @@ pub fn get() -> Route {
 ///
 /// let app = App::new().service(
 ///     web::resource("/{project_id}")
-///         .route(web::post().to(|| HttpResponse::Ok()))
+///         .route(web::post().to(|| HttpResponse::ok()))
 /// );
 /// ```
 ///
@@ -128,7 +128,7 @@ pub fn post() -> Route {
 ///
 /// let app = App::new().service(
 ///     web::resource("/{project_id}")
-///         .route(web::put().to(|| HttpResponse::Ok()))
+///         .route(web::put().to(|| HttpResponse::ok()))
 /// );
 /// ```
 ///
@@ -146,7 +146,7 @@ pub fn put() -> Route {
 ///
 /// let app = App::new().service(
 ///     web::resource("/{project_id}")
-///         .route(web::patch().to(|| HttpResponse::Ok()))
+///         .route(web::patch().to(|| HttpResponse::ok()))
 /// );
 /// ```
 ///
@@ -164,7 +164,7 @@ pub fn patch() -> Route {
 ///
 /// let app = App::new().service(
 ///     web::resource("/{project_id}")
-///         .route(web::delete().to(|| HttpResponse::Ok()))
+///         .route(web::delete().to(|| HttpResponse::ok()))
 /// );
 /// ```
 ///
@@ -182,7 +182,7 @@ pub fn delete() -> Route {
 ///
 /// let app = App::new().service(
 ///     web::resource("/{project_id}")
-///         .route(web::head().to(|| HttpResponse::Ok()))
+///         .route(web::head().to(|| HttpResponse::ok()))
 /// );
 /// ```
 ///
@@ -200,7 +200,7 @@ pub fn head() -> Route {
 ///
 /// let app = App::new().service(
 ///     web::resource("/{project_id}")
-///         .route(web::trace().to(|| HttpResponse::Ok()))
+///         .route(web::trace().to(|| HttpResponse::ok()))
 /// );
 /// ```
 ///
@@ -218,7 +218,7 @@ pub fn trace() -> Route {
 ///
 /// let app = App::new().service(
 ///     web::resource("/{project_id}")
-///         .route(web::method(http::Method::GET).to(|| HttpResponse::Ok()))
+///         .route(web::method(http::Method::GET).to(|| HttpResponse::ok()))
 /// );
 /// ```
 ///
@@ -235,7 +235,7 @@ pub fn method(method: Method) -> Route {
 /// use actix_web::{web, App, HttpResponse, Responder};
 ///
 /// async fn index() -> impl Responder {
-///    HttpResponse::Ok()
+///    HttpResponse::ok()
 /// }
 ///
 /// App::new().service(
@@ -259,7 +259,7 @@ where
 /// use actix_web::{dev, web, guard, App, Error, HttpResponse};
 ///
 /// async fn my_service(req: dev::ServiceRequest) -> Result<dev::ServiceResponse, Error> {
-///     Ok(req.into_response(HttpResponse::Ok().finish()))
+///     Ok(req.into_response(HttpResponse::ok().finish()))
 /// }
 ///
 /// let app = App::new().service(

--- a/tests/test_httpserver.rs
+++ b/tests/test_httpserver.rs
@@ -19,7 +19,7 @@ async fn test_start() {
             let srv = HttpServer::new(|| {
                 App::new().service(
                     web::resource("/")
-                        .route(web::to(|| HttpResponse::Ok().body("test"))),
+                        .route(web::to(|| HttpResponse::ok().body("test"))),
                 )
             })
             .workers(1)
@@ -97,7 +97,7 @@ async fn test_start_ssl() {
         let srv = HttpServer::new(|| {
             App::new().service(web::resource("/").route(web::to(|req: HttpRequest| {
                 assert!(req.app_config().secure());
-                HttpResponse::Ok().body("test")
+                HttpResponse::ok().body("test")
             })))
         })
         .workers(1)

--- a/tests/test_server.rs
+++ b/tests/test_server.rs
@@ -86,7 +86,7 @@ impl futures_core::stream::Stream for TestBody {
 async fn test_body() {
     let srv = test::start(|| {
         App::new()
-            .service(web::resource("/").route(web::to(|| HttpResponse::Ok().body(STR))))
+            .service(web::resource("/").route(web::to(|| HttpResponse::ok().body(STR))))
     });
 
     let mut response = srv.get("/").send().await.unwrap();
@@ -102,7 +102,7 @@ async fn test_body_gzip() {
     let srv = test::start_with(test::config().h1(), || {
         App::new()
             .wrap(Compress::new(ContentEncoding::Gzip))
-            .service(web::resource("/").route(web::to(|| HttpResponse::Ok().body(STR))))
+            .service(web::resource("/").route(web::to(|| HttpResponse::ok().body(STR))))
     });
 
     let mut response = srv
@@ -130,7 +130,7 @@ async fn test_body_gzip2() {
         App::new()
             .wrap(Compress::new(ContentEncoding::Gzip))
             .service(web::resource("/").route(web::to(|| {
-                HttpResponse::Ok().body(STR).into_body::<dev::Body>()
+                HttpResponse::ok().body(STR).into_body::<dev::Body>()
             })))
     });
 
@@ -159,7 +159,7 @@ async fn test_body_encoding_override() {
         App::new()
             .wrap(Compress::new(ContentEncoding::Gzip))
             .service(web::resource("/").route(web::to(|| {
-                HttpResponse::Ok()
+                HttpResponse::ok()
                     .encoding(ContentEncoding::Deflate)
                     .body(STR)
             })))
@@ -224,7 +224,7 @@ async fn test_body_gzip_large() {
             .wrap(Compress::new(ContentEncoding::Gzip))
             .service(
                 web::resource("/")
-                    .route(web::to(move || HttpResponse::Ok().body(data.clone()))),
+                    .route(web::to(move || HttpResponse::ok().body(data.clone()))),
             )
     });
 
@@ -262,7 +262,7 @@ async fn test_body_gzip_large_random() {
             .wrap(Compress::new(ContentEncoding::Gzip))
             .service(
                 web::resource("/")
-                    .route(web::to(move || HttpResponse::Ok().body(data.clone()))),
+                    .route(web::to(move || HttpResponse::ok().body(data.clone()))),
             )
     });
 
@@ -292,7 +292,7 @@ async fn test_body_chunked_implicit() {
         App::new()
             .wrap(Compress::new(ContentEncoding::Gzip))
             .service(web::resource("/").route(web::get().to(move || {
-                HttpResponse::Ok()
+                HttpResponse::ok()
                     .streaming(TestBody::new(Bytes::from_static(STR.as_ref()), 24))
             })))
     });
@@ -325,7 +325,7 @@ async fn test_body_br_streaming() {
     let srv = test::start_with(test::config().h1(), || {
         App::new().wrap(Compress::new(ContentEncoding::Br)).service(
             web::resource("/").route(web::to(move || {
-                HttpResponse::Ok()
+                HttpResponse::ok()
                     .streaming(TestBody::new(Bytes::from_static(STR.as_ref()), 24))
             })),
         )
@@ -357,7 +357,7 @@ async fn test_head_binary() {
     let srv = test::start_with(test::config().h1(), || {
         App::new().service(
             web::resource("/")
-                .route(web::head().to(move || HttpResponse::Ok().body(STR))),
+                .route(web::head().to(move || HttpResponse::ok().body(STR))),
         )
     });
 
@@ -378,7 +378,7 @@ async fn test_head_binary() {
 async fn test_no_chunking() {
     let srv = test::start_with(test::config().h1(), || {
         App::new().service(web::resource("/").route(web::to(move || {
-            HttpResponse::Ok()
+            HttpResponse::ok()
                 .no_chunking(STR.len() as u64)
                 .streaming(TestBody::new(Bytes::from_static(STR.as_ref()), 24))
         })))
@@ -399,7 +399,7 @@ async fn test_body_deflate() {
         App::new()
             .wrap(Compress::new(ContentEncoding::Deflate))
             .service(
-                web::resource("/").route(web::to(move || HttpResponse::Ok().body(STR))),
+                web::resource("/").route(web::to(move || HttpResponse::ok().body(STR))),
             )
     });
 
@@ -426,7 +426,7 @@ async fn test_body_deflate() {
 async fn test_body_brotli() {
     let srv = test::start_with(test::config().h1(), || {
         App::new().wrap(Compress::new(ContentEncoding::Br)).service(
-            web::resource("/").route(web::to(move || HttpResponse::Ok().body(STR))),
+            web::resource("/").route(web::to(move || HttpResponse::ok().body(STR))),
         )
     });
 
@@ -455,7 +455,7 @@ async fn test_encoding() {
     let srv = test::start_with(test::config().h1(), || {
         App::new().wrap(Compress::default()).service(
             web::resource("/")
-                .route(web::to(move |body: Bytes| HttpResponse::Ok().body(body))),
+                .route(web::to(move |body: Bytes| HttpResponse::ok().body(body))),
         )
     });
 
@@ -481,7 +481,7 @@ async fn test_gzip_encoding() {
     let srv = test::start_with(test::config().h1(), || {
         App::new().service(
             web::resource("/")
-                .route(web::to(move |body: Bytes| HttpResponse::Ok().body(body))),
+                .route(web::to(move |body: Bytes| HttpResponse::ok().body(body))),
         )
     });
 
@@ -508,7 +508,7 @@ async fn test_gzip_encoding_large() {
     let srv = test::start_with(test::config().h1(), || {
         App::new().service(
             web::resource("/")
-                .route(web::to(move |body: Bytes| HttpResponse::Ok().body(body))),
+                .route(web::to(move |body: Bytes| HttpResponse::ok().body(body))),
         )
     });
 
@@ -540,7 +540,7 @@ async fn test_reading_gzip_encoding_large_random() {
     let srv = test::start_with(test::config().h1(), || {
         App::new().service(
             web::resource("/")
-                .route(web::to(move |body: Bytes| HttpResponse::Ok().body(body))),
+                .route(web::to(move |body: Bytes| HttpResponse::ok().body(body))),
         )
     });
 
@@ -567,7 +567,7 @@ async fn test_reading_deflate_encoding() {
     let srv = test::start_with(test::config().h1(), || {
         App::new().service(
             web::resource("/")
-                .route(web::to(move |body: Bytes| HttpResponse::Ok().body(body))),
+                .route(web::to(move |body: Bytes| HttpResponse::ok().body(body))),
         )
     });
 
@@ -594,7 +594,7 @@ async fn test_reading_deflate_encoding_large() {
     let srv = test::start_with(test::config().h1(), || {
         App::new().service(
             web::resource("/")
-                .route(web::to(move |body: Bytes| HttpResponse::Ok().body(body))),
+                .route(web::to(move |body: Bytes| HttpResponse::ok().body(body))),
         )
     });
 
@@ -626,7 +626,7 @@ async fn test_reading_deflate_encoding_large_random() {
     let srv = test::start_with(test::config().h1(), || {
         App::new().service(
             web::resource("/")
-                .route(web::to(move |body: Bytes| HttpResponse::Ok().body(body))),
+                .route(web::to(move |body: Bytes| HttpResponse::ok().body(body))),
         )
     });
 
@@ -653,7 +653,7 @@ async fn test_brotli_encoding() {
     let srv = test::start_with(test::config().h1(), || {
         App::new().service(
             web::resource("/")
-                .route(web::to(move |body: Bytes| HttpResponse::Ok().body(body))),
+                .route(web::to(move |body: Bytes| HttpResponse::ok().body(body))),
         )
     });
 
@@ -687,7 +687,7 @@ async fn test_brotli_encoding_large() {
             web::resource("/")
                 .app_data(web::PayloadConfig::new(320_000))
                 .route(web::to(move |body: Bytes| {
-                    HttpResponse::Ok().streaming(TestBody::new(body, 10240))
+                    HttpResponse::ok().streaming(TestBody::new(body, 10240))
                 })),
         )
     });
@@ -725,7 +725,7 @@ async fn test_brotli_encoding_large_openssl() {
     let data = STR.repeat(10);
     let srv = test::start_with(test::config().openssl(builder.build()), move || {
         App::new().service(web::resource("/").route(web::to(|bytes: Bytes| {
-            HttpResponse::Ok()
+            HttpResponse::ok()
                 .encoding(actix_web::http::ContentEncoding::Identity)
                 .body(bytes)
         })))
@@ -774,7 +774,7 @@ async fn test_reading_deflate_encoding_large_random_rustls() {
 
     let srv = test::start_with(test::config().rustls(config), || {
         App::new().service(web::resource("/").route(web::to(|bytes: Bytes| {
-            HttpResponse::Ok()
+            HttpResponse::ok()
                 .encoding(actix_web::http::ContentEncoding::Identity)
                 .body(bytes)
         })))
@@ -808,7 +808,7 @@ async fn test_reading_deflate_encoding_large_random_rustls() {
 //     let srv = test::TestServer::with_factory(|| {
 //         App::new().resource("/", |r| {
 //             r.f(|_| {
-//                 HttpResponse::Ok()
+//                 HttpResponse::ok()
 //                     .cookie(
 //                         http::CookieBuilder::new("first", "first_value")
 //                             .http_only(true)
@@ -862,7 +862,7 @@ async fn test_slow_request() {
     use std::net;
 
     let srv = test::start_with(test::config().client_timeout(200), || {
-        App::new().service(web::resource("/").route(web::to(HttpResponse::Ok)))
+        App::new().service(web::resource("/").route(web::to(HttpResponse::ok)))
     });
 
     let mut stream = net::TcpStream::connect(srv.addr()).unwrap();
@@ -883,7 +883,7 @@ async fn test_normalize() {
         App::new()
             .wrap(NormalizePath::new(TrailingSlash::Trim))
             .service(
-                web::resource("/one").route(web::to(|| HttpResponse::Ok().finish())),
+                web::resource("/one").route(web::to(|| HttpResponse::ok().finish())),
             )
     });
 


### PR DESCRIPTION
## PR Type
Code Style

## PR Checklist

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.

## Overview
It's Rust convention for method names to be in snake case, so much so that the compiler emits a warning by default for non-snake-case methods. Reading something like `HttpResponse::Ok()` leads me to believe that I'm creating an instance of the `Ok` variant of a `HttpResponse` enum, but for some reason there's no associated data (which _is_ possible, there's just no reason to define an enum that way. [Here's what I'm talking about](https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=a6aecea976b9b5f342cdf32583b0d2bc)).

Note that `HttpResponse::Continue()` was renamed to `HttpResponse::kontinue()` rather than `HttpResponse::r#continue()`. This is because naming the function `r#continue()` requires that _users_ call it as `r#continue()` rather than simply `continue()` as can be seen [here](https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=e08a1fecedc278ffc7a6d2aa2500529a). I assume `r#continue()` is a bit too ugly to be in the public API, but `kontinue` doesn't look fantastic either, so I'm open to suggestions in this area.

There are other cases of `#[allow(non_snake_case)]` in the actix codebase, but this commit only addresses the `HttpResponse::XXX()` methods.

**This is a breaking change**