### PR TITLE
remove awc::connect::connect trait.

### DIFF
--- a/awc/src/lib.rs
+++ b/awc/src/lib.rs
@@ -115,13 +115,13 @@ pub mod test;
 pub mod ws;
 
 pub use self::builder::ClientBuilder;
-pub use self::connect::BoxedSocket;
+pub use self::connect::{BoxedSocket, ConnectRequest, ConnectResponse, ConnectService};
 pub use self::frozen::{FrozenClientRequest, FrozenSendBuilder};
 pub use self::request::ClientRequest;
 pub use self::response::{ClientResponse, JsonBody, MessageBody};
 pub use self::sender::SendClientRequest;
 
-use self::connect::{Connect, ConnectorWrapper};
+use self::connect::ConnectorWrapper;
 
 /// An asynchronous HTTP and WebSocket client.
 ///
@@ -146,7 +146,7 @@ use self::connect::{Connect, ConnectorWrapper};
 pub struct Client(Rc<ClientConfig>);
 
 pub(crate) struct ClientConfig {
-    pub(crate) connector: Box<dyn Connect>,
+    pub(crate) connector: ConnectService,
     pub(crate) headers: HeaderMap,
     pub(crate) timeout: Option<Duration>,
 }
@@ -154,7 +154,7 @@ pub(crate) struct ClientConfig {
 impl Default for Client {
     fn default() -> Self {
         Client(Rc::new(ClientConfig {
-            connector: Box::new(ConnectorWrapper(Connector::new().finish())),
+            connector: Box::new(ConnectorWrapper::new(Connector::new().finish())),
             headers: HeaderMap::new(),
             timeout: Some(Duration::from_secs(5)),
         }))

--- a/awc/src/sender.rs
+++ b/awc/src/sender.rs
@@ -130,7 +130,9 @@ impl Future for SendClientRequest {
                         _ => return Poll::Ready(Err(SendRequestError::Timeout)),
                     }
                 }
-                Pin::new(send).poll(cx)
+                Pin::new(send)
+                    .poll(cx)
+                    .map_ok(|res| res.into_client_response())
             }
             SendClientRequest::Err(ref mut e) => match e.take() {
                 Some(e) => Poll::Ready(Err(e)),


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Refactor


## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Remove `awc::connect::Connect` trait in favor of `Service` trait.
This would potential enable middleware around `ConnectService` type.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
