### PR TITLE
json method receives plain serialize

### DIFF
--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -4,6 +4,7 @@
 ### Changed
 * Feature `cookies` is now optional and disabled by default. [#1981]
 * `ws::hash_key` now returns array. [#2035]
+* `ResponseBuilder::json` now takes `impl Serialize`. [#2052]
 
 ### Removed
 * re-export of `futures_channel::oneshot::Canceled` is removed from `error` mod. [#1994]
@@ -12,6 +13,7 @@
 [#1981]: https://github.com/actix/actix-web/pull/1981
 [#1994]: https://github.com/actix/actix-web/pull/1994
 [#2035]: https://github.com/actix/actix-web/pull/2035
+[#2052]: https://github.com/actix/actix-web/pull/2052
 
 
 ## 3.0.0-beta.3 - 2021-02-10

--- a/src/data.rs
+++ b/src/data.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use actix_http::error::{Error, ErrorInternalServerError};
 use actix_http::Extensions;
 use futures_util::future::{err, ok, LocalBoxFuture, Ready};
+use serde::Serialize;
 
 use crate::dev::Payload;
 use crate::extract::FromRequest;
@@ -99,6 +100,18 @@ impl<T: ?Sized> Clone for Data<T> {
 impl<T: ?Sized> From<Arc<T>> for Data<T> {
     fn from(arc: Arc<T>) -> Self {
         Data(arc)
+    }
+}
+
+impl<T> Serialize for Data<T>
+where
+    T: Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.0.serialize(serializer)
     }
 }
 

--- a/src/types/form.rs
+++ b/src/types/form.rs
@@ -106,6 +106,18 @@ impl<T> ops::DerefMut for Form<T> {
     }
 }
 
+impl<T> Serialize for Form<T>
+where
+    T: Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+
 /// See [here](#extractor) for example of usage as an extractor.
 impl<T> FromRequest for Form<T>
 where

--- a/src/types/json.rs
+++ b/src/types/json.rs
@@ -114,6 +114,18 @@ where
     }
 }
 
+impl<T> Serialize for Json<T>
+where
+    T: Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+
 /// Creates response with OK status code, correct content type header, and serialized JSON payload.
 ///
 /// If serialization failed


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Refactor


## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
Following on from discussion in issue (tl;dr we want to support T and &T with a single method and generall support as many variants of Serialize as possible), this might be a suitable replacement for the weird signature .json has now while supporting all it's current use cases and more; plus better error messages.

closes #2047
