### PR TITLE
optional cookies features

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,8 @@
 # Changes
 
 ## Unreleased - 2021-xx-xx
-
+### Changed
+* Feature `cookies` is now optional and enabled by default.
 
 ## 4.0.0-beta.3 - 2021-02-10
 * Update `actix-web-codegen` to `0.5.0-beta.1`.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,10 @@
 
 ## Unreleased - 2021-xx-xx
 ### Changed
-* Feature `cookies` is now optional and enabled by default.
+* Feature `cookies` is now optional and enabled by default. [#1981]
+
+[#1981]: https://github.com/actix/actix-web/pull/1981
+
 
 ## 4.0.0-beta.3 - 2021-02-10
 * Update `actix-web-codegen` to `0.5.0-beta.1`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,8 +44,8 @@ default = ["compress", "cookies"]
 # content-encoding support
 compress = ["actix-http/compress", "awc/compress"]
 
-# cookies feature
-cookies = ["actix-http/cookies"]
+# support for cookies
+cookies = ["actix-http/cookies", "awc/cookies"]
 
 # secure cookies feature
 secure-cookies = ["actix-http/secure-cookies"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,6 @@ time = { version = "0.2.23", default-features = false, features = ["std"] }
 tls-openssl = { package = "openssl", version = "0.10.9", optional = true }
 tls-rustls = { package = "rustls", version = "0.19.0", optional = true }
 url = "2.1"
-smallvec = "1.6"
 
 [target.'cfg(windows)'.dependencies.tls-openssl]
 version = "0.10.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [package.metadata.docs.rs]
+# features that docs.rs will build with
 features = ["openssl", "rustls", "compress", "secure-cookies"]
 
 [badges]
@@ -38,12 +39,15 @@ members = [
 ]
 
 [features]
-default = ["compress"]
+default = ["compress", "cookies"]
 
 # content-encoding support
 compress = ["actix-http/compress", "awc/compress"]
 
-# sessions feature
+# cookies feature
+cookies = ["actix-http/cookies"]
+
+# secure cookies feature
 secure-cookies = ["actix-http/secure-cookies"]
 
 # openssl
@@ -95,16 +99,17 @@ futures-core = { version = "0.3.7", default-features = false }
 futures-util = { version = "0.3.7", default-features = false }
 log = "0.4"
 mime = "0.3"
-socket2 = "0.3.16"
 pin-project = "1.0.0"
 regex = "1.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_urlencoded = "0.7"
+smallvec = "1.6"
+socket2 = "0.3.16"
 time = { version = "0.2.23", default-features = false, features = ["std"] }
-url = "2.1"
 tls-openssl = { package = "openssl", version = "0.10.9", optional = true }
 tls-rustls = { package = "rustls", version = "0.19.0", optional = true }
+url = "2.1"
 smallvec = "1.6"
 
 [target.'cfg(windows)'.dependencies.tls-openssl]
@@ -121,9 +126,6 @@ serde_derive = "1.0"
 brotli2 = "0.3.2"
 flate2 = "1.0.13"
 criterion = "0.3"
-
-[profile.dev]
-debug = false
 
 [profile.release]
 lto = true

--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -2,7 +2,10 @@
 
 ## Unreleased - 2021-xx-xx
 ### Changed
-* Feature `cookies` is now optional and disabled by default.
+* Feature `cookies` is now optional and disabled by default. [#1981]
+
+[#1981]: https://github.com/actix/actix-web/pull/1981
+
 
 ## 3.0.0-beta.3 - 2021-02-10
 * No notable changes.

--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -1,7 +1,8 @@
 # Changes
 
 ## Unreleased - 2021-xx-xx
-
+### Changed
+* Feature `cookies` is now optional and disabled by default.
 
 ## 3.0.0-beta.3 - 2021-02-10
 * No notable changes.

--- a/actix-http/Cargo.toml
+++ b/actix-http/Cargo.toml
@@ -31,14 +31,14 @@ openssl = ["actix-tls/openssl"]
 # rustls support
 rustls = ["actix-tls/rustls"]
 
-# enable compressison support
+# enable compression support
 compress = ["flate2", "brotli2"]
 
 # support for cookies
 cookies = ["cookie"]
 
 # support for secure cookies
-secure-cookies = ["cookie", "cookie/secure"]
+secure-cookies = ["cookies", "cookie/secure"]
 
 # trust-dns as client dns resolver
 trust-dns = ["trust-dns-resolver"]

--- a/actix-http/Cargo.toml
+++ b/actix-http/Cargo.toml
@@ -15,7 +15,8 @@ license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [package.metadata.docs.rs]
-features = ["openssl", "rustls", "compress", "secure-cookies"]
+# features that docs.rs will build with
+features = ["openssl", "rustls", "compress", "cookies", "secure-cookies"]
 
 [lib]
 name = "actix_http"
@@ -33,8 +34,11 @@ rustls = ["actix-tls/rustls"]
 # enable compressison support
 compress = ["flate2", "brotli2"]
 
+# support for cookies
+cookies = ["cookie"]
+
 # support for secure cookies
-secure-cookies = ["cookie/secure"]
+secure-cookies = ["cookie", "cookie/secure"]
 
 # trust-dns as client dns resolver
 trust-dns = ["trust-dns-resolver"]
@@ -46,24 +50,25 @@ actix-utils = "3.0.0-beta.2"
 actix-rt = "2"
 actix-tls = "3.0.0-beta.2"
 
+ahash = "0.7"
 base64 = "0.13"
 bitflags = "1.2"
 bytes = "1"
 bytestring = "1"
-cookie = { version = "0.14.1", features = ["percent-encode"] }
+cfg-if = "1"
+cookie = { version = "0.14.1", features = ["percent-encode"], optional = true }
 derive_more = "0.99.5"
 encoding_rs = "0.8"
 futures-channel = { version = "0.3.7", default-features = false, features = ["alloc"] }
 futures-core = { version = "0.3.7", default-features = false, features = ["alloc"] }
 futures-util = { version = "0.3.7", default-features = false, features = ["alloc", "sink"] }
-ahash = "0.7"
 h2 = "0.3.0"
 http = "0.2.2"
 httparse = "1.3"
 indexmap = "1.3"
 itoa = "0.4"
-lazy_static = "1.4"
 language-tags = "0.2"
+lazy_static = "1.4"
 log = "0.4"
 mime = "0.3"
 percent-encoding = "2.1"
@@ -72,10 +77,10 @@ rand = "0.8"
 regex = "1.3"
 serde = "1.0"
 serde_json = "1.0"
-sha-1 = "0.9"
-smallvec = "1.6"
-slab = "0.4"
 serde_urlencoded = "0.7"
+sha-1 = "0.9"
+slab = "0.4"
+smallvec = "1.6"
 time = { version = "0.2.23", default-features = false, features = ["std"] }
 
 # compression

--- a/actix-http/src/error.rs
+++ b/actix-http/src/error.rs
@@ -19,9 +19,11 @@ use serde_json::error::Error as JsonError;
 use serde_urlencoded::ser::Error as FormError;
 
 use crate::body::Body;
-pub use crate::cookie::ParseError as CookieParseError;
 use crate::helpers::Writer;
 use crate::response::{Response, ResponseBuilder};
+
+#[cfg(feature = "cookies")]
+pub use crate::cookie::ParseError as CookieParseError;
 
 /// A specialized [`std::result::Result`]
 /// for actix web operations
@@ -397,6 +399,7 @@ impl ResponseError for PayloadError {
 }
 
 /// Return `BadRequest` for `cookie::ParseError`
+#[cfg(feature = "cookies")]
 impl ResponseError for crate::cookie::ParseError {
     fn status_code(&self) -> StatusCode {
         StatusCode::BAD_REQUEST

--- a/actix-http/src/h1/encoder.rs
+++ b/actix-http/src/h1/encoder.rs
@@ -549,7 +549,6 @@ mod tests {
         );
         let data =
             String::from_utf8(Vec::from(bytes.split().freeze().as_ref())).unwrap();
-        eprintln!("{}", &data);
 
         assert!(data.contains("Content-Length: 0\r\n"));
         assert!(data.contains("Connection: close\r\n"));

--- a/actix-http/src/http_message.rs
+++ b/actix-http/src/http_message.rs
@@ -108,8 +108,6 @@ pub trait HttpMessage: Sized {
     /// Load request cookies.
     #[cfg(feature = "cookies")]
     fn cookies(&self) -> Result<Ref<'_, Vec<Cookie<'static>>>, CookieParseError> {
-        eprintln!("default impl cookies?");
-
         if self.extensions().get::<Cookies>().is_none() {
             let mut cookies = Vec::new();
             for hdr in self.headers().get_all(header::COOKIE) {

--- a/actix-http/src/http_message.rs
+++ b/actix-http/src/http_message.rs
@@ -5,12 +5,14 @@ use encoding_rs::{Encoding, UTF_8};
 use http::header;
 use mime::Mime;
 
-use crate::cookie::Cookie;
-use crate::error::{ContentTypeError, CookieParseError, ParseError};
+use crate::error::{ContentTypeError, ParseError};
 use crate::extensions::Extensions;
 use crate::header::{Header, HeaderMap};
 use crate::payload::Payload;
+#[cfg(feature = "cookies")]
+use crate::{cookie::Cookie, error::CookieParseError};
 
+#[cfg(feature = "cookies")]
 struct Cookies(Vec<Cookie<'static>>);
 
 /// Trait that implements general purpose operations on HTTP messages.
@@ -104,6 +106,7 @@ pub trait HttpMessage: Sized {
     }
 
     /// Load request cookies.
+    #[cfg(feature = "cookies")]
     #[inline]
     fn cookies(&self) -> Result<Ref<'_, Vec<Cookie<'static>>>, CookieParseError> {
         if self.extensions().get::<Cookies>().is_none() {
@@ -125,6 +128,7 @@ pub trait HttpMessage: Sized {
     }
 
     /// Return request cookie.
+    #[cfg(feature = "cookies")]
     fn cookie(&self, name: &str) -> Option<Cookie<'static>> {
         if let Ok(cookies) = self.cookies() {
             for cookie in cookies.iter() {

--- a/actix-http/src/http_message.rs
+++ b/actix-http/src/http_message.rs
@@ -107,8 +107,9 @@ pub trait HttpMessage: Sized {
 
     /// Load request cookies.
     #[cfg(feature = "cookies")]
-    #[inline]
     fn cookies(&self) -> Result<Ref<'_, Vec<Cookie<'static>>>, CookieParseError> {
+        eprintln!("default impl cookies?");
+
         if self.extensions().get::<Cookies>().is_none() {
             let mut cookies = Vec::new();
             for hdr in self.headers().get_all(header::COOKIE) {
@@ -122,6 +123,7 @@ pub trait HttpMessage: Sized {
             }
             self.extensions_mut().insert(Cookies(cookies));
         }
+
         Ok(Ref::map(self.extensions(), |ext| {
             &ext.get::<Cookies>().unwrap().0
         }))

--- a/actix-http/src/lib.rs
+++ b/actix-http/src/lib.rs
@@ -1,4 +1,21 @@
 //! HTTP primitives for the Actix ecosystem.
+//!
+//! # Crate Features
+//! | Feature          | Functionality                                         |
+//! | ---------------- | ----------------------------------------------------- |
+//! | `openssl`        | TLS support via [OpenSSL](openssl).                   |
+//! | `rustls`         | TLS support via [rustls](rustls).                     |
+//! | `compress`       | Payload compression support. (Deflate, Gzip & Brotli) |
+//! | `cookies`        | Support for cookies backed by the [cookie] crate.     |
+//! | `secure-cookies` | Adds for secure cookies. Enables `cookies` feature.   |
+//! | `trust-dns`      | Uses [`trust-dns`] as the client DNS resolver.        |
+//! 
+//! [openssl]: https://crates.io/crates/openssl
+//! [rustls]: https://crates.io/crates/rustls
+//! [cookie]: https://crates.io/crates/cookie
+//! [trust-dns]: https://crates.io/crates/trust-dns
+//! [trust-dns]: https://crates.io/crates/trust-dns
+
 
 #![deny(rust_2018_idioms, nonstandard_style)]
 #![allow(

--- a/actix-http/src/lib.rs
+++ b/actix-http/src/lib.rs
@@ -1,21 +1,19 @@
 //! HTTP primitives for the Actix ecosystem.
 //!
-//! # Crate Features
+//! ## Crate Features
 //! | Feature          | Functionality                                         |
 //! | ---------------- | ----------------------------------------------------- |
-//! | `openssl`        | TLS support via [OpenSSL](openssl).                   |
-//! | `rustls`         | TLS support via [rustls](rustls).                     |
+//! | `openssl`        | TLS support via [OpenSSL].                            |
+//! | `rustls`         | TLS support via [rustls].                             |
 //! | `compress`       | Payload compression support. (Deflate, Gzip & Brotli) |
 //! | `cookies`        | Support for cookies backed by the [cookie] crate.     |
 //! | `secure-cookies` | Adds for secure cookies. Enables `cookies` feature.   |
-//! | `trust-dns`      | Uses [`trust-dns`] as the client DNS resolver.        |
-//! 
-//! [openssl]: https://crates.io/crates/openssl
+//! | `trust-dns`      | Use [trust-dns] as the client DNS resolver.           |
+//!
+//! [OpenSSL]: https://crates.io/crates/openssl
 //! [rustls]: https://crates.io/crates/rustls
 //! [cookie]: https://crates.io/crates/cookie
 //! [trust-dns]: https://crates.io/crates/trust-dns
-//! [trust-dns]: https://crates.io/crates/trust-dns
-
 
 #![deny(rust_2018_idioms, nonstandard_style)]
 #![allow(

--- a/actix-http/src/lib.rs
+++ b/actix-http/src/lib.rs
@@ -34,12 +34,14 @@ mod response;
 mod service;
 mod time_parser;
 
-pub use cookie;
 pub mod error;
 pub mod h1;
 pub mod h2;
 pub mod test;
 pub mod ws;
+
+#[cfg(feature = "cookies")]
+pub use cookie;
 
 pub use self::builder::HttpServiceBuilder;
 pub use self::config::{KeepAlive, ServiceConfig};
@@ -61,6 +63,7 @@ pub mod http {
     pub use http::{uri, Error, Uri};
     pub use http::{Method, StatusCode, Version};
 
+    #[cfg(feature = "cookies")]
     pub use crate::cookie::{Cookie, CookieBuilder};
     pub use crate::header::HeaderMap;
 

--- a/awc/CHANGES.md
+++ b/awc/CHANGES.md
@@ -1,7 +1,8 @@
 # Changes
 
 ## Unreleased - 2021-xx-xx
-
+### Changed
+* Feature `cookies` is now optional and enabled by default.
 
 ## 3.0.0-beta.2 - 2021-02-10
 ### Added

--- a/awc/CHANGES.md
+++ b/awc/CHANGES.md
@@ -2,7 +2,10 @@
 
 ## Unreleased - 2021-xx-xx
 ### Changed
-* Feature `cookies` is now optional and enabled by default.
+* Feature `cookies` is now optional and enabled by default. [#1981]
+
+[#1981]: https://github.com/actix/actix-web/pull/1981
+
 
 ## 3.0.0-beta.2 - 2021-02-10
 ### Added

--- a/awc/Cargo.toml
+++ b/awc/Cargo.toml
@@ -22,10 +22,11 @@ name = "awc"
 path = "src/lib.rs"
 
 [package.metadata.docs.rs]
-features = ["openssl", "rustls", "compress"]
+# features that docs.rs will build with
+features = ["openssl", "rustls", "compress", "cookies"]
 
 [features]
-default = ["compress"]
+default = ["compress", "cookies"]
 
 # openssl
 openssl = ["tls-openssl", "actix-http/openssl"]
@@ -35,6 +36,9 @@ rustls = ["tls-rustls", "actix-http/rustls"]
 
 # content-encoding support
 compress = ["actix-http/compress"]
+
+# cookie parsing and cookie jar
+cookies = ["actix-http/cookies"]
 
 # trust-dns as dns resolver
 trust-dns = ["actix-http/trust-dns"]

--- a/awc/src/lib.rs
+++ b/awc/src/lib.rs
@@ -97,7 +97,9 @@ use std::convert::TryFrom;
 use std::rc::Rc;
 use std::time::Duration;
 
-pub use actix_http::{client::Connector, cookie, http};
+#[cfg(feature = "cookies")]
+pub use actix_http::cookie;
+pub use actix_http::{client::Connector, http};
 
 use actix_http::http::{Error as HttpError, HeaderMap, Method, Uri};
 use actix_http::RequestHead;

--- a/awc/src/response.rs
+++ b/awc/src/response.rs
@@ -1,9 +1,12 @@
-use std::{cell::{Ref, RefMut}, mem};
 use std::fmt;
 use std::future::Future;
 use std::marker::PhantomData;
 use std::pin::Pin;
 use std::task::{Context, Poll};
+use std::{
+    cell::{Ref, RefMut},
+    mem,
+};
 
 use bytes::{Bytes, BytesMut};
 use futures_core::{ready, Stream};
@@ -47,7 +50,6 @@ impl<S> HttpMessage for ClientResponse<S> {
     /// Load request cookies.
     #[cfg(feature = "cookies")]
     fn cookies(&self) -> Result<Ref<'_, Vec<Cookie<'static>>>, CookieParseError> {
-
         struct Cookies(Vec<Cookie<'static>>);
 
         if self.extensions().get::<Cookies>().is_none() {

--- a/awc/src/response.rs
+++ b/awc/src/response.rs
@@ -8,10 +8,11 @@ use std::task::{Context, Poll};
 use bytes::{Bytes, BytesMut};
 use futures_core::{ready, Stream};
 
-use actix_http::cookie::Cookie;
-use actix_http::error::{CookieParseError, PayloadError};
-use actix_http::http::header::{CONTENT_LENGTH, SET_COOKIE};
+use actix_http::error::PayloadError;
+use actix_http::http::header;
 use actix_http::http::{HeaderMap, StatusCode, Version};
+#[cfg(feature = "cookies")]
+use actix_http::{cookie::Cookie, error::CookieParseError};
 use actix_http::{Extensions, HttpMessage, Payload, PayloadStream, ResponseHead};
 use serde::de::DeserializeOwned;
 
@@ -43,13 +44,14 @@ impl<S> HttpMessage for ClientResponse<S> {
     }
 
     /// Load request cookies.
+    #[cfg(feature = "cookies")]
     #[inline]
     fn cookies(&self) -> Result<Ref<'_, Vec<Cookie<'static>>>, CookieParseError> {
         struct Cookies(Vec<Cookie<'static>>);
 
         if self.extensions().get::<Cookies>().is_none() {
             let mut cookies = Vec::new();
-            for hdr in self.headers().get_all(&SET_COOKIE) {
+            for hdr in self.headers().get_all(&header::SET_COOKIE) {
                 let s = std::str::from_utf8(hdr.as_bytes()).map_err(CookieParseError::from)?;
                 cookies.push(Cookie::parse_encoded(s)?.into_owned());
             }
@@ -161,7 +163,7 @@ where
     /// Create `MessageBody` for request.
     pub fn new(res: &mut ClientResponse<S>) -> MessageBody<S> {
         let mut len = None;
-        if let Some(l) = res.headers().get(&CONTENT_LENGTH) {
+        if let Some(l) = res.headers().get(&header::CONTENT_LENGTH) {
             if let Ok(s) = l.to_str() {
                 if let Ok(l) = s.parse::<usize>() {
                     len = Some(l)
@@ -256,7 +258,7 @@ where
         }
 
         let mut len = None;
-        if let Some(l) = req.headers().get(&CONTENT_LENGTH) {
+        if let Some(l) = req.headers().get(&header::CONTENT_LENGTH) {
             if let Ok(s) = l.to_str() {
                 if let Ok(l) = s.parse::<usize>() {
                     len = Some(l)

--- a/awc/src/response.rs
+++ b/awc/src/response.rs
@@ -47,12 +47,10 @@ impl<S> HttpMessage for ClientResponse<S> {
     /// Load request cookies.
     #[cfg(feature = "cookies")]
     fn cookies(&self) -> Result<Ref<'_, Vec<Cookie<'static>>>, CookieParseError> {
-        eprintln!("awc fn cookies");
 
         struct Cookies(Vec<Cookie<'static>>);
 
         if self.extensions().get::<Cookies>().is_none() {
-            eprintln!("no cookies, inserting");
             let mut cookies = Vec::new();
             for hdr in self.headers().get_all(&header::SET_COOKIE) {
                 let s = std::str::from_utf8(hdr.as_bytes()).map_err(CookieParseError::from)?;

--- a/awc/src/ws.rs
+++ b/awc/src/ws.rs
@@ -32,6 +32,7 @@ use std::rc::Rc;
 use std::{fmt, str};
 
 use actix_codec::Framed;
+#[cfg(feature = "cookies")]
 use actix_http::cookie::{Cookie, CookieJar};
 use actix_http::{ws, Payload, RequestHead};
 use actix_rt::time::timeout;
@@ -54,8 +55,10 @@ pub struct WebsocketsRequest {
     addr: Option<SocketAddr>,
     max_size: usize,
     server_mode: bool,
-    cookies: Option<CookieJar>,
     config: Rc<ClientConfig>,
+
+    #[cfg(feature = "cookies")]
+    cookies: Option<CookieJar>,
 }
 
 impl WebsocketsRequest {
@@ -89,6 +92,7 @@ impl WebsocketsRequest {
             protocols: None,
             max_size: 65_536,
             server_mode: false,
+            #[cfg(feature = "cookies")]
             cookies: None,
         }
     }
@@ -117,6 +121,7 @@ impl WebsocketsRequest {
     }
 
     /// Set a cookie
+    #[cfg(feature = "cookies")]
     pub fn cookie(mut self, cookie: Cookie<'_>) -> Self {
         if self.cookies.is_none() {
             let mut jar = CookieJar::new();
@@ -270,6 +275,7 @@ impl WebsocketsRequest {
         }
 
         // set cookies
+        #[cfg(feature = "cookies")]
         if let Some(ref mut jar) = self.cookies {
             let cookie: String = jar
                 .delta()

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,9 +13,11 @@ pub enum UrlGenerationError {
     /// Resource not found
     #[display(fmt = "Resource not found")]
     ResourceNotFound,
+
     /// Not all path pattern covered
     #[display(fmt = "Not all path pattern covered")]
     NotEnoughElements,
+
     /// URL parse error
     #[display(fmt = "{}", _0)]
     ParseError(UrlParseError),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,7 @@
 //! ## Crate Features
 //!
 //! * `compress` - content encoding compression support (enabled by default)
+//! * `cookies` - cookies support (enabled by default)
 //! * `openssl` - HTTPS support via `openssl` crate, supports `HTTP/2`
 //! * `rustls` - HTTPS support via `rustls` crate, supports `HTTP/2`
 //! * `secure-cookies` - secure cookies support

--- a/tests/test_server.rs
+++ b/tests/test_server.rs
@@ -806,15 +806,18 @@ async fn test_server_cookies() {
         }))
     });
 
+    let req = srv.get("/");
+    let res = req.send().await.unwrap();
+    assert!(res.status().is_success());
+
+    eprintln!("{:?}", &res);
+
     let first_cookie = http::CookieBuilder::new("first", "first_value")
         .http_only(true)
         .finish();
     let second_cookie = http::Cookie::new("second", "second_value");
 
-    let req = srv.get("/");
-    let res = req.send().await.unwrap();
-    assert!(res.status().is_success());
-
+    eprintln!("gimme cookie");
     let cookies = res.cookies().expect("To have cookies");
     assert_eq!(cookies.len(), 2);
     if cookies[0] == first_cookie {

--- a/tests/test_server.rs
+++ b/tests/test_server.rs
@@ -810,14 +810,11 @@ async fn test_server_cookies() {
     let res = req.send().await.unwrap();
     assert!(res.status().is_success());
 
-    eprintln!("{:?}", &res);
-
     let first_cookie = http::CookieBuilder::new("first", "first_value")
         .http_only(true)
         .finish();
     let second_cookie = http::Cookie::new("second", "second_value");
 
-    eprintln!("gimme cookie");
     let cookies = res.cookies().expect("To have cookies");
     assert_eq!(cookies.len(), 2);
     if cookies[0] == first_cookie {


### PR DESCRIPTION
## PR Type
Refactor


## PR Checklist
- [x] Tests for the changes have been added / updated.
	- in the form of `--no-default-features` checks in CI
- [x] Documentation comments have been added / updated.
	- in the form of documenting crate features of actix-http in root doc
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
Cookies are now optional, disabled by default in -http and enabled by default in awc and -web.