### PR TITLE
fix limit not working on HttpMessageBody::limit

### DIFF
--- a/src/types/payload.rs
+++ b/src/types/payload.rs
@@ -289,10 +289,12 @@ impl HttpMessageBody {
         if let Some(l) = req.headers().get(&header::CONTENT_LENGTH) {
             match l.to_str() {
                 Ok(s) => match s.parse::<usize>() {
-                    Ok(l) if l > DEFAULT_CONFIG_LIMIT => {
-                        err = Some(PayloadError::Overflow)
+                    Ok(l) => {
+                        if l > DEFAULT_CONFIG_LIMIT {
+                            err = Some(PayloadError::Overflow);
+                        }
+                        length = Some(l)
                     }
-                    Ok(l) => length = Some(l),
                     Err(_) => err = Some(PayloadError::UnknownLength),
                 },
                 Err(_) => err = Some(PayloadError::UnknownLength),

--- a/src/types/payload.rs
+++ b/src/types/payload.rs
@@ -196,7 +196,7 @@ fn bytes_to_string(body: Bytes, encoding: &'static Encoding) -> Result<String, E
 /// `.app_data()` methods.
 #[derive(Clone)]
 pub struct PayloadConfig {
-    pub limit: usize,
+    limit: usize,
     mimetype: Option<Mime>,
 }
 

--- a/src/types/payload.rs
+++ b/src/types/payload.rs
@@ -196,7 +196,7 @@ fn bytes_to_string(body: Bytes, encoding: &'static Encoding) -> Result<String, E
 /// `.app_data()` methods.
 #[derive(Clone)]
 pub struct PayloadConfig {
-    limit: usize,
+    pub limit: usize,
     mimetype: Option<Mime>,
 }
 
@@ -316,9 +316,11 @@ impl HttpMessageBody {
     /// Change max size of payload. By default max size is 256kB
     pub fn limit(mut self, limit: usize) -> Self {
         if let Some(l) = self.length {
-            if l > limit {
-                self.err = Some(PayloadError::Overflow);
-            }
+            self.err = if l > limit {
+                Some(PayloadError::Overflow)
+            } else {
+                None
+            };
         }
         self.limit = limit;
         self


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Bug Fix


## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Fix the bug introduced by https://github.com/actix/actix-web/pull/1834.
When content length overflow the default limit overflow error is generated. The error is not removed when calling limit and set a new limit that is bigger than content length 

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
