### PR TITLE
optimize actix-http messages

### DIFF
--- a/actix-http/src/message.rs
+++ b/actix-http/src/message.rs
@@ -348,12 +348,6 @@ pub struct Message<T: Head> {
     head: Rc<T>,
 }
 
-impl<T: Head> Clone for Message<T> {
-    fn clone(&self) -> Self {
-        panic!("Message<T> type should not be Clone.")
-    }
-}
-
 impl<T: Head> Message<T> {
     /// Get new message from the pool of objects
     pub fn new() -> Self {

--- a/actix-http/src/message.rs
+++ b/actix-http/src/message.rs
@@ -343,7 +343,15 @@ impl ResponseHead {
 }
 
 pub struct Message<T: Head> {
+    // Rc here should not be cloned by anyone.
+    // It's used to reuse allocation of T and no shared ownership is allowed.
     head: Rc<T>,
+}
+
+impl<T: Head> Clone for Message<T> {
+    fn clone(&self) -> Self {
+        panic!("Message<T> type should not be Clone.")
+    }
 }
 
 impl<T: Head> Message<T> {

--- a/actix-http/src/message.rs
+++ b/actix-http/src/message.rs
@@ -414,13 +414,9 @@ impl std::ops::DerefMut for BoxedResponseHead {
 
 impl Drop for BoxedResponseHead {
     fn drop(&mut self) {
-        RESPONSE_POOL.with(move |p| {
-            p.release(
-                self.head
-                    .take()
-                    .expect("ResponseHead is taken before dropped"),
-            )
-        })
+        if let Some(head) = self.head.take() {
+            RESPONSE_POOL.with(move |p| p.release(head))
+        }
     }
 }
 

--- a/awc/tests/test_client.rs
+++ b/awc/tests/test_client.rs
@@ -722,9 +722,11 @@ async fn test_client_cookie_handling() {
 async fn client_unread_response() {
     let addr = test::unused_addr();
 
+    let (tx, rx) = std::sync::mpsc::sync_channel(1);
+
     std::thread::spawn(move || {
         let lst = std::net::TcpListener::bind(addr).unwrap();
-
+        tx.send(()).unwrap();
         for stream in lst.incoming() {
             let mut stream = stream.unwrap();
             let mut b = [0; 1000];
@@ -737,6 +739,8 @@ async fn client_unread_response() {
             );
         }
     });
+
+    rx.recv().unwrap();
 
     // client request
     let req = awc::Client::new().get(format!("http://{}/", addr).as_str());

--- a/awc/tests/test_client.rs
+++ b/awc/tests/test_client.rs
@@ -722,11 +722,9 @@ async fn test_client_cookie_handling() {
 async fn client_unread_response() {
     let addr = test::unused_addr();
 
-    let (tx, rx) = std::sync::mpsc::sync_channel(1);
+    let lst = std::net::TcpListener::bind(addr).unwrap();
 
     std::thread::spawn(move || {
-        let lst = std::net::TcpListener::bind(addr).unwrap();
-        tx.send(()).unwrap();
         for stream in lst.incoming() {
             let mut stream = stream.unwrap();
             let mut b = [0; 1000];
@@ -739,8 +737,6 @@ async fn client_unread_response() {
             );
         }
     });
-
-    rx.recv().unwrap();
 
     // client request
     let req = awc::Client::new().get(format!("http://{}/", addr).as_str());


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Refactor


## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Remove `Clone` impl from `Message<T>` type. This would eliminate all unintentional clone of said type.

Remove strong ref count check when dropping `Message<T>` as it's not clonable anymore and it's only the `T `type that are exposed to public so there is no possible of cloning `Rc<T>`. Therefore strong ref count should always be one when dropping.


<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
