### PR TITLE
Port over doc comments in route macros.

### DIFF
--- a/actix-web-codegen/CHANGES.md
+++ b/actix-web-codegen/CHANGES.md
@@ -1,6 +1,7 @@
 # Changes
 
 ## Unreleased - 2021-xx-xx
+* Preserve doc comments when using route macros.
 
 
 ## 0.5.0-beta.1 - 2021-02-10

--- a/actix-web-codegen/CHANGES.md
+++ b/actix-web-codegen/CHANGES.md
@@ -1,7 +1,9 @@
 # Changes
 
 ## Unreleased - 2021-xx-xx
-* Preserve doc comments when using route macros.
+* Preserve doc comments when using route macros. [#2022]
+
+[#2022]: https://github.com/actix/actix-web/pull/2022
 
 
 ## 0.5.0-beta.1 - 2021-02-10

--- a/actix-web-codegen/src/route.rs
+++ b/actix-web-codegen/src/route.rs
@@ -229,13 +229,12 @@ impl Route {
         //
         // Note that multi line doc comments are converted to multiple doc
         // attributes.
-        let mut doc_attributes = Vec::new();
-        for attr in &ast.attrs {
-            if attr.path.get_ident().is_ident("doc") {
-                    doc_attribute.push(attr.clone());
-                }
-            }
-        }
+        let doc_attributes = ast
+            .attrs
+            .iter()
+            .filter(|attr| attr.path.is_ident("doc"))
+            .cloned()
+            .collect();
 
         let args = Args::new(args, method)?;
         if args.methods.is_empty() {
@@ -264,7 +263,7 @@ impl Route {
             args,
             ast,
             resource_type,
-            doc_attributes: doc_attribute,
+            doc_attributes,
         })
     }
 }
@@ -304,13 +303,8 @@ impl ToTokens for Route {
             }
         };
 
-        let doc_comment_token_stream: TokenStream2 = doc_attribute
-            .iter()
-            .map(ToTokens::to_token_stream)
-            .collect();
-
         let stream = quote! {
-            #(#doc_comments)*
+            #(#doc_attributes)*
             #[allow(non_camel_case_types, missing_docs)]
             pub struct #name;
 

--- a/actix-web-codegen/src/route.rs
+++ b/actix-web-codegen/src/route.rs
@@ -229,10 +229,9 @@ impl Route {
         //
         // Note that multi line doc comments are converted to multiple doc
         // attributes.
-        let mut doc_attribute = Vec::new();
+        let mut doc_attributes = Vec::new();
         for attr in &ast.attrs {
-            if let Some(ident) = attr.path.get_ident() {
-                if ident == "doc" {
+            if attr.path.get_ident().is_ident("doc") {
                     doc_attribute.push(attr.clone());
                 }
             }
@@ -283,7 +282,7 @@ impl ToTokens for Route {
                     methods,
                 },
             resource_type,
-            doc_attributes: doc_attribute,
+            doc_attributes,
         } = self;
         let resource_name = name.to_string();
         let method_guards = {
@@ -311,7 +310,7 @@ impl ToTokens for Route {
             .collect();
 
         let stream = quote! {
-            #doc_comment_token_stream
+            #(#doc_comments)*
             #[allow(non_camel_case_types, missing_docs)]
             pub struct #name;
 

--- a/actix-web-codegen/tests/trybuild.rs
+++ b/actix-web-codegen/tests/trybuild.rs
@@ -9,6 +9,8 @@ fn compile_macros() {
     t.compile_fail("tests/trybuild/route-missing-method-fail.rs");
     t.compile_fail("tests/trybuild/route-duplicate-method-fail.rs");
     t.compile_fail("tests/trybuild/route-unexpected-method-fail.rs");
+
+    t.pass("tests/trybuild/docstring-ok.rs");
 }
 
 // #[rustversion::not(nightly)]

--- a/actix-web-codegen/tests/trybuild/docstring-ok.rs
+++ b/actix-web-codegen/tests/trybuild/docstring-ok.rs
@@ -1,0 +1,17 @@
+use actix_web::{Responder, HttpResponse, App, test};
+use actix_web_codegen::*;
+
+/// Docstrings shouldn't break anything.
+#[get("/")]
+async fn index() -> impl Responder {
+    HttpResponse::Ok()
+}
+
+#[actix_web::main]
+async fn main() {
+    let srv = test::start(|| App::new().service(index));
+
+    let request = srv.get("/");
+    let response = request.send().await.unwrap();
+    assert!(response.status().is_success());
+}


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Bug Fix / Feature

## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview

This allows documentation on the functions to appear in the generated
docs, e.g.:

```rust
/// The index page
async fn index() -> &'static str {
    "Hello!"
}
```

Closes #1389

--- 

I'm afraid I have no idea how to add tests for this beyond making sure this doesn't break when using docstrings.