### PR TITLE
remove actix_http::client::pool::Protocol

### DIFF
--- a/actix-http/src/client/mod.rs
+++ b/actix-http/src/client/mod.rs
@@ -17,7 +17,7 @@ pub use actix_tls::connect::{
 pub use self::connection::Connection;
 pub use self::connector::Connector;
 pub use self::error::{ConnectError, FreezeRequestError, InvalidUrl, SendRequestError};
-pub use self::pool::Protocol;
+pub use crate::Protocol;
 
 #[derive(Clone)]
 pub struct Connect {


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Refactor


## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Remove `actix_http::client::pool::Protocol` type. Use `actix_http::Protocol` instead.
Client export Protocol as public type but it's not possible to enable Http3 variant and an assert in `actix_http::client::connector` for double check is added.

Remove a couple of unused Clones.

Fix doc where default connector timeout setting is wrong.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
