### PR TITLE
Fix Json extractor to be 32kB by default

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,8 +3,11 @@
 ## Unreleased - 2021-xx-xx
 ### Changed
 * Feature `cookies` is now optional and enabled by default. [#1981]
+* `JsonBody::new` returns a default limit of 32kB to be consistent with `JsonConfig` and the
+  default behaviour of the `web::Json<T>` extractor. [#2010] 
 
 [#1981]: https://github.com/actix/actix-web/pull/1981
+[#2010]: https://github.com/actix/actix-web/pull/2010
 
 
 ## 4.0.0-beta.3 - 2021-02-10

--- a/src/types/json.rs
+++ b/src/types/json.rs
@@ -345,7 +345,7 @@ where
         let payload = payload.take();
 
         JsonBody::Body {
-            limit: 262_144,
+            limit: 32_768,
             length,
             payload,
             buf: BytesMut::with_capacity(8192),
@@ -353,7 +353,7 @@ where
         }
     }
 
-    /// Set maximum accepted payload size. The default limit is 256kB.
+    /// Set maximum accepted payload size. The default limit is 32kB.
     pub fn limit(self, limit: usize) -> Self {
         match self {
             JsonBody::Body {


### PR DESCRIPTION
## PR Type
Other

## PR Checklist
- [x] Tests for the changes have been added / updated. (**not applicable**)
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview

While technically the default limit for `JsonBody` is indeed 256kB when called through `JsonBody::new`, in practice the limit is always set to 32kB for every context where `JsonBody` is used (via `JsonConfig`). This is also consistent with the documentation of the `JsonError::Overflow`, which mentions a default maximum of `32kB`.

This commit changes the default to also be `32kB` instead of `256kB`.

## Alternatives

The alternative to this commit is to instead change the default of `JsonConfig` to have a limit of `256kB` instead of currently `32kB`.