### PR TITLE
add services register for tuple and vec of services

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 ### Added
 * The method `Either<web::Json<T>, web::Form<T>>::into_inner()` which returns the inner type for
   whichever variant was created. Also works for `Either<web::Form<T>, web::Json<T>>`. [#1894]
+* Add `services!` macro for helping register multiple services to `App`. [#1933]
+* Enable registering vector of same type of `HttpServiceFactory` to `App` [#1933]
 
 ### Changed
 * Rework `Responder` trait to be sync and returns `Response`/`HttpResponse` directly.
@@ -28,6 +30,7 @@
 [#1894]: https://github.com/actix/actix-web/pull/1894
 [#1869]: https://github.com/actix/actix-web/pull/1869
 [#1906]: https://github.com/actix/actix-web/pull/1906
+[#1933]: https://github.com/actix/actix-web/pull/1933
 
 
 ## 4.0.0-beta.1 - 2021-01-07

--- a/src/service.rs
+++ b/src/service.rs
@@ -694,7 +694,7 @@ mod tests {
             web::scope("/test3").service(scoped)
         ];
 
-        let mut srv = init_service(App::new().service(services)).await;
+        let srv = init_service(App::new().service(services)).await;
 
         let req = TestRequest::with_uri("/test1").to_request();
         let resp = srv.call(req).await.unwrap();
@@ -725,7 +725,7 @@ mod tests {
             web::resource("/scoped_test2").to(|| async { "test2" }),
         ];
 
-        let mut srv = init_service(
+        let srv = init_service(
             App::new()
                 .service(services)
                 .service(web::scope("/test3").service(scoped)),

--- a/src/service.rs
+++ b/src/service.rs
@@ -22,6 +22,13 @@ pub trait HttpServiceFactory {
     fn register(self, config: &mut AppService);
 }
 
+impl<T: HttpServiceFactory> HttpServiceFactory for Vec<T> {
+    fn register(self, config: &mut AppService) {
+        self.into_iter()
+            .for_each(|factory| factory.register(config));
+    }
+}
+
 pub(crate) trait AppServiceFactory {
     fn register(&mut self, config: &mut AppService);
 }
@@ -532,6 +539,65 @@ where
     }
 }
 
+/// Macro helping register different types of services at the sametime.
+///
+/// The service type must be implementing [`HttpServiceFactory`](self::HttpServiceFactory) trait.
+///
+/// The max number of services can be grouped together is 12.
+///
+/// # Examples
+///
+/// ```
+/// use actix_web::{services, web, App};
+///
+/// let services = services![
+///     web::resource("/test2").to(|| async { "test2" }),
+///     web::scope("/test3").route("/", web::get().to(|| async { "test3" }))
+/// ];
+///
+/// let app = App::new().service(services);
+///
+/// // services macro just convert multiple services to a tuple.
+/// // below would also work without importing the macro.
+/// let app = App::new().service((
+///     web::resource("/test2").to(|| async { "test2" }),
+///     web::scope("/test3").route("/", web::get().to(|| async { "test3" }))
+/// ));
+/// ```
+#[macro_export]
+macro_rules! services {
+    ($($x:expr),+ $(,)?) => {
+        ($($x,)+)
+    }
+}
+
+/// HttpServiceFactory trait impl for tuples
+macro_rules! service_tuple ({ $(($n:tt, $T:ident)),+} => {
+    impl<$($T: HttpServiceFactory),+> HttpServiceFactory for ($($T,)+) {
+        fn register(self, config: &mut AppService) {
+            $(self.$n.register(config);)+
+        }
+    }
+});
+
+#[rustfmt::skip]
+mod m {
+    use super::*;
+
+    service_tuple!((0, A));
+    service_tuple!((0, A), (1, B));
+    service_tuple!((0, A), (1, B), (2, C));
+    service_tuple!((0, A), (1, B), (2, C), (3, D));
+    service_tuple!((0, A), (1, B), (2, C), (3, D), (4, E));
+    service_tuple!((0, A), (1, B), (2, C), (3, D), (4, E), (5, F));
+    service_tuple!((0, A), (1, B), (2, C), (3, D), (4, E), (5, F), (6, G));
+    service_tuple!((0, A), (1, B), (2, C), (3, D), (4, E), (5, F), (6, G), (7, H));
+    service_tuple!((0, A), (1, B), (2, C), (3, D), (4, E), (5, F), (6, G), (7, H), (8, I));
+    service_tuple!((0, A), (1, B), (2, C), (3, D), (4, E), (5, F), (6, G), (7, H), (8, I), (9, J));
+    service_tuple!((0, A), (1, B), (2, C), (3, D), (4, E), (5, F), (6, G), (7, H), (8, I), (9, J), (10, K));
+    service_tuple!((0, A), (1, B), (2, C), (3, D), (4, E), (5, F), (6, G), (7, H), (8, I), (9, J), (10, K), (11, L));
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -605,5 +671,55 @@ mod tests {
         let s = format!("{:?}", res);
         assert!(s.contains("ServiceResponse"));
         assert!(s.contains("x-test"));
+    }
+
+    #[actix_rt::test]
+    async fn test_services_macro() {
+        let services = services![
+            web::service("/test1")
+                .name("test")
+                .finish(|req: ServiceRequest| async {
+                    Ok(req.into_response(HttpResponse::Ok().finish()))
+                }),
+            web::resource("/test2").to(|| async { "test2" }),
+            web::scope("/test3").route("/", web::get().to(|| async { "test3" }))
+        ];
+
+        let mut srv = init_service(App::new().service(services)).await;
+
+        let req = TestRequest::with_uri("/test1").to_request();
+        let resp = srv.call(req).await.unwrap();
+        assert_eq!(resp.status(), http::StatusCode::OK);
+
+        let req = TestRequest::with_uri("/test2").to_request();
+        let resp = srv.call(req).await.unwrap();
+        assert_eq!(resp.status(), http::StatusCode::OK);
+
+        let req = TestRequest::with_uri("/test3/").to_request();
+        let resp = srv.call(req).await.unwrap();
+        assert_eq!(resp.status(), http::StatusCode::OK);
+    }
+
+    #[actix_rt::test]
+    async fn test_services_vec() {
+        let services = vec![
+            web::resource("/test1").to(|| async { "test1" }),
+            web::resource("/test2").to(|| async { "test2" }),
+            web::resource("/test3").to(|| async { "test3" }),
+        ];
+
+        let mut srv = init_service(App::new().service(services)).await;
+
+        let req = TestRequest::with_uri("/test1").to_request();
+        let resp = srv.call(req).await.unwrap();
+        assert_eq!(resp.status(), http::StatusCode::OK);
+
+        let req = TestRequest::with_uri("/test2").to_request();
+        let resp = srv.call(req).await.unwrap();
+        assert_eq!(resp.status(), http::StatusCode::OK);
+
+        let req = TestRequest::with_uri("/test3").to_request();
+        let resp = srv.call(req).await.unwrap();
+        assert_eq!(resp.status(), http::StatusCode::OK);
     }
 }


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Feature


## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Add `services!` macro to convert multiple types of service factory to a tuple.

impl `HttpServiceFactory` trait for `Vec<T: HttpServiceFactory>` and `(T: HttpServiceFactory, +)` 

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
