### PR TITLE
make actix_http::ws::Codec::new const

### DIFF
--- a/actix-http/src/ws/codec.rs
+++ b/actix-http/src/ws/codec.rs
@@ -80,7 +80,7 @@ bitflags! {
 
 impl Codec {
     /// Create new WebSocket frames decoder.
-    pub fn new() -> Codec {
+    pub const fn new() -> Codec {
         Codec {
             max_size: 65_536,
             flags: Flags::SERVER,


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Feature


## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Make `actix_http::ws::Codec::new` const. This would enable default const websocket codec through `FromRequest::Config`

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
