### PR TITLE
ensure poll_flush on h1 connection disconnect

### DIFF
--- a/actix-http/src/h1/dispatcher.rs
+++ b/actix-http/src/h1/dispatcher.rs
@@ -841,9 +841,8 @@ where
                     if inner.flags.contains(Flags::WRITE_DISCONNECT) {
                         Poll::Ready(Ok(()))
                     } else {
-                        // flush buffer
-                        inner.as_mut().poll_flush(cx)?;
-                        if !inner.write_buf.is_empty() {
+                        // flush buffer and wait on block.
+                        if inner.as_mut().poll_flush(cx)? {
                             Poll::Pending
                         } else {
                             Pin::new(inner.project().io.as_mut().unwrap())


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Bug Fix


## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Documentation comments have been added / updated.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
With the change of https://github.com/actix/actix-web/pull/1971 h1 dispatcher now have one more condition that would return blocked state.On connection disconnect this condition should be checked. 

`wirte_buf` empty does not indicate a flush is finished so as long as `poll_flush` returns in blocked state the dispatcher should enter pending.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
