### PR TITLE
Inner field of web::Query is public again (#2016)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,6 @@
 * Feature `cookies` is now optional and enabled by default. [#1981]
 * `JsonBody::new` returns a default limit of 32kB to be consistent with `JsonConfig` and the
   default behaviour of the `web::Json<T>` extractor. [#2010] 
-* `web::Query` has a public inner field again [#2016]
 
 [#1981]: https://github.com/actix/actix-web/pull/1981
 [#2010]: https://github.com/actix/actix-web/pull/2010

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 * Feature `cookies` is now optional and enabled by default. [#1981]
 * `JsonBody::new` returns a default limit of 32kB to be consistent with `JsonConfig` and the
   default behaviour of the `web::Json<T>` extractor. [#2010] 
+* `web::Query` has a public inner field again [#2016]
 
 [#1981]: https://github.com/actix/actix-web/pull/1981
 [#2010]: https://github.com/actix/actix-web/pull/2010

--- a/src/types/query.rs
+++ b/src/types/query.rs
@@ -29,7 +29,7 @@ use crate::{dev::Payload, error::QueryPayloadError, Error, FromRequest, HttpRequ
 ///    Code
 /// }
 ///
-/// #[derive(Deserialize)]
+/// #[derive(Debug, Deserialize)]
 /// pub struct AuthRequest {
 ///    id: u64,
 ///    response_type: ResponseType,
@@ -42,9 +42,23 @@ use crate::{dev::Payload, error::QueryPayloadError, Error, FromRequest, HttpRequ
 /// async fn index(info: web::Query<AuthRequest>) -> String {
 ///     format!("Authorization request for id={} and type={:?}!", info.id, info.response_type)
 /// }
+///
+/// // To access the entire underlying query struct, use `.into_inner()`.
+/// #[get("/debug1")]
+/// async fn debug1(info: web::Query<AuthRequest>) -> String {
+///     dbg!("Authorization object={:?}", info.into_inner());
+///     "OK".to_string()
+/// }
+///
+/// // Or use `.0`, which is equivalent to `.into_inner()`.
+/// #[get("/debug2")]
+/// async fn debug2(info: web::Query<AuthRequest>) -> String {
+///     dbg!("Authorization object={:?}", info.0);
+///     "OK".to_string()
+/// }
 /// ```
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Query<T>(T);
+pub struct Query<T>(pub T);
 
 impl<T> Query<T> {
     /// Unwrap into inner `T` value.


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Feature


## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
The v4 beta made Query's inner field private, but the discussion in the linked issue said that we should revert this change, as it doesn't prevent any bad behaviour.

Because none of the documentation or examples have mentioned using .0 syntax, I didn't think any documentation changes were necessary. I didn't think any tests were necessary either, as this doesn't add any logic, it merely exports a field. If you'd like me to add an example or test, I'd be happy to!


<!-- If this PR fixes or closes an issue, reference it here. -->
Closes #2016 
