### PR TITLE
optimize Route guards

### DIFF
--- a/src/guard.rs
+++ b/src/guard.rs
@@ -195,7 +195,7 @@ impl Guard for NotGuard {
     }
 
     fn clone_guard(&self) -> Box<dyn Guard> {
-        self.0.clone_guard()
+        Box::new(NotGuard(self.0.clone_guard()))
     }
 }
 


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Refactor


## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Documentation comments have been added / updated.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Add `Guard::clone_guard` method for cloning a `Guard` trait object. 
Internal types that impl `Guard` trait are all constrant to `Clone`. This is a break change for `FnGuard` type.
In return `Route`'s guards are not wrapped in `Rc` therefore reduce indirection when checking guard.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
