### PR TITLE
remove unused flag upgrade

### DIFF
--- a/actix-http/src/h1/dispatcher.rs
+++ b/actix-http/src/h1/dispatcher.rs
@@ -40,7 +40,6 @@ bitflags! {
         const SHUTDOWN           = 0b0000_0100;
         const READ_DISCONNECT    = 0b0000_1000;
         const WRITE_DISCONNECT   = 0b0001_0000;
-        const UPGRADE            = 0b0010_0000;
     }
 }
 
@@ -215,10 +214,7 @@ where
     U::Error: fmt::Display,
 {
     fn can_read(&self, cx: &mut Context<'_>) -> bool {
-        if self
-            .flags
-            .intersects(Flags::READ_DISCONNECT | Flags::UPGRADE)
-        {
+        if self.flags.contains(Flags::READ_DISCONNECT) {
             false
         } else if let Some(ref info) = self.payload {
             info.need_read(cx) == PayloadStatus::Read
@@ -501,7 +497,7 @@ where
     }
 
     /// Process one incoming request.
-    pub(self) fn poll_request(
+    fn poll_request(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Result<bool, DispatchError> {


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Refactor


## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Remove unused `Flags::UPGRADE`. There is no insert this flag anywhere. Actual upgrade requests would be pushed to `DispatcherMessage` queue and later returned directly as `DispatcherState::Upgrade`. 

Remove unnecessary pub(self) on poll_request

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
