### PR TITLE
simplify connector generic type

### DIFF
--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -1,6 +1,10 @@
 # Changes
 
 ## Unreleased - 2021-xx-xx
+### Chaged
+* `client::Connector` type now only have one generic type for `actix_service::Service`. [#2063]
+
+[#2063]: https://github.com/actix/actix-web/pull/2063
 
 
 ## 3.0.0-beta.4 - 2021-03-08

--- a/awc/src/lib.rs
+++ b/awc/src/lib.rs
@@ -175,7 +175,6 @@ impl Client {
                 Response = TcpConnection<Uri, TcpStream>,
                 Error = TcpConnectError,
             > + Clone,
-        TcpStream,
     > {
         ClientBuilder::new()
     }


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Refactor


## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Simplify `actix_http::client::Connector`'s generic type. Remove Stream type from the signature.

Call `ConnectionPoll as Service<Req>::poll_ready` when tls connection pool is enabled. The current tls services use no op `poll_ready` impl but this change would make sure future changes to it would not inferior the ready state check. 

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
