### PR TITLE
remove ka timer from h2 dispatcher

### DIFF
--- a/actix-http/src/h2/dispatcher.rs
+++ b/actix-http/src/h2/dispatcher.rs
@@ -2,7 +2,6 @@ use std::task::{Context, Poll};
 use std::{cmp, future::Future, marker::PhantomData, net, pin::Pin, rc::Rc};
 
 use actix_codec::{AsyncRead, AsyncWrite};
-use actix_rt::time::{Instant, Sleep};
 use actix_service::Service;
 use bytes::{Bytes, BytesMut};
 use futures_core::ready;
@@ -36,8 +35,6 @@ where
     on_connect_data: OnConnectData,
     config: ServiceConfig,
     peer_addr: Option<net::SocketAddr>,
-    ka_expire: Instant,
-    ka_timer: Option<Sleep>,
     _phantom: PhantomData<B>,
 }
 
@@ -54,33 +51,14 @@ where
         connection: Connection<T, Bytes>,
         on_connect_data: OnConnectData,
         config: ServiceConfig,
-        timeout: Option<Sleep>,
         peer_addr: Option<net::SocketAddr>,
     ) -> Self {
-        // let keepalive = config.keep_alive_enabled();
-        // let flags = if keepalive {
-        // Flags::KEEPALIVE | Flags::KEEPALIVE_ENABLED
-        // } else {
-        //     Flags::empty()
-        // };
-
-        // keep-alive timer
-        let (ka_expire, ka_timer) = if let Some(delay) = timeout {
-            (delay.deadline(), Some(delay))
-        } else if let Some(delay) = config.keep_alive_timer() {
-            (delay.deadline(), Some(delay))
-        } else {
-            (config.now(), None)
-        };
-
         Dispatcher {
             flow,
             config,
             peer_addr,
             connection,
             on_connect_data,
-            ka_expire,
-            ka_timer,
             _phantom: PhantomData,
         }
     }
@@ -108,13 +86,6 @@ where
                 Some(Err(err)) => return Poll::Ready(Err(err.into())),
 
                 Some(Ok((req, res))) => {
-                    // update keep-alive expire
-                    if this.ka_timer.is_some() {
-                        if let Some(expire) = this.config.keep_alive_expire() {
-                            this.ka_expire = expire;
-                        }
-                    }
-
                     let (parts, body) = req.into_parts();
                     let pl = crate::h2::Payload::new(body);
                     let pl = Payload::<crate::payload::PayloadStream>::H2(pl);
@@ -130,7 +101,7 @@ where
                     // merge on_connect_ext data into request extensions
                     this.on_connect_data.merge_into(&mut req);
 
-                    let svc = ServiceResponse::<S::Future, S::Response, S::Error, B> {
+                    let svc = ServiceResponse {
                         state: ServiceResponseState::ServiceCall(
                             this.flow.service.call(req),
                             Some(res),
@@ -312,57 +283,50 @@ where
 
             ServiceResponseStateProj::SendPayload(ref mut stream, ref mut body) => {
                 loop {
-                    loop {
-                        match this.buffer {
-                            Some(ref mut buffer) => {
-                                match ready!(stream.poll_capacity(cx)) {
-                                    None => return Poll::Ready(()),
+                    match this.buffer {
+                        Some(ref mut buffer) => match ready!(stream.poll_capacity(cx)) {
+                            None => return Poll::Ready(()),
 
-                                    Some(Ok(cap)) => {
-                                        let len = buffer.len();
-                                        let bytes = buffer.split_to(cmp::min(cap, len));
+                            Some(Ok(cap)) => {
+                                let len = buffer.len();
+                                let bytes = buffer.split_to(cmp::min(cap, len));
 
-                                        if let Err(e) = stream.send_data(bytes, false) {
-                                            warn!("{:?}", e);
-                                            return Poll::Ready(());
-                                        } else if !buffer.is_empty() {
-                                            let cap = cmp::min(buffer.len(), CHUNK_SIZE);
-                                            stream.reserve_capacity(cap);
-                                        } else {
-                                            this.buffer.take();
-                                        }
-                                    }
-
-                                    Some(Err(e)) => {
-                                        warn!("{:?}", e);
-                                        return Poll::Ready(());
-                                    }
+                                if let Err(e) = stream.send_data(bytes, false) {
+                                    warn!("{:?}", e);
+                                    return Poll::Ready(());
+                                } else if !buffer.is_empty() {
+                                    let cap = cmp::min(buffer.len(), CHUNK_SIZE);
+                                    stream.reserve_capacity(cap);
+                                } else {
+                                    this.buffer.take();
                                 }
                             }
 
-                            None => match ready!(body.as_mut().poll_next(cx)) {
-                                None => {
-                                    if let Err(e) = stream.send_data(Bytes::new(), true)
-                                    {
-                                        warn!("{:?}", e);
-                                    }
-                                    return Poll::Ready(());
-                                }
+                            Some(Err(e)) => {
+                                warn!("{:?}", e);
+                                return Poll::Ready(());
+                            }
+                        },
 
-                                Some(Ok(chunk)) => {
-                                    stream.reserve_capacity(cmp::min(
-                                        chunk.len(),
-                                        CHUNK_SIZE,
-                                    ));
-                                    *this.buffer = Some(chunk);
+                        None => match ready!(body.as_mut().poll_next(cx)) {
+                            None => {
+                                if let Err(e) = stream.send_data(Bytes::new(), true) {
+                                    warn!("{:?}", e);
                                 }
+                                return Poll::Ready(());
+                            }
 
-                                Some(Err(e)) => {
-                                    error!("Response payload stream error: {:?}", e);
-                                    return Poll::Ready(());
-                                }
-                            },
-                        }
+                            Some(Ok(chunk)) => {
+                                stream
+                                    .reserve_capacity(cmp::min(chunk.len(), CHUNK_SIZE));
+                                *this.buffer = Some(chunk);
+                            }
+
+                            Some(Err(e)) => {
+                                error!("Response payload stream error: {:?}", e);
+                                return Poll::Ready(());
+                            }
+                        },
                     }
                 }
             }

--- a/actix-http/src/h2/service.rs
+++ b/actix-http/src/h2/service.rs
@@ -368,7 +368,6 @@ where
                         conn,
                         on_connect_data,
                         config.take().unwrap(),
-                        None,
                         *peer_addr,
                     ));
                     self.poll(cx)

--- a/actix-http/src/service.rs
+++ b/actix-http/src/service.rs
@@ -658,7 +658,6 @@ where
                             conn,
                             on_connect_data,
                             cfg,
-                            None,
                             peer_addr,
                         )));
                         self.poll(cx)


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Refactor


## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Remove keep alive timer from h2 dispatcher. The timer is not used (no poll of the timer exist so it does not take part in the future execution) This would fix the clippy warning in CI.

Remove the nest loop in `ServiceResponseStateProj::SendPayload` variant 

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
