### PR TITLE
fix memory usage for h1 and read bug on buffer size.

### DIFF
--- a/actix-http/src/h1/decoder.rs
+++ b/actix-http/src/h1/decoder.rs
@@ -208,8 +208,9 @@ impl MessageType for Request {
                         trace!("MAX_BUFFER_SIZE unprocessed data reached, closing");
                         Err(ParseError::TooLarge)
                     } else {
+                        // Return None to notify more read are needed for parsing request
                         Ok(None)
-                    }
+                    };
                 }
             }
         };
@@ -277,14 +278,16 @@ impl MessageType for ResponseHead {
 
                     (len, version, status, res.headers.len())
                 }
-                httparse::Status::Partial => return {
-                    if src.len() >= MAX_BUFFER_SIZE {
-                        error!("MAX_BUFFER_SIZE unprocessed data reached, closing");
-                        Err(ParseError::TooLarge)
-                    } else {
-                        Ok(None)
+                httparse::Status::Partial => {
+                    return {
+                        if src.len() >= MAX_BUFFER_SIZE {
+                            error!("MAX_BUFFER_SIZE unprocessed data reached, closing");
+                            Err(ParseError::TooLarge)
+                        } else {
+                            Ok(None)
+                        }
                     }
-                },
+                }
             }
         };
 

--- a/actix-http/src/h1/decoder.rs
+++ b/actix-http/src/h1/decoder.rs
@@ -279,13 +279,11 @@ impl MessageType for ResponseHead {
                     (len, version, status, res.headers.len())
                 }
                 httparse::Status::Partial => {
-                    return {
-                        if src.len() >= MAX_BUFFER_SIZE {
-                            error!("MAX_BUFFER_SIZE unprocessed data reached, closing");
-                            Err(ParseError::TooLarge)
-                        } else {
-                            Ok(None)
-                        }
+                    return if src.len() >= MAX_BUFFER_SIZE {
+                        error!("MAX_BUFFER_SIZE unprocessed data reached, closing");
+                        Err(ParseError::TooLarge)
+                    } else {
+                        Ok(None)
                     }
                 }
             }

--- a/actix-http/src/h1/decoder.rs
+++ b/actix-http/src/h1/decoder.rs
@@ -203,7 +203,13 @@ impl MessageType for Request {
 
                     (len, method, uri, version, req.headers.len())
                 }
-                httparse::Status::Partial => return Ok(None),
+                httparse::Status::Partial => {
+                    return if src.len() >= super::dispatcher::MAX_HW_BUFFER_SIZE {
+                        Err(ParseError::TooLarge)
+                    } else {
+                        Ok(None)
+                    }
+                }
             }
         };
 

--- a/actix-http/src/h1/dispatcher.rs
+++ b/actix-http/src/h1/dispatcher.rs
@@ -609,6 +609,8 @@ where
                         }
                     }
                 }
+                // decode is partial and buffer is not full yet.
+                // break and wait for more read.
                 Ok(None) => break,
                 Err(ParseError::Io(e)) => {
                     self.as_mut().client_disconnected();

--- a/actix-http/src/h1/dispatcher.rs
+++ b/actix-http/src/h1/dispatcher.rs
@@ -27,12 +27,12 @@ use crate::service::HttpFlow;
 use crate::OnConnectData;
 
 use super::codec::Codec;
+use super::decoder::MAX_BUFFER_SIZE;
 use super::payload::{Payload, PayloadSender, PayloadStatus};
 use super::{Message, MessageType};
 
 const LW_BUFFER_SIZE: usize = 1024;
 const HW_BUFFER_SIZE: usize = 1024 * 8;
-pub(crate) const MAX_HW_BUFFER_SIZE: usize = HW_BUFFER_SIZE * 4;
 const MAX_PIPELINED_MESSAGES: usize = 16;
 
 bitflags! {
@@ -911,7 +911,7 @@ where
                 } else {
                     // If buf is full return but do not disconnect since
                     // there is more reading to be done
-                    if buf.len() >= MAX_HW_BUFFER_SIZE {
+                    if buf.len() >= MAX_BUFFER_SIZE {
                         return Ok(Some(false));
                     }
 


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Bug Fix


## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Documentation comments have been added / updated.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
This is an atempt to fix the memory issue related to h1 dispatcher.

Reduce the size of read/write buffer to 1024 low and 8192 high in bytes.
Add max hw buffer size matching the current behavior of actix-web.
http parse on buffer exceed max hw buffer would return as a parse error.(Result in 400 error to client).
Only check buffer length on successful read.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
