### PR TITLE
Use askama-escape for html escaping

### DIFF
--- a/actix-files/CHANGES.md
+++ b/actix-files/CHANGES.md
@@ -2,8 +2,10 @@
 
 ## Unreleased - 2021-xx-xx
 * Fix If-Modified-Since and If-Unmodified-Since to not compare using sub-second timestamps. [#1887]
+* Replace `v_htmlescape` with `askama_escape`. [#1953]
 
 [#1887]: https://github.com/actix/actix-web/pull/1887
+[#1953]: https://github.com/actix/actix-web/pull/1953
 
 ## 0.6.0-beta.1 - 2021-01-07
 * `HttpRange::parse` now has its own error type.

--- a/actix-files/Cargo.toml
+++ b/actix-files/Cargo.toml
@@ -19,6 +19,7 @@ path = "src/lib.rs"
 [dependencies]
 actix-web = { version = "4.0.0-beta.1", default-features = false }
 actix-service = "2.0.0-beta.3"
+askama_escape = "0.10"
 bitflags = "1"
 bytes = "1"
 futures-core = { version = "0.3.7", default-features = false }
@@ -28,7 +29,6 @@ log = "0.4"
 mime = "0.3"
 mime_guess = "2.0.1"
 percent-encoding = "2.1"
-v_htmlescape = "0.12"
 
 [dev-dependencies]
 actix-rt = "2.0.0-beta.2"

--- a/actix-files/src/directory.rs
+++ b/actix-files/src/directory.rs
@@ -1,8 +1,8 @@
 use std::{fmt::Write, fs::DirEntry, io, path::Path, path::PathBuf};
 
 use actix_web::{dev::ServiceResponse, HttpRequest, HttpResponse};
+use askama_escape::{escape as escape_html_entity, Html};
 use percent_encoding::{utf8_percent_encode, CONTROLS};
-use v_htmlescape::escape as escape_html_entity;
 
 /// A directory; responds with the generated directory listing.
 #[derive(Debug)]
@@ -50,7 +50,7 @@ macro_rules! encode_file_url {
 // " -- &quot;  & -- &amp;  ' -- &#x27;  < -- &lt;  > -- &gt;  / -- &#x2f;
 macro_rules! encode_file_name {
     ($entry:ident) => {
-        escape_html_entity(&$entry.file_name().to_string_lossy())
+        escape_html_entity(&$entry.file_name().to_string_lossy(), Html)
     };
 }
 


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Refactor/Other


## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
This replaces [v_htmlescape](https://docs.rs/v_htmlescape/0.12.0/v_htmlescape/) in actix-files with [askama_escape](https://docs.rs/askama_escape/0.10.1/askama_escape/), which has zero dependencies instead of 3 like v_htmlescape and does not pull in outdated `bytes` versions. 

I was not able to run tests or even build it because actix-server seems to be broken right now, but both the old and new method take a `&str` and the return types are only used for Display , which it still implements (see [here](https://github.com/djc/askama/blob/main/askama_escape/src/lib.rs#L179-L184)).


<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
