### PR TITLE
Add "name" attribute to route macro

### DIFF
--- a/actix-web-codegen/CHANGES.md
+++ b/actix-web-codegen/CHANGES.md
@@ -2,8 +2,10 @@
 
 ## Unreleased - 2021-xx-xx
 * Preserve doc comments when using route macros. [#2022]
+* Add `name` attribute to `route` macro. [#1934]
 
 [#2022]: https://github.com/actix/actix-web/pull/2022
+[#1934]: https://github.com/actix/actix-web/pull/1934
 
 
 ## 0.5.0-beta.1 - 2021-02-10

--- a/actix-web-codegen/src/lib.rs
+++ b/actix-web-codegen/src/lib.rs
@@ -71,6 +71,7 @@ mod route;
 ///
 /// # Attributes
 /// - `"path"` - Raw literal string with path for which to register handler.
+/// - `name="resource_name"` - Specifies resource name for the handler. If not set, the function name of handler is used.
 /// - `method="HTTP_METHOD"` - Registers HTTP method to provide guard for. Upper-case string, "GET", "POST" for example.
 /// - `guard="function_name"` - Registers function as guard using `actix_web::guard::fn_guard`
 /// - `wrap="Middleware"` - Registers a resource middleware.
@@ -116,6 +117,7 @@ Creates route handler with `actix_web::guard::", stringify!($variant), "`.
 
 # Attributes
 - `"path"` - Raw literal string with path for which to register handler.
+- `name="resource_name"` - Specifies resource name for the handler. If not set, the function name of handler is used.
 - `guard="function_name"` - Registers function as guard using `actix_web::guard::fn_guard`.
 - `wrap="Middleware"` - Registers a resource middleware.
 

--- a/actix-web-codegen/src/route.rs
+++ b/actix-web-codegen/src/route.rs
@@ -78,6 +78,7 @@ impl TryFrom<&syn::LitStr> for MethodType {
 
 struct Args {
     path: syn::LitStr,
+    resource_name: Option<syn::LitStr>,
     guards: Vec<Ident>,
     wrappers: Vec<syn::Type>,
     methods: HashSet<MethodType>,
@@ -86,6 +87,7 @@ struct Args {
 impl Args {
     fn new(args: AttributeArgs, method: Option<MethodType>) -> syn::Result<Self> {
         let mut path = None;
+        let mut resource_name = None;
         let mut guards = Vec::new();
         let mut wrappers = Vec::new();
         let mut methods = HashSet::new();
@@ -109,7 +111,16 @@ impl Args {
                     }
                 },
                 NestedMeta::Meta(syn::Meta::NameValue(nv)) => {
-                    if nv.path.is_ident("guard") {
+                    if nv.path.is_ident("name") {
+                        if let syn::Lit::Str(lit) = nv.lit {
+                            resource_name = Some(lit);
+                        } else {
+                            return Err(syn::Error::new_spanned(
+                                nv.lit,
+                                "Attribute endpoint expects literal string!",
+                            ));
+                        }
+                    } else if nv.path.is_ident("guard") {
                         if let syn::Lit::Str(lit) = nv.lit {
                             guards.push(Ident::new(&lit.value(), Span::call_site()));
                         } else {
@@ -164,6 +175,7 @@ impl Args {
         }
         Ok(Args {
             path: path.unwrap(),
+            resource_name,
             guards,
             wrappers,
             methods,
@@ -276,6 +288,7 @@ impl ToTokens for Route {
             args:
                 Args {
                     path,
+                    resource_name,
                     guards,
                     wrappers,
                     methods,
@@ -283,7 +296,11 @@ impl ToTokens for Route {
             resource_type,
             doc_attributes,
         } = self;
-        let resource_name = name.to_string();
+        let resource_name = if let Some(resource_name) = resource_name {
+            resource_name.value()
+        } else {
+            name.to_string()
+        };
         let method_guards = {
             let mut others = methods.iter();
             // unwrapping since length is checked to be at least one

--- a/actix-web-codegen/src/route.rs
+++ b/actix-web-codegen/src/route.rs
@@ -117,7 +117,7 @@ impl Args {
                         } else {
                             return Err(syn::Error::new_spanned(
                                 nv.lit,
-                                "Attribute endpoint expects literal string!",
+                                "Attribute name expects literal string!",
                             ));
                         }
                     } else if nv.path.is_ident("guard") {
@@ -296,11 +296,9 @@ impl ToTokens for Route {
             resource_type,
             doc_attributes,
         } = self;
-        let resource_name = if let Some(resource_name) = resource_name {
-            resource_name.value()
-        } else {
-            name.to_string()
-        };
+        let resource_name = resource_name
+            .as_ref()
+            .map_or_else(|| name.to_string(), |n| n.value());
         let method_guards = {
             let mut others = methods.iter();
             // unwrapping since length is checked to be at least one

--- a/actix-web-codegen/tests/test_macro.rs
+++ b/actix-web-codegen/tests/test_macro.rs
@@ -83,6 +83,13 @@ async fn route_test() -> impl Responder {
     HttpResponse::Ok()
 }
 
+#[get("/custom_resource_name", name = "custom")]
+async fn custom_resource_name_test<'a>(req: actix_web::HttpRequest) -> impl Responder {
+    assert!(req.url_for_static("custom").is_ok());
+    assert!(req.url_for_static("custom_resource_name_test").is_err());
+    HttpResponse::Ok()
+}
+
 pub struct ChangeStatusCode;
 
 impl<S, B> Transform<S, ServiceRequest> for ChangeStatusCode
@@ -174,6 +181,7 @@ async fn test_body() {
             .service(patch_test)
             .service(test_handler)
             .service(route_test)
+            .service(custom_resource_name_test)
     });
     let request = srv.request(http::Method::GET, srv.url("/test"));
     let response = request.send().await.unwrap();
@@ -228,6 +236,10 @@ async fn test_body() {
     let request = srv.request(http::Method::PATCH, srv.url("/multi"));
     let response = request.send().await.unwrap();
     assert!(!response.status().is_success());
+
+    let request = srv.request(http::Method::GET, srv.url("/custom_resource_name"));
+    let response = request.send().await.unwrap();
+    assert!(response.status().is_success());
 }
 
 #[actix_rt::test]


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Feature

## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
This PR adds a new `name` attribute to the `route` macro, so that user can specify a resource name, which by default is the name of handler function since #1178, and call `HttpRequest.url_for` on the name later.

Example:

```rust
#[get("/static", name = "static")]
async fn static_file() -> impl Responder {
    // ...
}
```

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
