### PR TITLE
remove either crate and simplify AsName trait

### DIFF
--- a/actix-http/Cargo.toml
+++ b/actix-http/Cargo.toml
@@ -53,7 +53,6 @@ bytes = "1"
 bytestring = "1"
 cookie = { version = "0.14.1", features = ["percent-encode"] }
 derive_more = "0.99.5"
-either = "1.5.3"
 encoding_rs = "0.8"
 futures-channel = { version = "0.3.7", default-features = false }
 futures-core = { version = "0.3.7", default-features = false }


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Refactor


## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Remove `Either` crate from dep and use a simple enum for match header names.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
