### PR TITLE
do not self wake up when have a payload

### DIFF
--- a/actix-http/src/h1/dispatcher.rs
+++ b/actix-http/src/h1/dispatcher.rs
@@ -772,7 +772,12 @@ where
                             // at this point it's not known io is still scheduled to
                             // be waked up. so force wake up dispatcher just in case.
                             // TODO: figure out the overhead.
-                            cx.waker().wake_by_ref();
+                            if this.payload.is_none() {
+                                // When dispatcher has a payload. The responsibility of
+                                // wake up stream would be shift to PayloadSender.
+                                // Therefore no self wake up is needed.
+                                cx.waker().wake_by_ref();
+                            }
                             return Ok(false);
                         }
 


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Bug Fix


## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Documentation comments have been added / updated.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Do not self wake up when there is a payload. This would prevent the active consumption of request payload when payload is dropped intentionally.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
