### PR TITLE
actix-http-test: minimize features of dependencies

### DIFF
--- a/actix-http-test/Cargo.toml
+++ b/actix-http-test/Cargo.toml
@@ -35,7 +35,7 @@ actix-tls = "3.0.0-beta.3"
 actix-utils = "3.0.0-beta.2"
 actix-rt = "2"
 actix-server = "2.0.0-beta.3"
-awc = "3.0.0-beta.2"
+awc = { version = "3.0.0-beta.2", default-features = false }
 
 base64 = "0.13"
 bytes = "1"
@@ -57,5 +57,5 @@ features = ["vendored"]
 optional = true
 
 [dev-dependencies]
-actix-web = "4.0.0-beta.3"
+actix-web = { version = "4.0.0-beta.3", default-features = false, features = ["cookies"] }
 actix-http = "3.0.0-beta.3"

--- a/actix-http/src/error.rs
+++ b/actix-http/src/error.rs
@@ -983,6 +983,7 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
     }
 
+    #[cfg(feature = "cookies")]
     #[test]
     fn test_cookie_parse() {
         let resp: Response = CookieParseError::EmptyName.error_response();

--- a/actix-http/src/response.rs
+++ b/actix-http/src/response.rs
@@ -896,8 +896,9 @@ mod tests {
 
     use super::*;
     use crate::body::Body;
-    use crate::http::header::{HeaderValue, CONTENT_TYPE, COOKIE, SET_COOKIE};
-    use crate::HttpMessage;
+    use crate::http::header::{HeaderValue, CONTENT_TYPE, COOKIE};
+    #[cfg(feature = "cookies")]
+    use crate::{http::header::SET_COOKIE, HttpMessage};
 
     #[test]
     fn test_debug() {
@@ -909,6 +910,7 @@ mod tests {
         assert!(dbg.contains("Response"));
     }
 
+    #[cfg(feature = "cookies")]
     #[test]
     fn test_response_cookies() {
         let req = crate::test::TestRequest::default()
@@ -946,6 +948,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "cookies")]
     #[test]
     fn test_update_response_cookies() {
         let mut r = Response::Ok()
@@ -1097,6 +1100,7 @@ mod tests {
         assert_eq!(resp.body().get_ref(), b"test");
     }
 
+    #[cfg(feature = "cookies")]
     #[test]
     fn test_into_builder() {
         let mut resp: Response = "test".into();


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Other


## PR Checklist
- [x] (Team) Label with affected crates and semver status.

## Overview
<!-- Describe the current and new behavior. -->

This PR disables default features from `awc` and `actix-web` in `actix-http-test`. This speeds up compilation by removing some optional dependencies like `brotli2` when they are not needed.

<!-- Emphasize any breaking changes. -->


<!-- If this PR fixes or closes an issue, reference it here. -->
Helps with #1561