### PR TITLE
Disable actix's default features on -actors

### DIFF
--- a/actix-web-actors/Cargo.toml
+++ b/actix-web-actors/Cargo.toml
@@ -16,7 +16,7 @@ name = "actix_web_actors"
 path = "src/lib.rs"
 
 [dependencies]
-actix = "0.11.0-beta.1"
+actix = { version = "0.11.0-beta.1", default-features = false }
 actix-codec = "0.4.0-beta.1"
 actix-http = "3.0.0-beta.1"
 actix-web = { version = "4.0.0-beta.1", default-features = false }


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Other


## PR Checklist
- [ ] A changelog entry has been made for the appropriate packages.
- [x] (Team) Label with affected crates and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
This was forcing `trust-dns-*` crates into the dependency graph.
CI will probably fail due to `actix-rt`.


<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
