### PR TITLE
remove cookie support from -http

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,7 @@
 [alias]
 chk = "hack check --workspace --all-features --tests --examples"
 lint = "hack --clean-per-run clippy --workspace --tests --examples"
+ci-min = "hack check --workspace --no-default-features"
+ci-min-test = "hack check --workspace --no-default-features --tests --examples"
+ci-default = "hack check --workspace"
+ci-full = "check --workspace --bins --examples --tests"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,10 @@
 # Changes
 
 ## Unreleased - 2021-xx-xx
+### Added
+* `HttpResponse` and `HttpResponseBuilder` structs. [#2065]
 
+[#2065]: https://github.com/actix/actix-web/pull/2065
 
 ## 4.0.0-beta.5 - 2021-04-02
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 
 [package.metadata.docs.rs]
 # features that docs.rs will build with
-features = ["openssl", "rustls", "compress", "secure-cookies"]
+features = ["openssl", "rustls", "compress", "cookies", "secure-cookies"]
 
 [lib]
 name = "actix_web"
@@ -34,6 +34,7 @@ members = [
   "actix-http-test",
   "actix-test",
 ]
+resolver = "2"
 
 [features]
 default = ["compress", "cookies"]
@@ -52,22 +53,6 @@ openssl = ["actix-http/openssl", "actix-tls/accept", "actix-tls/openssl"]
 
 # rustls
 rustls = ["actix-http/rustls", "actix-tls/accept", "actix-tls/rustls"]
-
-[[example]]
-name = "basic"
-required-features = ["compress"]
-
-[[example]]
-name = "uds"
-required-features = ["compress"]
-
-[[test]]
-name = "test_server"
-required-features = ["compress", "cookies"]
-
-[[example]]
-name = "on_connect"
-required-features = []
 
 [dependencies]
 actix-codec = "0.4.0-beta.1"
@@ -134,6 +119,22 @@ actix-web = { path = "." }
 actix-web-actors = { path = "actix-web-actors" }
 actix-web-codegen = { path = "actix-web-codegen" }
 awc = { path = "awc" }
+
+[[test]]
+name = "test_server"
+required-features = ["compress", "cookies"]
+
+[[example]]
+name = "basic"
+required-features = ["compress"]
+
+[[example]]
+name = "uds"
+required-features = ["compress"]
+
+[[example]]
+name = "on_connect"
+required-features = []
 
 [[bench]]
 name = "server"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,6 @@ edition = "2018"
 # features that docs.rs will build with
 features = ["openssl", "rustls", "compress", "secure-cookies"]
 
-[badges]
-travis-ci = { repository = "actix/actix-web", branch = "master" }
-codecov = { repository = "actix/actix-web", branch = "master", service = "github" }
-
 [lib]
 name = "actix_web"
 path = "src/lib.rs"
@@ -46,10 +42,10 @@ default = ["compress", "cookies"]
 compress = ["actix-http/compress"]
 
 # support for cookies
-cookies = ["actix-http/cookies"]
+cookies = ["cookie"]
 
 # secure cookies feature
-secure-cookies = ["actix-http/secure-cookies"]
+secure-cookies = ["cookie/secure"]
 
 # openssl
 openssl = ["actix-http/openssl", "actix-tls/accept", "actix-tls/openssl"]
@@ -88,7 +84,7 @@ actix-http = "3.0.0-beta.5"
 
 ahash = "0.7"
 bytes = "1"
-cookie = "0.15"
+cookie = { version = "0.15", features = ["percent-encode"], optional = true }
 derive_more = "0.99.5"
 either = "1.5.3"
 encoding_rs = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,7 @@ actix-http = "3.0.0-beta.5"
 
 ahash = "0.7"
 bytes = "1"
+cookie = "0.15"
 derive_more = "0.99.5"
 either = "1.5.3"
 encoding_rs = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,8 @@ members = [
   "actix-http-test",
   "actix-test",
 ]
-resolver = "2"
+# enable when MSRV is 1.51+
+# resolver = "2"
 
 [features]
 default = ["compress", "cookies"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,7 @@ either = "1.5.3"
 encoding_rs = "0.8"
 futures-core = { version = "0.3.7", default-features = false }
 futures-util = { version = "0.3.7", default-features = false }
+itoa = "0.4"
 language-tags = "0.2"
 once_cell = "1.5"
 log = "0.4"

--- a/actix-files/src/error.rs
+++ b/actix-files/src/error.rs
@@ -1,4 +1,4 @@
-use actix_web::{http::StatusCode, HttpResponse, ResponseError};
+use actix_web::{http::StatusCode, ResponseError};
 use derive_more::Display;
 
 /// Errors which can occur when serving static files.
@@ -16,8 +16,8 @@ pub enum FilesError {
 
 /// Return `NotFound` for `FilesError`
 impl ResponseError for FilesError {
-    fn error_response(&self) -> HttpResponse {
-        HttpResponse::new(StatusCode::NOT_FOUND)
+    fn status_code(&self) -> StatusCode {
+        StatusCode::NOT_FOUND
     }
 }
 

--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -2,8 +2,13 @@
 
 ## Unreleased - 2021-xx-xx
 ### Removed
-* `HttpMessage::cookies` and `HttpMessage::cookie`. [#????]
-* `impl ResponseError for CookieParseError`. [#????]
+* `cookies` feature flag. [#2065]
+* Top-level `cookies` mod (re-export). [#2065]
+* `HttpMessage` trait loses the `cookies` and `cookie` methods. [#2065]
+* `impl ResponseError for CookieParseError`. [#2065]
+
+[#2065]: https://github.com/actix/actix-web/pull/2065
+
 
 ## 3.0.0-beta.5 - 2021-04-02
 ### Added

--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -1,7 +1,9 @@
 # Changes
 
 ## Unreleased - 2021-xx-xx
-
+### Removed
+* `HttpMessage::cookies` and `HttpMessage::cookie`. [#????]
+* `impl ResponseError for CookieParseError`. [#????]
 
 ## 3.0.0-beta.5 - 2021-04-02
 ### Added

--- a/actix-http/Cargo.toml
+++ b/actix-http/Cargo.toml
@@ -55,7 +55,7 @@ base64 = "0.13"
 bitflags = "1.2"
 bytes = "1"
 bytestring = "1"
-cookie = { version = "0.14.1", features = ["percent-encode"], optional = true }
+cookie = { version = "0.15", features = ["percent-encode"], optional = true }
 derive_more = "0.99.5"
 encoding_rs = "0.8"
 futures-core = { version = "0.3.7", default-features = false, features = ["alloc"] }

--- a/actix-http/Cargo.toml
+++ b/actix-http/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 
 [package.metadata.docs.rs]
 # features that docs.rs will build with
-features = ["openssl", "rustls", "compress", "cookies", "secure-cookies"]
+features = ["openssl", "rustls", "compress"]
 
 [lib]
 name = "actix_http"
@@ -34,12 +34,6 @@ rustls = ["actix-tls/rustls"]
 # enable compression support
 compress = ["flate2", "brotli2"]
 
-# support for cookies
-cookies = ["cookie"]
-
-# support for secure cookies
-secure-cookies = ["cookies", "cookie/secure"]
-
 # trust-dns as client dns resolver
 trust-dns = ["trust-dns-resolver"]
 
@@ -55,7 +49,6 @@ base64 = "0.13"
 bitflags = "1.2"
 bytes = "1"
 bytestring = "1"
-cookie = { version = "0.15", features = ["percent-encode"], optional = true }
 derive_more = "0.99.5"
 encoding_rs = "0.8"
 futures-core = { version = "0.3.7", default-features = false, features = ["alloc"] }
@@ -95,7 +88,7 @@ actix-tls = { version = "3.0.0-beta.5", features = ["openssl"] }
 criterion = "0.3"
 env_logger = "0.8"
 rcgen = "0.8"
-serde_derive = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 tls-openssl = { version = "0.10", package = "openssl" }
 tls-rustls = { version = "0.19", package = "rustls" }
 

--- a/actix-http/examples/ws.rs
+++ b/actix-http/examples/ws.rs
@@ -36,12 +36,12 @@ async fn main() -> io::Result<()> {
 
 async fn handler(req: Request) -> Result<Response<BodyStream<Heartbeat>>, Error> {
     log::info!("handshaking");
-    let res = ws::handshake(req.head())?;
+    let mut res = ws::handshake(req.head())?;
 
     // handshake will always fail under HTTP/2
 
     log::info!("responding");
-    Ok(res.set_body(BodyStream::new(Heartbeat::new(ws::Codec::new()))))
+    Ok(res.message_body(BodyStream::new(Heartbeat::new(ws::Codec::new()))))
 }
 
 struct Heartbeat {

--- a/actix-http/examples/ws.rs
+++ b/actix-http/examples/ws.rs
@@ -11,7 +11,7 @@ use std::{
 };
 
 use actix_codec::Encoder;
-use actix_http::{error::Error, ws, HttpService, Request, Response};
+use actix_http::{body::BodyStream, error::Error, ws, HttpService, Request, Response};
 use actix_rt::time::{interval, Interval};
 use actix_server::Server;
 use bytes::{Bytes, BytesMut};
@@ -34,14 +34,14 @@ async fn main() -> io::Result<()> {
         .await
 }
 
-async fn handler(req: Request) -> Result<Response, Error> {
+async fn handler(req: Request) -> Result<Response<BodyStream<Heartbeat>>, Error> {
     log::info!("handshaking");
-    let mut res = ws::handshake(req.head())?;
+    let res = ws::handshake(req.head())?;
 
     // handshake will always fail under HTTP/2
 
     log::info!("responding");
-    Ok(res.streaming(Heartbeat::new(ws::Codec::new())))
+    Ok(res.set_body(BodyStream::new(Heartbeat::new(ws::Codec::new()))))
 }
 
 struct Heartbeat {

--- a/actix-http/src/error.rs
+++ b/actix-http/src/error.rs
@@ -16,7 +16,7 @@ use serde_urlencoded::ser::Error as FormError;
 
 use crate::body::Body;
 use crate::helpers::Writer;
-use crate::response::{Response, ResponseBuilder};
+use crate::response::Response;
 
 /// A specialized [`std::result::Result`]
 /// for actix web operations
@@ -135,12 +135,12 @@ impl From<Response> for Error {
     }
 }
 
-/// Convert ResponseBuilder to a Error
-impl From<ResponseBuilder> for Error {
-    fn from(mut res: ResponseBuilder) -> Error {
-        InternalError::from_response("", res.finish()).into()
-    }
-}
+// /// Convert ResponseBuilder to a Error
+// impl From<ResponseBuilder> for Error {
+//     fn from(mut res: ResponseBuilder) -> Error {
+//         InternalError::from_response("", res.finish()).into()
+//     }
+// }
 
 #[derive(Debug, Display)]
 #[display(fmt = "UnknownError")]

--- a/actix-http/src/error.rs
+++ b/actix-http/src/error.rs
@@ -18,9 +18,6 @@ use crate::body::Body;
 use crate::helpers::Writer;
 use crate::response::{Response, ResponseBuilder};
 
-#[cfg(feature = "cookies")]
-pub use crate::cookie::ParseError as CookieParseError;
-
 /// A specialized [`std::result::Result`]
 /// for actix web operations
 ///
@@ -375,14 +372,6 @@ impl ResponseError for PayloadError {
             PayloadError::Overflow => StatusCode::PAYLOAD_TOO_LARGE,
             _ => StatusCode::BAD_REQUEST,
         }
-    }
-}
-
-/// Return `BadRequest` for `cookie::ParseError`
-#[cfg(feature = "cookies")]
-impl ResponseError for crate::cookie::ParseError {
-    fn status_code(&self) -> StatusCode {
-        StatusCode::BAD_REQUEST
     }
 }
 
@@ -957,13 +946,6 @@ mod tests {
         let err: HttpError = StatusCode::from_u16(10000).err().unwrap().into();
         let resp: Response = err.error_response();
         assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
-    }
-
-    #[cfg(feature = "cookies")]
-    #[test]
-    fn test_cookie_parse() {
-        let resp: Response = CookieParseError::EmptyName.error_response();
-        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     }
 
     #[test]

--- a/actix-http/src/error.rs
+++ b/actix-http/src/error.rs
@@ -14,9 +14,7 @@ use serde::de::value::Error as DeError;
 use serde_json::error::Error as JsonError;
 use serde_urlencoded::ser::Error as FormError;
 
-use crate::body::Body;
-use crate::helpers::Writer;
-use crate::response::Response;
+use crate::{body::Body, helpers::Writer, Response, ResponseBuilder};
 
 /// A specialized [`std::result::Result`]
 /// for actix web operations
@@ -135,12 +133,12 @@ impl From<Response> for Error {
     }
 }
 
-// /// Convert ResponseBuilder to a Error
-// impl From<ResponseBuilder> for Error {
-//     fn from(mut res: ResponseBuilder) -> Error {
-//         InternalError::from_response("", res.finish()).into()
-//     }
-// }
+/// Convert ResponseBuilder to a Error
+impl From<ResponseBuilder> for Error {
+    fn from(mut res: ResponseBuilder) -> Error {
+        InternalError::from_response("", res.finish()).into()
+    }
+}
 
 #[derive(Debug, Display)]
 #[display(fmt = "UnknownError")]

--- a/actix-http/src/h1/dispatcher.rs
+++ b/actix-http/src/h1/dispatcher.rs
@@ -340,13 +340,15 @@ where
                 StateProj::ServiceCall(fut) => match fut.poll(cx) {
                     // service call resolved. send response.
                     Poll::Ready(Ok(res)) => {
+                        eprintln!("dispatcher ok!");
                         let (res, body) = res.into().replace_body(());
                         self.as_mut().send_response(res, body)?;
                     }
 
                     // send service call error as response
                     Poll::Ready(Err(err)) => {
-                        let res: Response = err.into().into();
+                        eprintln!("dispatcher err");
+                        let res = Response::from_error(err.into());
                         let (res, body) = res.replace_body(());
                         self.as_mut().send_response(res, body.into_body())?;
                     }

--- a/actix-http/src/h1/dispatcher.rs
+++ b/actix-http/src/h1/dispatcher.rs
@@ -340,14 +340,12 @@ where
                 StateProj::ServiceCall(fut) => match fut.poll(cx) {
                     // service call resolved. send response.
                     Poll::Ready(Ok(res)) => {
-                        eprintln!("dispatcher ok!");
                         let (res, body) = res.into().replace_body(());
                         self.as_mut().send_response(res, body)?;
                     }
 
                     // send service call error as response
                     Poll::Ready(Err(err)) => {
-                        eprintln!("dispatcher err");
                         let res = Response::from_error(err.into());
                         let (res, body) = res.replace_body(());
                         self.as_mut().send_response(res, body.into_body())?;

--- a/actix-http/src/http_message.rs
+++ b/actix-http/src/http_message.rs
@@ -126,19 +126,6 @@ pub trait HttpMessage: Sized {
             &ext.get::<Cookies>().unwrap().0
         }))
     }
-
-    /// Return request cookie.
-    #[cfg(feature = "cookies")]
-    fn cookie(&self, name: &str) -> Option<Cookie<'static>> {
-        if let Ok(cookies) = self.cookies() {
-            for cookie in cookies.iter() {
-                if cookie.name() == name {
-                    return Some(cookie.to_owned());
-                }
-            }
-        }
-        None
-    }
 }
 
 impl<'a, T> HttpMessage for &'a mut T

--- a/actix-http/src/lib.rs
+++ b/actix-http/src/lib.rs
@@ -6,13 +6,11 @@
 //! | `openssl`        | TLS support via [OpenSSL].                            |
 //! | `rustls`         | TLS support via [rustls].                             |
 //! | `compress`       | Payload compression support. (Deflate, Gzip & Brotli) |
-//! | `cookies`        | Support for cookies backed by the [cookie] crate.     |
 //! | `secure-cookies` | Adds for secure cookies. Enables `cookies` feature.   |
 //! | `trust-dns`      | Use [trust-dns] as the client DNS resolver.           |
 //!
 //! [OpenSSL]: https://crates.io/crates/openssl
 //! [rustls]: https://crates.io/crates/rustls
-//! [cookie]: https://crates.io/crates/cookie
 //! [trust-dns]: https://crates.io/crates/trust-dns
 
 #![deny(rust_2018_idioms, nonstandard_style)]
@@ -56,7 +54,7 @@ pub mod test;
 pub mod ws;
 
 #[cfg(feature = "cookies")]
-pub use cookie;
+use cookie;
 
 pub use self::builder::HttpServiceBuilder;
 pub use self::config::{KeepAlive, ServiceConfig};

--- a/actix-http/src/lib.rs
+++ b/actix-http/src/lib.rs
@@ -53,9 +53,6 @@ pub mod h2;
 pub mod test;
 pub mod ws;
 
-#[cfg(feature = "cookies")]
-use cookie;
-
 pub use self::builder::HttpServiceBuilder;
 pub use self::config::{KeepAlive, ServiceConfig};
 pub use self::error::{Error, ResponseError, Result};
@@ -76,8 +73,6 @@ pub mod http {
     pub use http::{uri, Error, Uri};
     pub use http::{Method, StatusCode, Version};
 
-    #[cfg(feature = "cookies")]
-    pub use crate::cookie::{Cookie, CookieBuilder};
     pub use crate::header::HeaderMap;
 
     /// A collection of HTTP headers and helpers.

--- a/actix-http/src/message.rs
+++ b/actix-http/src/message.rs
@@ -345,8 +345,8 @@ impl ResponseHead {
 }
 
 pub struct Message<T: Head> {
-    // Rc here should not be cloned by anyone.
-    // It's used to reuse allocation of T and no shared ownership is allowed.
+    /// Rc here should not be cloned by anyone.
+    /// It's used to reuse allocation of T and no shared ownership is allowed.
     head: Rc<T>,
 }
 

--- a/actix-http/src/request.rs
+++ b/actix-http/src/request.rs
@@ -5,6 +5,7 @@ use std::{
     fmt, net,
 };
 
+use cookie::Cookie;
 use http::{header, Method, Uri, Version};
 
 use crate::extensions::Extensions;
@@ -167,6 +168,20 @@ impl<P> Request<P> {
     #[inline]
     pub fn peer_addr(&self) -> Option<net::SocketAddr> {
         self.head().peer_addr
+    }
+
+    /// Return request cookie.
+    #[cfg(feature = "cookies")]
+    pub fn cookie(&self, name: &str) -> Option<Cookie<'static>> {
+        if let Ok(cookies) = self.cookies() {
+            for cookie in cookies.iter() {
+                if cookie.name() == name {
+                    return Some(cookie.to_owned());
+                }
+            }
+        }
+
+        None
     }
 }
 

--- a/actix-http/src/request.rs
+++ b/actix-http/src/request.rs
@@ -9,11 +9,14 @@ use std::{
 use cookie::{Cookie, ParseError as CookieParseError};
 use http::{header, Method, Uri, Version};
 
-use crate::extensions::Extensions;
-use crate::header::HeaderMap;
-use crate::message::{Message, RequestHead};
-use crate::payload::{Payload, PayloadStream};
-use crate::HttpMessage;
+
+use crate::{
+    extensions::Extensions,
+    header::HeaderMap,
+    message::{Message, RequestHead},
+    payload::{Payload, PayloadStream},
+    HttpMessage,
+};
 
 #[cfg(feature = "cookies")]
 struct Cookies(Vec<Cookie<'static>>);

--- a/actix-http/src/request.rs
+++ b/actix-http/src/request.rs
@@ -9,7 +9,6 @@ use std::{
 use cookie::{Cookie, ParseError as CookieParseError};
 use http::{header, Method, Uri, Version};
 
-
 use crate::{
     extensions::Extensions,
     header::HeaderMap,

--- a/actix-http/src/response.rs
+++ b/actix-http/src/response.rs
@@ -892,9 +892,9 @@ mod tests {
 
     use super::*;
     use crate::body::Body;
-    use crate::http::header::{HeaderValue, CONTENT_TYPE, COOKIE};
     #[cfg(feature = "cookies")]
-    use crate::{http::header::SET_COOKIE, HttpMessage};
+    use crate::http::header::SET_COOKIE;
+    use crate::http::header::{HeaderValue, CONTENT_TYPE, COOKIE};
 
     #[test]
     fn test_debug() {

--- a/actix-http/src/test.rs
+++ b/actix-http/src/test.rs
@@ -13,11 +13,6 @@ use actix_codec::{AsyncRead, AsyncWrite, ReadBuf};
 use bytes::{Bytes, BytesMut};
 use http::{Method, Uri, Version};
 
-#[cfg(feature = "cookies")]
-use crate::{
-    cookie::{Cookie, CookieJar},
-    header::{self, HeaderValue},
-};
 use crate::{
     header::{HeaderMap, IntoHeaderPair},
     payload::Payload,
@@ -54,8 +49,6 @@ struct Inner {
     method: Method,
     uri: Uri,
     headers: HeaderMap,
-    #[cfg(feature = "cookies")]
-    cookies: CookieJar,
     payload: Option<Payload>,
 }
 
@@ -66,8 +59,6 @@ impl Default for TestRequest {
             uri: Uri::from_str("/").unwrap(),
             version: Version::HTTP_11,
             headers: HeaderMap::new(),
-            #[cfg(feature = "cookies")]
-            cookies: CookieJar::new(),
             payload: None,
         }))
     }
@@ -134,13 +125,6 @@ impl TestRequest {
         self
     }
 
-    /// Set cookie for this request.
-    #[cfg(feature = "cookies")]
-    pub fn cookie<'a>(&mut self, cookie: Cookie<'a>) -> &mut Self {
-        parts(&mut self.0).cookies.add(cookie.into_owned());
-        self
-    }
-
     /// Set request payload.
     pub fn set_payload<B: Into<Bytes>>(&mut self, data: B) -> &mut Self {
         let mut payload = crate::h1::Payload::empty();
@@ -168,22 +152,6 @@ impl TestRequest {
         head.method = inner.method;
         head.version = inner.version;
         head.headers = inner.headers;
-
-        #[cfg(feature = "cookies")]
-        {
-            let cookie: String = inner
-                .cookies
-                .delta()
-                // ensure only name=value is written to cookie header
-                .map(|c| Cookie::new(c.name(), c.value()).encoded().to_string())
-                .collect::<Vec<_>>()
-                .join("; ");
-
-            if !cookie.is_empty() {
-                head.headers
-                    .insert(header::COOKIE, HeaderValue::from_str(&cookie).unwrap());
-            }
-        }
 
         req
     }

--- a/actix-http/tests/test_ws.rs
+++ b/actix-http/tests/test_ws.rs
@@ -52,7 +52,7 @@ where
 
     fn call(&self, (req, mut framed): (Request, Framed<T, h1::Codec>)) -> Self::Future {
         let fut = async move {
-            let res = ws::handshake(req.head()).unwrap().message_body(());
+            let res = ws::handshake(req.head()).unwrap().set_body(());
 
             framed
                 .send((res, body::BodySize::None).into())

--- a/actix-http/tests/test_ws.rs
+++ b/actix-http/tests/test_ws.rs
@@ -52,7 +52,7 @@ where
 
     fn call(&self, (req, mut framed): (Request, Framed<T, h1::Codec>)) -> Self::Future {
         let fut = async move {
-            let res = ws::handshake(req.head()).unwrap().set_body(());
+            let res = ws::handshake(req.head()).unwrap().message_body(());
 
             framed
                 .send((res, body::BodySize::None).into())

--- a/actix-multipart/src/error.rs
+++ b/actix-multipart/src/error.rs
@@ -45,11 +45,10 @@ impl ResponseError for MultipartError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use actix_web::HttpResponse;
 
     #[test]
     fn test_multipart_error() {
-        let resp: HttpResponse = MultipartError::Boundary.error_response();
+        let resp = MultipartError::Boundary.error_response();
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     }
 }

--- a/actix-test/Cargo.toml
+++ b/actix-test/Cargo.toml
@@ -20,7 +20,7 @@ openssl = ["tls-openssl", "actix-http/openssl"]
 
 [dependencies]
 actix-codec = "0.4.0-beta.1"
-actix-http = { version = "3.0.0-beta.5", features = ["cookies"] }
+actix-http = "3.0.0-beta.5"
 actix-http-test = { version = "3.0.0-beta.4", features = [] }
 actix-service = "2.0.0-beta.4"
 actix-utils = "3.0.0-beta.2"

--- a/actix-test/src/lib.rs
+++ b/actix-test/src/lib.rs
@@ -37,12 +37,12 @@ use actix_codec::{AsyncRead, AsyncWrite, Framed};
 pub use actix_http::test::TestBuffer;
 use actix_http::{
     http::{HeaderMap, Method},
-    ws, HttpService, Request,
+    ws, HttpService, Request, Response,
 };
 use actix_service::{map_config, IntoServiceFactory, ServiceFactory};
 use actix_web::{
     dev::{AppConfig, MessageBody, Server, Service},
-    rt, web, Error, HttpResponse,
+    rt, web, Error,
 };
 use awc::{error::PayloadError, Client, ClientRequest, ClientResponse, Connector};
 use futures_core::Stream;
@@ -83,7 +83,7 @@ where
     S: ServiceFactory<Request, Config = AppConfig> + 'static,
     S::Error: Into<Error> + 'static,
     S::InitError: fmt::Debug,
-    S::Response: Into<HttpResponse<B>> + 'static,
+    S::Response: Into<Response<B>> + 'static,
     <S::Service as Service<Request>>::Future: 'static,
     B: MessageBody + 'static,
 {
@@ -122,7 +122,7 @@ where
     S: ServiceFactory<Request, Config = AppConfig> + 'static,
     S::Error: Into<Error> + 'static,
     S::InitError: fmt::Debug,
-    S::Response: Into<HttpResponse<B>> + 'static,
+    S::Response: Into<Response<B>> + 'static,
     <S::Service as Service<Request>>::Future: 'static,
     B: MessageBody + 'static,
 {

--- a/actix-web-actors/src/ws.rs
+++ b/actix-web-actors/src/ws.rs
@@ -22,9 +22,9 @@ use actix_http::{
     http::HeaderValue,
     ws::{hash_key, Codec},
 };
-use actix_web::HttpResponseBuilder;
 use actix_web::error::{Error, PayloadError};
 use actix_web::http::{header, Method, StatusCode};
+use actix_web::HttpResponseBuilder;
 use actix_web::{HttpRequest, HttpResponse};
 use bytes::{Bytes, BytesMut};
 use bytestring::ByteString;

--- a/actix-web-actors/src/ws.rs
+++ b/actix-web-actors/src/ws.rs
@@ -22,7 +22,7 @@ use actix_http::{
     http::HeaderValue,
     ws::{hash_key, Codec},
 };
-use actix_web::dev::HttpResponseBuilder;
+use actix_web::HttpResponseBuilder;
 use actix_web::error::{Error, PayloadError};
 use actix_web::http::{header, Method, StatusCode};
 use actix_web::{HttpRequest, HttpResponse};
@@ -163,7 +163,7 @@ pub fn handshake_with_protocols(
                     .find(|req_p| protocols.iter().any(|p| p == req_p))
             });
 
-    let mut response = HttpResponse::build(StatusCode::SWITCHING_PROTOCOLS)
+    let mut response = HttpResponseBuilder::new(StatusCode::SWITCHING_PROTOCOLS)
         .upgrade("websocket")
         .insert_header((
             header::SEC_WEBSOCKET_ACCEPT,

--- a/actix-web-actors/src/ws.rs
+++ b/actix-web-actors/src/ws.rs
@@ -163,7 +163,7 @@ pub fn handshake_with_protocols(
                     .find(|req_p| protocols.iter().any(|p| p == req_p))
             });
 
-    let mut response = HttpResponseBuilder::new(StatusCode::SWITCHING_PROTOCOLS)
+    let mut response = HttpResponse::build(StatusCode::SWITCHING_PROTOCOLS)
         .upgrade("websocket")
         .insert_header((
             header::SEC_WEBSOCKET_ACCEPT,

--- a/awc/Cargo.toml
+++ b/awc/Cargo.toml
@@ -54,6 +54,7 @@ actix-rt = { version = "2.1", default-features = false }
 
 base64 = "0.13"
 bytes = "1"
+cookie = "0.15"
 derive_more = "0.99.5"
 futures-core = { version = "0.3.7", default-features = false }
 itoa = "0.4"

--- a/awc/Cargo.toml
+++ b/awc/Cargo.toml
@@ -41,7 +41,7 @@ rustls = ["tls-rustls", "actix-http/rustls"]
 compress = ["actix-http/compress"]
 
 # cookie parsing and cookie jar
-cookies = ["actix-http/cookies"]
+cookies = ["cookie"]
 
 # trust-dns as dns resolver
 trust-dns = ["actix-http/trust-dns"]
@@ -54,7 +54,7 @@ actix-rt = { version = "2.1", default-features = false }
 
 base64 = "0.13"
 bytes = "1"
-cookie = "0.15"
+cookie = { version = "0.15", features = ["percent-encode"], optional = true }
 derive_more = "0.99.5"
 futures-core = { version = "0.3.7", default-features = false }
 itoa = "0.4"

--- a/awc/src/lib.rs
+++ b/awc/src/lib.rs
@@ -93,12 +93,11 @@
 #![doc(html_logo_url = "https://actix.rs/img/logo.png")]
 #![doc(html_favicon_url = "https://actix.rs/favicon.ico")]
 
-use std::convert::TryFrom;
-use std::rc::Rc;
-use std::time::Duration;
+use std::{convert::TryFrom, rc::Rc, time::Duration};
 
 #[cfg(feature = "cookies")]
-pub use actix_http::cookie;
+pub use cookie;
+
 pub use actix_http::{client::Connector, http};
 
 use actix_http::{

--- a/awc/src/request.rs
+++ b/awc/src/request.rs
@@ -271,7 +271,7 @@ impl ClientRequest {
     /// async fn main() {
     ///     let resp = awc::Client::new().get("https://www.rust-lang.org")
     ///         .cookie(
-    ///             awc::http::Cookie::build("name", "value")
+    ///             awc::cookie::Cookie::build("name", "value")
     ///                 .domain("www.rust-lang.org")
     ///                 .path("/")
     ///                 .secure(true)

--- a/awc/src/request.rs
+++ b/awc/src/request.rs
@@ -8,13 +8,13 @@ use futures_core::Stream;
 use serde::Serialize;
 
 use actix_http::body::Body;
-#[cfg(feature = "cookies")]
 use actix_http::http::header::{self, IntoHeaderPair};
 use actix_http::http::{
     uri, ConnectionType, Error as HttpError, HeaderMap, HeaderValue, Method, Uri, Version,
 };
 use actix_http::{Error, RequestHead};
 
+#[cfg(feature = "cookies")]
 use crate::cookie::{Cookie, CookieJar};
 use crate::error::{FreezeRequestError, InvalidUrl};
 use crate::frozen::FrozenClientRequest;

--- a/awc/src/request.rs
+++ b/awc/src/request.rs
@@ -9,13 +9,13 @@ use serde::Serialize;
 
 use actix_http::body::Body;
 #[cfg(feature = "cookies")]
-use actix_http::cookie::{Cookie, CookieJar};
 use actix_http::http::header::{self, IntoHeaderPair};
 use actix_http::http::{
     uri, ConnectionType, Error as HttpError, HeaderMap, HeaderValue, Method, Uri, Version,
 };
 use actix_http::{Error, RequestHead};
 
+use crate::cookie::{Cookie, CookieJar};
 use crate::error::{FreezeRequestError, InvalidUrl};
 use crate::frozen::FrozenClientRequest;
 use crate::sender::{PrepForSendingError, RequestSender, SendClientRequest};

--- a/awc/src/request.rs
+++ b/awc/src/request.rs
@@ -494,7 +494,7 @@ impl ClientRequest {
             let cookie: String = jar
                 .delta()
                 // ensure only name=value is written to cookie header
-                .map(|c| Cookie::new(c.name(), c.value()).encoded().to_string())
+                .map(|c| c.stripped().encoded().to_string())
                 .collect::<Vec<_>>()
                 .join("; ");
 

--- a/awc/src/response.rs
+++ b/awc/src/response.rs
@@ -20,7 +20,7 @@ use futures_core::{ready, Stream};
 use serde::de::DeserializeOwned;
 
 #[cfg(feature = "cookies")]
-use actix_http::{cookie::Cookie, error::CookieParseError};
+use {crate::cookie::Cookie, actix_http::error::CookieParseError};
 
 use crate::error::JsonPayloadError;
 
@@ -179,6 +179,19 @@ impl<S> ClientResponse<S> {
     pub(crate) fn _timeout(mut self, timeout: Option<Pin<Box<Sleep>>>) -> Self {
         self.timeout = ResponseTimeout::Disabled(timeout);
         self
+    }
+
+    /// Return request cookie.
+    #[cfg(feature = "cookies")]
+    pub fn cookie(&self, name: &str) -> Option<Cookie<'static>> {
+        if let Ok(cookies) = self.cookies() {
+            for cookie in cookies.iter() {
+                if cookie.name() == name {
+                    return Some(cookie.to_owned());
+                }
+            }
+        }
+        None
     }
 }
 

--- a/awc/src/test.rs
+++ b/awc/src/test.rs
@@ -1,6 +1,5 @@
 //! Test helpers for actix http client to use during testing.
 use actix_http::http::header::IntoHeaderPair;
-use actix_http::http::header::{self, HeaderValue};
 use actix_http::http::{StatusCode, Version};
 use actix_http::{h1, Payload, ResponseHead};
 use bytes::Bytes;
@@ -90,6 +89,8 @@ impl TestResponse {
 
         #[cfg(feature = "cookies")]
         for cookie in self.cookies.delta() {
+            use actix_http::http::header::{self, HeaderValue};
+
             head.headers.insert(
                 header::SET_COOKIE,
                 HeaderValue::from_str(&cookie.encoded().to_string()).unwrap(),

--- a/awc/src/test.rs
+++ b/awc/src/test.rs
@@ -1,14 +1,12 @@
 //! Test helpers for actix http client to use during testing.
 use actix_http::http::header::IntoHeaderPair;
+use actix_http::http::header::{self, HeaderValue};
 use actix_http::http::{StatusCode, Version};
-#[cfg(feature = "cookies")]
-use actix_http::{
-    cookie::{Cookie, CookieJar},
-    http::header::{self, HeaderValue},
-};
 use actix_http::{h1, Payload, ResponseHead};
 use bytes::Bytes;
 
+#[cfg(feature = "cookies")]
+use crate::cookie::{Cookie, CookieJar};
 use crate::ClientResponse;
 
 /// Test `ClientResponse` builder

--- a/awc/src/ws.rs
+++ b/awc/src/ws.rs
@@ -37,9 +37,9 @@ use actix_service::Service;
 
 pub use actix_http::ws::{CloseCode, CloseReason, Codec, Frame, Message};
 
+use crate::connect::{BoxedSocket, ConnectRequest};
 #[cfg(feature = "cookies")]
 use crate::cookie::{Cookie, CookieJar};
-use crate::connect::{BoxedSocket, ConnectRequest};
 use crate::error::{InvalidUrl, SendRequestError, WsClientError};
 use crate::http::header::{self, HeaderName, HeaderValue, IntoHeaderValue, AUTHORIZATION};
 use crate::http::{ConnectionType, Error as HttpError, Method, StatusCode, Uri, Version};

--- a/awc/src/ws.rs
+++ b/awc/src/ws.rs
@@ -280,7 +280,7 @@ impl WebsocketsRequest {
             let cookie: String = jar
                 .delta()
                 // ensure only name=value is written to cookie header
-                .map(|c| Cookie::new(c.name(), c.value()).encoded().to_string())
+                .map(|c| c.stripped().encoded().to_string())
                 .collect::<Vec<_>>()
                 .join("; ");
 

--- a/awc/src/ws.rs
+++ b/awc/src/ws.rs
@@ -31,14 +31,14 @@ use std::net::SocketAddr;
 use std::{fmt, str};
 
 use actix_codec::Framed;
-#[cfg(feature = "cookies")]
-use actix_http::cookie::{Cookie, CookieJar};
 use actix_http::{ws, Payload, RequestHead};
 use actix_rt::time::timeout;
 use actix_service::Service;
 
 pub use actix_http::ws::{CloseCode, CloseReason, Codec, Frame, Message};
 
+#[cfg(feature = "cookies")]
+use crate::cookie::{Cookie, CookieJar};
 use crate::connect::{BoxedSocket, ConnectRequest};
 use crate::error::{InvalidUrl, SendRequestError, WsClientError};
 use crate::http::header::{self, HeaderName, HeaderValue, IntoHeaderValue, AUTHORIZATION};

--- a/awc/tests/test_client.rs
+++ b/awc/tests/test_client.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 use actix_utils::future::ok;
 use brotli2::write::BrotliEncoder;
 use bytes::Bytes;
+use cookie::Cookie;
 use flate2::read::GzDecoder;
 use flate2::write::GzEncoder;
 use flate2::Compression;
@@ -22,7 +23,7 @@ use actix_http_test::test_server;
 use actix_service::{map_config, pipeline_factory};
 use actix_web::{
     dev::{AppConfig, BodyEncoding},
-    http::{header, Cookie},
+    http::header,
     middleware::Compress,
     web, App, Error, HttpRequest, HttpResponse,
 };

--- a/awc/tests/test_client.rs
+++ b/awc/tests/test_client.rs
@@ -24,7 +24,7 @@ use actix_web::{
     dev::{AppConfig, BodyEncoding},
     http::{header, Cookie},
     middleware::Compress,
-    web, App, Error, HttpMessage, HttpRequest, HttpResponse,
+    web, App, Error, HttpRequest, HttpResponse,
 };
 use awc::error::{JsonPayloadError, PayloadError, SendRequestError};
 

--- a/awc/tests/test_ws.rs
+++ b/awc/tests/test_ws.rs
@@ -25,7 +25,7 @@ async fn test_simple() {
         HttpService::build()
             .upgrade(|(req, mut framed): (Request, Framed<_, _>)| {
                 async move {
-                    let res = ws::handshake_response(req.head()).finish();
+                    let res = ws::handshake_response(req.head());
                     // send handshake response
                     framed
                         .send(h1::Message::Item((res.drop_body(), BodySize::None)))

--- a/awc/tests/test_ws.rs
+++ b/awc/tests/test_ws.rs
@@ -25,7 +25,7 @@ async fn test_simple() {
         HttpService::build()
             .upgrade(|(req, mut framed): (Request, Framed<_, _>)| {
                 async move {
-                    let res = ws::handshake_response(req.head());
+                    let res = ws::handshake_response(req.head()).finish();
                     // send handshake response
                     framed
                         .send(h1::Message::Item((res.drop_body(), BodySize::None)))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,13 +95,13 @@ pub mod test;
 pub(crate) mod types;
 pub mod web;
 
-#[cfg(feature = "cookies")]
-pub use actix_http::cookie;
 pub use actix_http::Response as HttpResponse;
 pub use actix_http::{body, Error, HttpMessage, ResponseError, Result};
 #[doc(inline)]
 pub use actix_rt as rt;
 pub use actix_web_codegen::*;
+#[cfg(feature = "cookies")]
+pub use cookie;
 
 pub use crate::app::App;
 pub use crate::extract::FromRequest;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,10 +96,10 @@ pub mod test;
 pub(crate) mod types;
 pub mod web;
 
+pub use actix_http::Response as BaseHttpResponse;
 pub use actix_http::{body, Error, HttpMessage, ResponseError, Result};
 #[doc(inline)]
 pub use actix_rt as rt;
-pub use actix_http::Response as HttpResponse;
 pub use actix_web_codegen::*;
 #[cfg(feature = "cookies")]
 pub use cookie;
@@ -109,7 +109,7 @@ pub use crate::extract::FromRequest;
 pub use crate::request::HttpRequest;
 pub use crate::resource::Resource;
 pub use crate::responder::Responder;
-pub use crate::response::HttpResponseBuilder;
+pub use crate::response::{HttpResponse, HttpResponseBuilder};
 pub use crate::route::Route;
 pub use crate::scope::Scope;
 pub use crate::server::HttpServer;
@@ -182,6 +182,28 @@ pub mod dev {
     }
 
     impl<B> BodyEncoding for Response<B> {
+        fn get_encoding(&self) -> Option<ContentEncoding> {
+            self.extensions().get::<Enc>().map(|enc| enc.0)
+        }
+
+        fn encoding(&mut self, encoding: ContentEncoding) -> &mut Self {
+            self.extensions_mut().insert(Enc(encoding));
+            self
+        }
+    }
+
+    impl BodyEncoding for crate::HttpResponseBuilder {
+        fn get_encoding(&self) -> Option<ContentEncoding> {
+            self.extensions().get::<Enc>().map(|enc| enc.0)
+        }
+
+        fn encoding(&mut self, encoding: ContentEncoding) -> &mut Self {
+            self.extensions_mut().insert(Enc(encoding));
+            self
+        }
+    }
+
+    impl<B> BodyEncoding for crate::HttpResponse<B> {
         fn get_encoding(&self) -> Option<ContentEncoding> {
             self.extensions().get::<Enc>().map(|enc| enc.0)
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,7 @@ mod request;
 mod request_data;
 mod resource;
 mod responder;
+mod response;
 mod rmap;
 mod route;
 mod scope;
@@ -95,10 +96,10 @@ pub mod test;
 pub(crate) mod types;
 pub mod web;
 
-pub use actix_http::Response as HttpResponse;
 pub use actix_http::{body, Error, HttpMessage, ResponseError, Result};
 #[doc(inline)]
 pub use actix_rt as rt;
+pub use actix_http::Response as HttpResponse;
 pub use actix_web_codegen::*;
 #[cfg(feature = "cookies")]
 pub use cookie;
@@ -108,6 +109,7 @@ pub use crate::extract::FromRequest;
 pub use crate::request::HttpRequest;
 pub use crate::resource::Resource;
 pub use crate::responder::Responder;
+pub use crate::response::HttpResponseBuilder;
 pub use crate::route::Route;
 pub use crate::scope::Scope;
 pub use crate::server::HttpServer;
@@ -139,7 +141,7 @@ pub mod dev {
     pub use actix_http::body::{Body, BodySize, MessageBody, ResponseBody, SizedStream};
     #[cfg(feature = "compress")]
     pub use actix_http::encoding::Decoder as Decompress;
-    pub use actix_http::ResponseBuilder as HttpResponseBuilder;
+    pub use actix_http::ResponseBuilder as BaseHttpResponseBuilder;
     pub use actix_http::{Extensions, Payload, PayloadStream, RequestHead, ResponseHead};
     pub use actix_router::{Path, ResourceDef, ResourcePath, Url};
     pub use actix_server::Server;

--- a/src/request.rs
+++ b/src/request.rs
@@ -6,6 +6,7 @@ use actix_http::http::{HeaderMap, Method, Uri, Version};
 use actix_http::{Error, Extensions, HttpMessage, Message, Payload, RequestHead};
 use actix_router::{Path, Url};
 use actix_utils::future::{ok, Ready};
+use cookie::Cookie;
 use smallvec::SmallVec;
 
 use crate::app_service::AppInitServiceState;
@@ -259,6 +260,19 @@ impl HttpRequest {
     #[inline]
     fn app_state(&self) -> &AppInitServiceState {
         &*self.inner.app_state
+    }
+
+    /// Return request cookie.
+    #[cfg(feature = "cookies")]
+    pub fn cookie(&self, name: &str) -> Option<Cookie<'static>> {
+        if let Ok(cookies) = self.cookies() {
+            for cookie in cookies.iter() {
+                if cookie.name() == name {
+                    return Some(cookie.to_owned());
+                }
+            }
+        }
+        None
     }
 }
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,20 +1,27 @@
-use std::cell::{Ref, RefCell, RefMut};
-use std::rc::Rc;
-use std::{fmt, net};
+use std::{
+    cell::{Ref, RefCell, RefMut},
+    fmt, net,
+    rc::Rc,
+    str,
+};
 
-use actix_http::http::{HeaderMap, Method, Uri, Version};
-use actix_http::{Error, Extensions, HttpMessage, Message, Payload, RequestHead};
+use actix_http::{
+    http::{HeaderMap, Method, Uri, Version},
+    Error, Extensions, HttpMessage, Message, Payload, RequestHead,
+};
 use actix_router::{Path, Url};
 use actix_utils::future::{ok, Ready};
-use cookie::Cookie;
+#[cfg(feature = "cookies")]
+use cookie::{Cookie, ParseError as CookieParseError};
 use smallvec::SmallVec;
 
-use crate::app_service::AppInitServiceState;
-use crate::config::AppConfig;
-use crate::error::UrlGenerationError;
-use crate::extract::FromRequest;
-use crate::info::ConnectionInfo;
-use crate::rmap::ResourceMap;
+use crate::{
+    app_service::AppInitServiceState, config::AppConfig, error::UrlGenerationError,
+    extract::FromRequest, http::header, info::ConnectionInfo, rmap::ResourceMap,
+};
+
+#[cfg(feature = "cookies")]
+struct Cookies(Vec<Cookie<'static>>);
 
 #[derive(Clone)]
 /// An HTTP Request
@@ -260,6 +267,27 @@ impl HttpRequest {
     #[inline]
     fn app_state(&self) -> &AppInitServiceState {
         &*self.inner.app_state
+    }
+
+    /// Load request cookies.
+    #[cfg(feature = "cookies")]
+    pub fn cookies(&self) -> Result<Ref<'_, Vec<Cookie<'static>>>, CookieParseError> {
+        if self.extensions().get::<Cookies>().is_none() {
+            let mut cookies = Vec::new();
+            for hdr in self.headers().get_all(header::COOKIE) {
+                let s = str::from_utf8(hdr.as_bytes()).map_err(CookieParseError::from)?;
+                for cookie_str in s.split(';').map(|s| s.trim()) {
+                    if !cookie_str.is_empty() {
+                        cookies.push(Cookie::parse_encoded(cookie_str)?.into_owned());
+                    }
+                }
+            }
+            self.extensions_mut().insert(Cookies(cookies));
+        }
+
+        Ok(Ref::map(self.extensions(), |ext| {
+            &ext.get::<Cookies>().unwrap().0
+        }))
     }
 
     /// Return request cookie.

--- a/src/request.rs
+++ b/src/request.rs
@@ -273,7 +273,7 @@ impl HttpRequest {
     #[cfg(feature = "cookies")]
     pub fn cookies(&self) -> Result<Ref<'_, Vec<Cookie<'static>>>, CookieParseError> {
         use actix_http::http::header::COOKIE;
-        
+
         if self.extensions().get::<Cookies>().is_none() {
             let mut cookies = Vec::new();
             for hdr in self.headers().get_all(COOKIE) {

--- a/src/request.rs
+++ b/src/request.rs
@@ -17,7 +17,7 @@ use smallvec::SmallVec;
 
 use crate::{
     app_service::AppInitServiceState, config::AppConfig, error::UrlGenerationError,
-    extract::FromRequest, http::header, info::ConnectionInfo, rmap::ResourceMap,
+    extract::FromRequest, info::ConnectionInfo, rmap::ResourceMap,
 };
 
 #[cfg(feature = "cookies")]
@@ -272,9 +272,11 @@ impl HttpRequest {
     /// Load request cookies.
     #[cfg(feature = "cookies")]
     pub fn cookies(&self) -> Result<Ref<'_, Vec<Cookie<'static>>>, CookieParseError> {
+        use actix_http::http::header::COOKIE;
+        
         if self.extensions().get::<Cookies>().is_none() {
             let mut cookies = Vec::new();
-            for hdr in self.headers().get_all(header::COOKIE) {
+            for hdr in self.headers().get_all(COOKIE) {
                 let s = str::from_utf8(hdr.as_bytes()).map_err(CookieParseError::from)?;
                 for cookie_str in s.split(';').map(|s| s.trim()) {
                     if !cookie_str.is_empty() {

--- a/src/responder.rs
+++ b/src/responder.rs
@@ -3,7 +3,6 @@ use std::fmt;
 use actix_http::{
     error::InternalError,
     http::{header::IntoHeaderPair, Error as HttpError, HeaderMap, StatusCode},
-    ResponseBuilder,
 };
 use bytes::{Bytes, BytesMut};
 
@@ -73,11 +72,25 @@ impl Responder for actix_http::Response {
     }
 }
 
+impl Responder for HttpResponseBuilder {
+    #[inline]
+    fn respond_to(mut self, _: &HttpRequest) -> HttpResponse {
+        self.finish()
+    }
+}
+
+impl Responder for actix_http::ResponseBuilder {
+    #[inline]
+    fn respond_to(mut self, _: &HttpRequest) -> HttpResponse {
+        HttpResponse::from(self.finish())
+    }
+}
+
 impl<T: Responder> Responder for Option<T> {
     fn respond_to(self, req: &HttpRequest) -> HttpResponse {
         match self {
-            Some(t) => t.respond_to(req),
-            None => HttpResponseBuilder::new(StatusCode::NOT_FOUND).finish(),
+            Some(val) => val.respond_to(req),
+            None => HttpResponse::new(StatusCode::NOT_FOUND),
         }
     }
 }
@@ -92,20 +105,6 @@ where
             Ok(val) => val.respond_to(req),
             Err(e) => HttpResponse::from_error(e.into()),
         }
-    }
-}
-
-impl Responder for HttpResponseBuilder {
-    #[inline]
-    fn respond_to(mut self, _: &HttpRequest) -> HttpResponse {
-        self.finish()
-    }
-}
-
-impl Responder for ResponseBuilder {
-    #[inline]
-    fn respond_to(mut self, _: &HttpRequest) -> HttpResponse {
-        HttpResponse::from(self.finish())
     }
 }
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,12 +1,16 @@
 use std::{
     cell::{Ref, RefMut},
     convert::TryInto,
+    fmt,
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
 };
 
 use actix_http::{
-    body::{Body, BodyStream},
+    body::{Body, BodyStream, MessageBody, ResponseBody},
     http::{
-        header::{self, HeaderName, IntoHeaderPair, IntoHeaderValue},
+        header::{self, HeaderMap, HeaderName, IntoHeaderPair, IntoHeaderValue},
         ConnectionType, Error as HttpError, StatusCode,
     },
     Extensions, Response, ResponseHead,
@@ -15,49 +19,301 @@ use bytes::Bytes;
 use futures_core::Stream;
 use serde::Serialize;
 
+#[cfg(feature = "cookies")]
+use actix_http::http::header::HeaderValue;
+#[cfg(feature = "cookies")]
+use cookie::{Cookie, CookieJar};
+
 use crate::error::Error;
 
-// pub struct HttpResponse<B = dev::Body>(dev::BaseHttpResponse<B>);
+/// An HTTP Response
+pub struct HttpResponse<B = Body> {
+    res: Response<B>,
+    error: Option<Error>,
+}
 
-// impl HttpResponse {
-//     /// Create HTTP response builder with specific status.
-//     #[inline]
-//     pub fn build(status: http::StatusCode) -> HttpResponseBuilder {
-//         HttpResponseBuilder(dev::BaseHttpResponse::build(status))
-//     }
+impl HttpResponse<Body> {
+    /// Create HTTP response builder with specific status.
+    #[inline]
+    pub fn build(status: StatusCode) -> HttpResponseBuilder {
+        HttpResponseBuilder::new(status)
+    }
 
-//     /// Constructs a response
-//     #[inline]
-//     pub fn new(status: http::StatusCode) -> HttpResponse {
-//         HttpResponse(dev::BaseHttpResponse::new(status))
-//     }
+    /// Create HTTP response builder
+    #[inline]
+    pub fn build_from<T: Into<HttpResponseBuilder>>(source: T) -> HttpResponseBuilder {
+        source.into()
+    }
 
-//     /// Constructs an error response
-//     #[inline]
-//     pub fn from_error(error: Error) -> HttpResponse {
-//         HttpResponse(dev::BaseHttpResponse::from_error(error))
-//     }
-// }
+    /// Create a response.
+    #[inline]
+    pub fn new(status: StatusCode) -> Self {
+        Self {
+            res: Response::new(status),
+            error: None,
+        }
+    }
 
-// impl ops::Deref for HttpResponse {
-//     type Target = dev::BaseHttpResponse;
+    /// Create an error response.
+    #[inline]
+    pub fn from_error(error: Error) -> Self {
+        let res = error.as_response_error().error_response();
 
-//     fn deref(&self) -> &Self::Target {
-//         &self.0
-//     }
-// }
+        Self {
+            res,
+            error: Some(error),
+        }
+    }
 
-// impl ops::DerefMut for HttpResponse {
-//     fn deref_mut(&mut self) -> &mut Self::Target {
-//         &mut self.0
-//     }
-// }
+    /// Convert response to response with body
+    pub fn into_body<B>(self) -> HttpResponse<B> {
+        HttpResponse {
+            res: self.res.into_body(),
+            error: self.error,
+        }
+    }
+}
 
-// impl<B> From<HttpResponse<B>> for dev::BaseHttpResponse<B> {
-//     fn from(res: HttpResponse<B>) -> Self {
-//         res.0
-//     }
-// }
+impl<B> HttpResponse<B> {
+    /// Constructs a response with body
+    #[inline]
+    pub fn with_body(status: StatusCode, body: B) -> Self {
+        Self {
+            res: Response::with_body(status, body),
+            error: None,
+        }
+    }
+
+    /// Returns a reference to response head.
+    #[inline]
+    pub fn head(&self) -> &ResponseHead {
+        self.res.head()
+    }
+
+    /// Returns a mutable reference to response head.
+    #[inline]
+    pub fn head_mut(&mut self) -> &mut ResponseHead {
+        self.res.head_mut()
+    }
+
+    /// The source `error` for this response
+    #[inline]
+    pub fn error(&self) -> Option<&Error> {
+        self.error.as_ref()
+    }
+
+    /// Get the response status code
+    #[inline]
+    pub fn status(&self) -> StatusCode {
+        self.res.status()
+    }
+
+    /// Set the `StatusCode` for this response
+    #[inline]
+    pub fn status_mut(&mut self) -> &mut StatusCode {
+        self.res.status_mut()
+    }
+
+    /// Get the headers from the response
+    #[inline]
+    pub fn headers(&self) -> &HeaderMap {
+        self.res.headers()
+    }
+
+    /// Get a mutable reference to the headers
+    #[inline]
+    pub fn headers_mut(&mut self) -> &mut HeaderMap {
+        self.res.headers_mut()
+    }
+
+    /// Get an iterator for the cookies set by this response.
+    #[cfg(feature = "cookies")]
+    pub fn cookies(&self) -> CookieIter<'_> {
+        CookieIter {
+            iter: self.headers().get_all(header::SET_COOKIE),
+        }
+    }
+
+    /// Add a cookie to this response
+    #[cfg(feature = "cookies")]
+    pub fn add_cookie(&mut self, cookie: &Cookie<'_>) -> Result<(), HttpError> {
+        HeaderValue::from_str(&cookie.to_string())
+            .map(|c| {
+                self.headers_mut().append(header::SET_COOKIE, c);
+            })
+            .map_err(|e| e.into())
+    }
+
+    /// Remove all cookies with the given name from this response. Returns
+    /// the number of cookies removed.
+    #[cfg(feature = "cookies")]
+    pub fn del_cookie(&mut self, name: &str) -> usize {
+        let headers = self.headers_mut();
+
+        let vals: Vec<HeaderValue> = headers
+            .get_all(header::SET_COOKIE)
+            .map(|v| v.to_owned())
+            .collect();
+
+        headers.remove(header::SET_COOKIE);
+
+        let mut count: usize = 0;
+        for v in vals {
+            if let Ok(s) = v.to_str() {
+                if let Ok(c) = Cookie::parse_encoded(s) {
+                    if c.name() == name {
+                        count += 1;
+                        continue;
+                    }
+                }
+            }
+
+            // put set-cookie header head back if it does not validate
+            headers.append(header::SET_COOKIE, v);
+        }
+
+        count
+    }
+
+    /// Connection upgrade status
+    #[inline]
+    pub fn upgrade(&self) -> bool {
+        self.res.upgrade()
+    }
+
+    /// Keep-alive status for this connection
+    pub fn keep_alive(&self) -> bool {
+        self.res.keep_alive()
+    }
+
+    /// Responses extensions
+    #[inline]
+    pub fn extensions(&self) -> Ref<'_, Extensions> {
+        self.res.extensions()
+    }
+
+    /// Mutable reference to a the response's extensions
+    #[inline]
+    pub fn extensions_mut(&mut self) -> RefMut<'_, Extensions> {
+        self.res.extensions_mut()
+    }
+
+    /// Get body of this response
+    #[inline]
+    pub fn body(&self) -> &ResponseBody<B> {
+        self.res.body()
+    }
+
+    /// Set a body
+    pub fn set_body<B2>(self, body: B2) -> HttpResponse<B2> {
+        HttpResponse {
+            res: self.res.set_body(body),
+            error: None,
+            // error: self.error, ??
+        }
+    }
+
+    /// Split response and body
+    pub fn into_parts(self) -> (HttpResponse<()>, ResponseBody<B>) {
+        let (head, body) = self.res.into_parts();
+
+        (
+            HttpResponse {
+                res: head,
+                error: None,
+            },
+            body,
+        )
+    }
+
+    /// Drop request's body
+    pub fn drop_body(self) -> HttpResponse<()> {
+        HttpResponse {
+            res: self.res.drop_body(),
+            error: None,
+        }
+    }
+
+    // /// Set a body and return previous body value
+    // pub(crate) fn replace_body<B2>(self, body: B2) -> (HttpResponse<B2>, ResponseBody<B>) {
+    //     let (res, old_body) = self.res.replace_body(body);
+
+    //     (
+    //         HttpResponse {
+    //             res,
+    //             error: self.error,
+    //         },
+    //         old_body,
+    //     )
+    // }
+
+    /// Set a body and return previous body value
+    pub fn map_body<F, B2>(self, f: F) -> HttpResponse<B2>
+    where
+        F: FnOnce(&mut ResponseHead, ResponseBody<B>) -> ResponseBody<B2>,
+    {
+        HttpResponse {
+            res: self.res.map_body(f),
+            error: self.error,
+        }
+    }
+
+    /// Extract response body
+    pub fn take_body(&mut self) -> ResponseBody<B> {
+        self.res.take_body()
+    }
+}
+
+impl<B: MessageBody> fmt::Debug for HttpResponse<B> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HttpResponse")
+            .field("error", &self.error)
+            .field("res", &self.res)
+            .finish()
+    }
+}
+
+impl<B> From<Response<B>> for HttpResponse<B> {
+    fn from(res: Response<B>) -> Self {
+        HttpResponse { res, error: None }
+    }
+}
+
+impl From<Error> for HttpResponse {
+    fn from(err: Error) -> Self {
+        HttpResponse::from_error(err)
+    }
+}
+
+impl<B> From<HttpResponse<B>> for Response<B> {
+    fn from(res: HttpResponse<B>) -> Self {
+        // this impl will always be called as part of dispatcher
+
+        // TODO: expose cause somewhere?
+        // if let Some(err) = res.error {
+        //     eprintln!("impl<B> From<HttpResponse<B>> for Response<B> let Some(err)");
+        //     return Response::from_error(err).into_body();
+        // }
+
+        res.res
+    }
+}
+
+impl Future for HttpResponse {
+    type Output = Result<Response, Error>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if let Some(err) = self.error.take() {
+            eprintln!("httpresponse future error");
+            return Poll::Ready(Ok(Response::from_error(err).into_body()));
+        }
+
+        let res = &mut self.res;
+        actix_rt::pin!(res);
+
+        res.poll(cx)
+    }
+}
 
 /// An HTTP response builder.
 ///
@@ -65,6 +321,8 @@ use crate::error::Error;
 pub struct HttpResponseBuilder {
     head: Option<ResponseHead>,
     err: Option<HttpError>,
+    #[cfg(feature = "cookies")]
+    cookies: Option<CookieJar>,
 }
 
 impl HttpResponseBuilder {
@@ -74,6 +332,8 @@ impl HttpResponseBuilder {
         Self {
             head: Some(ResponseHead::new(status)),
             err: None,
+            #[cfg(feature = "cookies")]
+            cookies: None,
         }
     }
 
@@ -254,6 +514,63 @@ impl HttpResponseBuilder {
         self
     }
 
+    /// Set a cookie
+    ///
+    /// ```
+    /// use actix_http::{http, Request, Response};
+    ///
+    /// fn index(req: Request) -> Response {
+    ///     Response::Ok()
+    ///         .cookie(
+    ///             http::Cookie::build("name", "value")
+    ///                 .domain("www.rust-lang.org")
+    ///                 .path("/")
+    ///                 .secure(true)
+    ///                 .http_only(true)
+    ///                 .finish(),
+    ///         )
+    ///         .finish()
+    /// }
+    /// ```
+    #[cfg(feature = "cookies")]
+    pub fn cookie<'c>(&mut self, cookie: Cookie<'c>) -> &mut Self {
+        if self.cookies.is_none() {
+            let mut jar = CookieJar::new();
+            jar.add(cookie.into_owned());
+            self.cookies = Some(jar)
+        } else {
+            self.cookies.as_mut().unwrap().add(cookie.into_owned());
+        }
+        self
+    }
+
+    /// Remove cookie
+    ///
+    /// ```
+    /// use actix_http::{http, Request, Response, HttpMessage};
+    ///
+    /// fn index(req: Request) -> Response {
+    ///     let mut builder = Response::Ok();
+    ///
+    ///     if let Some(ref cookie) = req.cookie("name") {
+    ///         builder.del_cookie(cookie);
+    ///     }
+    ///
+    ///     builder.finish()
+    /// }
+    /// ```
+    #[cfg(feature = "cookies")]
+    pub fn del_cookie<'a>(&mut self, cookie: &Cookie<'a>) -> &mut Self {
+        if self.cookies.is_none() {
+            self.cookies = Some(CookieJar::new())
+        }
+        let jar = self.cookies.as_mut().unwrap();
+        let cookie = cookie.clone().into_owned();
+        jar.add_original(cookie.clone());
+        jar.remove(cookie);
+        self
+    }
+
     /// Responses extensions
     #[inline]
     pub fn extensions(&self) -> Ref<'_, Extensions> {
@@ -272,24 +589,35 @@ impl HttpResponseBuilder {
     ///
     /// `ResponseBuilder` can not be used after this call.
     #[inline]
-    pub fn body<B: Into<Body>>(&mut self, body: B) -> Response {
+    pub fn body<B: Into<Body>>(&mut self, body: B) -> HttpResponse {
         self.message_body(body.into())
     }
 
     /// Set a body and generate `Response`.
     ///
     /// `ResponseBuilder` can not be used after this call.
-    pub fn message_body<B>(&mut self, body: B) -> Response<B> {
-        if let Some(e) = self.err.take() {
-            return Response::from(Error::from(e)).into_body();
+    pub fn message_body<B>(&mut self, body: B) -> HttpResponse<B> {
+        if let Some(err) = self.err.take() {
+            return HttpResponse::from_error(Error::from(err)).into_body();
         }
 
         // allow unused mut when cookies feature is disabled
         #[allow(unused_mut)]
         let mut head = self.head.take().expect("cannot reuse response builder");
 
-        let mut res = Response::with_body(StatusCode::OK, body);
+        let mut res = HttpResponse::with_body(StatusCode::OK, body);
         *res.head_mut() = head;
+
+        #[cfg(feature = "cookies")]
+        if let Some(ref jar) = self.cookies {
+            for cookie in jar.delta() {
+                match HeaderValue::from_str(&cookie.to_string()) {
+                    Ok(val) => res.headers_mut().append(header::SET_COOKIE, val),
+                    Err(err) => return HttpResponse::from_error(Error::from(err)).into_body(),
+                };
+            }
+        }
+
         res
     }
 
@@ -297,7 +625,7 @@ impl HttpResponseBuilder {
     ///
     /// `ResponseBuilder` can not be used after this call.
     #[inline]
-    pub fn streaming<S, E>(&mut self, stream: S) -> Response
+    pub fn streaming<S, E>(&mut self, stream: S) -> HttpResponse
     where
         S: Stream<Item = Result<Bytes, E>> + Unpin + 'static,
         E: Into<Error> + 'static,
@@ -308,7 +636,7 @@ impl HttpResponseBuilder {
     /// Set a json body and generate `Response`
     ///
     /// `ResponseBuilder` can not be used after this call.
-    pub fn json(&mut self, value: impl Serialize) -> Response {
+    pub fn json(&mut self, value: impl Serialize) -> HttpResponse {
         match serde_json::to_string(&value) {
             Ok(body) => {
                 let contains = if let Some(parts) = self.parts() {
@@ -323,7 +651,7 @@ impl HttpResponseBuilder {
 
                 self.body(Body::from(body))
             }
-            Err(e) => Error::from(e).into(),
+            Err(e) => HttpResponse::from_error(Error::from(e)),
         }
     }
 
@@ -331,7 +659,7 @@ impl HttpResponseBuilder {
     ///
     /// `ResponseBuilder` can not be used after this call.
     #[inline]
-    pub fn finish(&mut self) -> Response {
+    pub fn finish(&mut self) -> HttpResponse {
         self.body(Body::Empty)
     }
 
@@ -340,6 +668,8 @@ impl HttpResponseBuilder {
         Self {
             head: self.head.take(),
             err: self.err.take(),
+            #[cfg(feature = "cookies")]
+            cookies: self.cookies.take(),
         }
     }
 
@@ -353,104 +683,301 @@ impl HttpResponseBuilder {
     }
 }
 
-// mod http_codes {
-//     //! Status code based HTTP response builders.
+impl From<HttpResponseBuilder> for HttpResponse {
+    fn from(mut builder: HttpResponseBuilder) -> Self {
+        builder.finish()
+    }
+}
 
-//     use actix_http::http::StatusCode;
+impl From<HttpResponseBuilder> for Response {
+    fn from(mut builder: HttpResponseBuilder) -> Self {
+        builder.finish().into()
+    }
+}
 
-//     use super::{HttpResponse, HttpResponseBuilder};
+impl Future for HttpResponseBuilder {
+    type Output = Result<HttpResponse, Error>;
 
-//     macro_rules! static_resp {
-//         ($name:ident, $status:expr) => {
-//             #[allow(non_snake_case, missing_docs)]
-//             pub fn $name() -> HttpResponseBuilder {
-//                 HttpResponseBuilder::new($status)
-//             }
-//         };
-//     }
+    fn poll(mut self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Self::Output> {
+        eprintln!("httpresponse future error");
+        Poll::Ready(Ok(self.finish()))
+    }
+}
 
-//     impl HttpResponse {
-//         static_resp!(Continue, StatusCode::CONTINUE);
-//         static_resp!(SwitchingProtocols, StatusCode::SWITCHING_PROTOCOLS);
-//         static_resp!(Processing, StatusCode::PROCESSING);
+#[cfg(feature = "cookies")]
+pub struct CookieIter<'a> {
+    iter: header::GetAll<'a>,
+}
 
-//         static_resp!(Ok, StatusCode::OK);
-//         static_resp!(Created, StatusCode::CREATED);
-//         static_resp!(Accepted, StatusCode::ACCEPTED);
-//         static_resp!(
-//             NonAuthoritativeInformation,
-//             StatusCode::NON_AUTHORITATIVE_INFORMATION
-//         );
+#[cfg(feature = "cookies")]
+impl<'a> Iterator for CookieIter<'a> {
+    type Item = Cookie<'a>;
 
-//         static_resp!(NoContent, StatusCode::NO_CONTENT);
-//         static_resp!(ResetContent, StatusCode::RESET_CONTENT);
-//         static_resp!(PartialContent, StatusCode::PARTIAL_CONTENT);
-//         static_resp!(MultiStatus, StatusCode::MULTI_STATUS);
-//         static_resp!(AlreadyReported, StatusCode::ALREADY_REPORTED);
+    #[inline]
+    fn next(&mut self) -> Option<Cookie<'a>> {
+        for v in self.iter.by_ref() {
+            if let Ok(c) = Cookie::parse_encoded(v.to_str().ok()?) {
+                return Some(c);
+            }
+        }
+        None
+    }
+}
 
-//         static_resp!(MultipleChoices, StatusCode::MULTIPLE_CHOICES);
-//         static_resp!(MovedPermanently, StatusCode::MOVED_PERMANENTLY);
-//         static_resp!(Found, StatusCode::FOUND);
-//         static_resp!(SeeOther, StatusCode::SEE_OTHER);
-//         static_resp!(NotModified, StatusCode::NOT_MODIFIED);
-//         static_resp!(UseProxy, StatusCode::USE_PROXY);
-//         static_resp!(TemporaryRedirect, StatusCode::TEMPORARY_REDIRECT);
-//         static_resp!(PermanentRedirect, StatusCode::PERMANENT_REDIRECT);
+mod http_codes {
+    //! Status code based HTTP response builders.
 
-//         static_resp!(BadRequest, StatusCode::BAD_REQUEST);
-//         static_resp!(NotFound, StatusCode::NOT_FOUND);
-//         static_resp!(Unauthorized, StatusCode::UNAUTHORIZED);
-//         static_resp!(PaymentRequired, StatusCode::PAYMENT_REQUIRED);
-//         static_resp!(Forbidden, StatusCode::FORBIDDEN);
-//         static_resp!(MethodNotAllowed, StatusCode::METHOD_NOT_ALLOWED);
-//         static_resp!(NotAcceptable, StatusCode::NOT_ACCEPTABLE);
-//         static_resp!(
-//             ProxyAuthenticationRequired,
-//             StatusCode::PROXY_AUTHENTICATION_REQUIRED
-//         );
-//         static_resp!(RequestTimeout, StatusCode::REQUEST_TIMEOUT);
-//         static_resp!(Conflict, StatusCode::CONFLICT);
-//         static_resp!(Gone, StatusCode::GONE);
-//         static_resp!(LengthRequired, StatusCode::LENGTH_REQUIRED);
-//         static_resp!(PreconditionFailed, StatusCode::PRECONDITION_FAILED);
-//         static_resp!(PreconditionRequired, StatusCode::PRECONDITION_REQUIRED);
-//         static_resp!(PayloadTooLarge, StatusCode::PAYLOAD_TOO_LARGE);
-//         static_resp!(UriTooLong, StatusCode::URI_TOO_LONG);
-//         static_resp!(UnsupportedMediaType, StatusCode::UNSUPPORTED_MEDIA_TYPE);
-//         static_resp!(RangeNotSatisfiable, StatusCode::RANGE_NOT_SATISFIABLE);
-//         static_resp!(ExpectationFailed, StatusCode::EXPECTATION_FAILED);
-//         static_resp!(UnprocessableEntity, StatusCode::UNPROCESSABLE_ENTITY);
-//         static_resp!(TooManyRequests, StatusCode::TOO_MANY_REQUESTS);
-//         static_resp!(
-//             RequestHeaderFieldsTooLarge,
-//             StatusCode::REQUEST_HEADER_FIELDS_TOO_LARGE
-//         );
-//         static_resp!(
-//             UnavailableForLegalReasons,
-//             StatusCode::UNAVAILABLE_FOR_LEGAL_REASONS
-//         );
+    use actix_http::http::StatusCode;
 
-//         static_resp!(InternalServerError, StatusCode::INTERNAL_SERVER_ERROR);
-//         static_resp!(NotImplemented, StatusCode::NOT_IMPLEMENTED);
-//         static_resp!(BadGateway, StatusCode::BAD_GATEWAY);
-//         static_resp!(ServiceUnavailable, StatusCode::SERVICE_UNAVAILABLE);
-//         static_resp!(GatewayTimeout, StatusCode::GATEWAY_TIMEOUT);
-//         static_resp!(VersionNotSupported, StatusCode::HTTP_VERSION_NOT_SUPPORTED);
-//         static_resp!(VariantAlsoNegotiates, StatusCode::VARIANT_ALSO_NEGOTIATES);
-//         static_resp!(InsufficientStorage, StatusCode::INSUFFICIENT_STORAGE);
-//         static_resp!(LoopDetected, StatusCode::LOOP_DETECTED);
-//     }
+    use super::{HttpResponse, HttpResponseBuilder};
 
-//     #[cfg(test)]
-//     mod tests {
-//         use crate::dev::Body;
-//         use crate::http::StatusCode;
-//         use crate::HttpRespone;
+    macro_rules! static_resp {
+        ($name:ident, $status:expr) => {
+            #[allow(non_snake_case, missing_docs)]
+            pub fn $name() -> HttpResponseBuilder {
+                HttpResponseBuilder::new($status)
+            }
+        };
+    }
 
-//         #[test]
-//         fn test_build() {
-//             let resp = HttpResponse::Ok().body(Body::Empty);
-//             assert_eq!(resp.status(), StatusCode::OK);
-//         }
-//     }
-// }
+    impl HttpResponse {
+        static_resp!(Continue, StatusCode::CONTINUE);
+        static_resp!(SwitchingProtocols, StatusCode::SWITCHING_PROTOCOLS);
+        static_resp!(Processing, StatusCode::PROCESSING);
+
+        static_resp!(Ok, StatusCode::OK);
+        static_resp!(Created, StatusCode::CREATED);
+        static_resp!(Accepted, StatusCode::ACCEPTED);
+        static_resp!(
+            NonAuthoritativeInformation,
+            StatusCode::NON_AUTHORITATIVE_INFORMATION
+        );
+
+        static_resp!(NoContent, StatusCode::NO_CONTENT);
+        static_resp!(ResetContent, StatusCode::RESET_CONTENT);
+        static_resp!(PartialContent, StatusCode::PARTIAL_CONTENT);
+        static_resp!(MultiStatus, StatusCode::MULTI_STATUS);
+        static_resp!(AlreadyReported, StatusCode::ALREADY_REPORTED);
+
+        static_resp!(MultipleChoices, StatusCode::MULTIPLE_CHOICES);
+        static_resp!(MovedPermanently, StatusCode::MOVED_PERMANENTLY);
+        static_resp!(Found, StatusCode::FOUND);
+        static_resp!(SeeOther, StatusCode::SEE_OTHER);
+        static_resp!(NotModified, StatusCode::NOT_MODIFIED);
+        static_resp!(UseProxy, StatusCode::USE_PROXY);
+        static_resp!(TemporaryRedirect, StatusCode::TEMPORARY_REDIRECT);
+        static_resp!(PermanentRedirect, StatusCode::PERMANENT_REDIRECT);
+
+        static_resp!(BadRequest, StatusCode::BAD_REQUEST);
+        static_resp!(NotFound, StatusCode::NOT_FOUND);
+        static_resp!(Unauthorized, StatusCode::UNAUTHORIZED);
+        static_resp!(PaymentRequired, StatusCode::PAYMENT_REQUIRED);
+        static_resp!(Forbidden, StatusCode::FORBIDDEN);
+        static_resp!(MethodNotAllowed, StatusCode::METHOD_NOT_ALLOWED);
+        static_resp!(NotAcceptable, StatusCode::NOT_ACCEPTABLE);
+        static_resp!(
+            ProxyAuthenticationRequired,
+            StatusCode::PROXY_AUTHENTICATION_REQUIRED
+        );
+        static_resp!(RequestTimeout, StatusCode::REQUEST_TIMEOUT);
+        static_resp!(Conflict, StatusCode::CONFLICT);
+        static_resp!(Gone, StatusCode::GONE);
+        static_resp!(LengthRequired, StatusCode::LENGTH_REQUIRED);
+        static_resp!(PreconditionFailed, StatusCode::PRECONDITION_FAILED);
+        static_resp!(PreconditionRequired, StatusCode::PRECONDITION_REQUIRED);
+        static_resp!(PayloadTooLarge, StatusCode::PAYLOAD_TOO_LARGE);
+        static_resp!(UriTooLong, StatusCode::URI_TOO_LONG);
+        static_resp!(UnsupportedMediaType, StatusCode::UNSUPPORTED_MEDIA_TYPE);
+        static_resp!(RangeNotSatisfiable, StatusCode::RANGE_NOT_SATISFIABLE);
+        static_resp!(ExpectationFailed, StatusCode::EXPECTATION_FAILED);
+        static_resp!(UnprocessableEntity, StatusCode::UNPROCESSABLE_ENTITY);
+        static_resp!(TooManyRequests, StatusCode::TOO_MANY_REQUESTS);
+        static_resp!(
+            RequestHeaderFieldsTooLarge,
+            StatusCode::REQUEST_HEADER_FIELDS_TOO_LARGE
+        );
+        static_resp!(
+            UnavailableForLegalReasons,
+            StatusCode::UNAVAILABLE_FOR_LEGAL_REASONS
+        );
+
+        static_resp!(InternalServerError, StatusCode::INTERNAL_SERVER_ERROR);
+        static_resp!(NotImplemented, StatusCode::NOT_IMPLEMENTED);
+        static_resp!(BadGateway, StatusCode::BAD_GATEWAY);
+        static_resp!(ServiceUnavailable, StatusCode::SERVICE_UNAVAILABLE);
+        static_resp!(GatewayTimeout, StatusCode::GATEWAY_TIMEOUT);
+        static_resp!(VersionNotSupported, StatusCode::HTTP_VERSION_NOT_SUPPORTED);
+        static_resp!(VariantAlsoNegotiates, StatusCode::VARIANT_ALSO_NEGOTIATES);
+        static_resp!(InsufficientStorage, StatusCode::INSUFFICIENT_STORAGE);
+        static_resp!(LoopDetected, StatusCode::LOOP_DETECTED);
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use crate::dev::Body;
+        use crate::http::StatusCode;
+        use crate::HttpResponse;
+
+        #[test]
+        fn test_build() {
+            let resp = HttpResponse::Ok().body(Body::Empty);
+            assert_eq!(resp.status(), StatusCode::OK);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::{Bytes, BytesMut};
+    use serde_json::json;
+
+    use super::{HttpResponse as Response, HttpResponseBuilder as ResponseBuilder};
+    use crate::dev::{Body, MessageBody, ResponseBody};
+    use crate::http::header::{self, HeaderValue, CONTENT_TYPE, COOKIE};
+    use crate::http::StatusCode;
+
+    #[test]
+    fn test_debug() {
+        let resp = Response::Ok()
+            .append_header((COOKIE, HeaderValue::from_static("cookie1=value1; ")))
+            .append_header((COOKIE, HeaderValue::from_static("cookie2=value2; ")))
+            .finish();
+        let dbg = format!("{:?}", resp);
+        assert!(dbg.contains("Response"));
+    }
+
+    #[test]
+    fn test_basic_builder() {
+        let resp = Response::Ok().insert_header(("X-TEST", "value")).finish();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[test]
+    fn test_upgrade() {
+        let resp = ResponseBuilder::new(StatusCode::OK)
+            .upgrade("websocket")
+            .finish();
+        assert!(resp.upgrade());
+        assert_eq!(
+            resp.headers().get(header::UPGRADE).unwrap(),
+            HeaderValue::from_static("websocket")
+        );
+    }
+
+    #[test]
+    fn test_force_close() {
+        let resp = ResponseBuilder::new(StatusCode::OK).force_close().finish();
+        assert!(!resp.keep_alive())
+    }
+
+    #[test]
+    fn test_content_type() {
+        let resp = ResponseBuilder::new(StatusCode::OK)
+            .content_type("text/plain")
+            .body(Body::Empty);
+        assert_eq!(resp.headers().get(CONTENT_TYPE).unwrap(), "text/plain")
+    }
+
+    pub async fn read_body<B>(mut body: ResponseBody<B>) -> Bytes
+    where
+        B: MessageBody + Unpin,
+    {
+        use futures_util::StreamExt as _;
+
+        let mut bytes = BytesMut::new();
+        while let Some(item) = body.next().await {
+            bytes.extend_from_slice(&item.unwrap());
+        }
+        bytes.freeze()
+    }
+
+    #[actix_rt::test]
+    async fn test_json() {
+        let mut resp = Response::Ok().json(vec!["v1", "v2", "v3"]);
+        let ct = resp.headers().get(CONTENT_TYPE).unwrap();
+        assert_eq!(ct, HeaderValue::from_static("application/json"));
+        assert_eq!(
+            read_body(resp.take_body()).await.as_ref(),
+            br#"["v1","v2","v3"]"#
+        );
+
+        let mut resp = Response::Ok().json(&["v1", "v2", "v3"]);
+        let ct = resp.headers().get(CONTENT_TYPE).unwrap();
+        assert_eq!(ct, HeaderValue::from_static("application/json"));
+        assert_eq!(
+            read_body(resp.take_body()).await.as_ref(),
+            br#"["v1","v2","v3"]"#
+        );
+
+        // content type override
+        let mut resp = Response::Ok()
+            .insert_header((CONTENT_TYPE, "text/json"))
+            .json(&vec!["v1", "v2", "v3"]);
+        let ct = resp.headers().get(CONTENT_TYPE).unwrap();
+        assert_eq!(ct, HeaderValue::from_static("text/json"));
+        assert_eq!(
+            read_body(resp.take_body()).await.as_ref(),
+            br#"["v1","v2","v3"]"#
+        );
+    }
+
+    #[actix_rt::test]
+    async fn test_serde_json_in_body() {
+        use serde_json::json;
+        let mut resp = Response::Ok().body(json!({"test-key":"test-value"}));
+        assert_eq!(
+            read_body(resp.take_body()).await.as_ref(),
+            br#"{"test-key":"test-value"}"#
+        );
+    }
+
+    #[test]
+    fn response_builder_header_insert_kv() {
+        let mut res = Response::Ok();
+        res.insert_header(("Content-Type", "application/octet-stream"));
+        let res = res.finish();
+
+        assert_eq!(
+            res.headers().get("Content-Type"),
+            Some(&HeaderValue::from_static("application/octet-stream"))
+        );
+    }
+
+    #[test]
+    fn response_builder_header_insert_typed() {
+        let mut res = Response::Ok();
+        res.insert_header((header::CONTENT_TYPE, mime::APPLICATION_OCTET_STREAM));
+        let res = res.finish();
+
+        assert_eq!(
+            res.headers().get("Content-Type"),
+            Some(&HeaderValue::from_static("application/octet-stream"))
+        );
+    }
+
+    #[test]
+    fn response_builder_header_append_kv() {
+        let mut res = Response::Ok();
+        res.append_header(("Content-Type", "application/octet-stream"));
+        res.append_header(("Content-Type", "application/json"));
+        let res = res.finish();
+
+        let headers: Vec<_> = res.headers().get_all("Content-Type").cloned().collect();
+        assert_eq!(headers.len(), 2);
+        assert!(headers.contains(&HeaderValue::from_static("application/octet-stream")));
+        assert!(headers.contains(&HeaderValue::from_static("application/json")));
+    }
+
+    #[test]
+    fn response_builder_header_append_typed() {
+        let mut res = Response::Ok();
+        res.append_header((header::CONTENT_TYPE, mime::APPLICATION_OCTET_STREAM));
+        res.append_header((header::CONTENT_TYPE, mime::APPLICATION_JSON));
+        let res = res.finish();
+
+        let headers: Vec<_> = res.headers().get_all("Content-Type").cloned().collect();
+        assert_eq!(headers.len(), 2);
+        assert!(headers.contains(&HeaderValue::from_static("application/octet-stream")));
+        assert!(headers.contains(&HeaderValue::from_static("application/json")));
+    }
+}

--- a/src/response.rs
+++ b/src/response.rs
@@ -234,19 +234,6 @@ impl<B> HttpResponse<B> {
         }
     }
 
-    // /// Set a body and return previous body value
-    // pub(crate) fn replace_body<B2>(self, body: B2) -> (HttpResponse<B2>, ResponseBody<B>) {
-    //     let (res, old_body) = self.res.replace_body(body);
-
-    //     (
-    //         HttpResponse {
-    //             res,
-    //             error: self.error,
-    //         },
-    //         old_body,
-    //     )
-    // }
-
     /// Set a body and return previous body value
     pub fn map_body<F, B2>(self, f: F) -> HttpResponse<B2>
     where
@@ -349,11 +336,10 @@ impl HttpResponseBuilder {
     /// Insert a header, replacing any that were set with an equivalent field name.
     ///
     /// ```
-    /// # use actix_http::Response;
-    /// use actix_http::http::header;
+    /// use actix_web::{HttpResponse, http::header};
     ///
-    /// Response::Ok()
-    ///     .insert_header((header::CONTENT_TYPE, mime::APPLICATION_JSON))
+    /// HttpResponse::Ok()
+    ///     .insert_header(header::ContentType(mime::APPLICATION_JSON))
     ///     .insert_header(("X-TEST", "value"))
     ///     .finish();
     /// ```
@@ -376,11 +362,10 @@ impl HttpResponseBuilder {
     /// Append a header, keeping any that were set with an equivalent field name.
     ///
     /// ```
-    /// # use actix_http::Response;
-    /// use actix_http::http::header;
+    /// use actix_web::{HttpResponse, http::header};
     ///
-    /// Response::Ok()
-    ///     .append_header((header::CONTENT_TYPE, mime::APPLICATION_JSON))
+    /// HttpResponse::Ok()
+    ///     .append_header(header::ContentType(mime::APPLICATION_JSON))
     ///     .append_header(("X-TEST", "value1"))
     ///     .append_header(("X-TEST", "value2"))
     ///     .finish();
@@ -514,23 +499,21 @@ impl HttpResponseBuilder {
         self
     }
 
-    /// Set a cookie
+    /// Set a cookie.
     ///
     /// ```
-    /// use actix_http::{http, Request, Response};
+    /// use actix_web::{HttpResponse, cookie::Cookie};
     ///
-    /// fn index(req: Request) -> Response {
-    ///     Response::Ok()
-    ///         .cookie(
-    ///             http::Cookie::build("name", "value")
-    ///                 .domain("www.rust-lang.org")
-    ///                 .path("/")
-    ///                 .secure(true)
-    ///                 .http_only(true)
-    ///                 .finish(),
-    ///         )
-    ///         .finish()
-    /// }
+    /// HttpResponse::Ok()
+    ///     .cookie(
+    ///         Cookie::build("name", "value")
+    ///             .domain("www.rust-lang.org")
+    ///             .path("/")
+    ///             .secure(true)
+    ///             .http_only(true)
+    ///             .finish(),
+    ///     )
+    ///     .finish();
     /// ```
     #[cfg(feature = "cookies")]
     pub fn cookie<'c>(&mut self, cookie: Cookie<'c>) -> &mut Self {
@@ -544,13 +527,15 @@ impl HttpResponseBuilder {
         self
     }
 
-    /// Remove cookie
+    /// Remove cookie.
+    ///
+    /// A `Set-Cookie` header is added that will delete a cookie with the same name from the client.
     ///
     /// ```
-    /// use actix_http::{http, Request, Response, HttpMessage};
+    /// use actix_web::{HttpRequest, HttpResponse, Responder};
     ///
-    /// fn index(req: Request) -> Response {
-    ///     let mut builder = Response::Ok();
+    /// async fn handler(req: HttpRequest) -> impl Responder {
+    ///     let mut builder = HttpResponse::Ok();
     ///
     ///     if let Some(ref cookie) = req.cookie("name") {
     ///         builder.del_cookie(cookie);

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,0 +1,456 @@
+use std::{
+    cell::{Ref, RefMut},
+    convert::TryInto,
+};
+
+use actix_http::{
+    body::{Body, BodyStream},
+    http::{
+        header::{self, HeaderName, IntoHeaderPair, IntoHeaderValue},
+        ConnectionType, Error as HttpError, StatusCode,
+    },
+    Extensions, Response, ResponseHead,
+};
+use bytes::Bytes;
+use futures_core::Stream;
+use serde::Serialize;
+
+use crate::error::Error;
+
+// pub struct HttpResponse<B = dev::Body>(dev::BaseHttpResponse<B>);
+
+// impl HttpResponse {
+//     /// Create HTTP response builder with specific status.
+//     #[inline]
+//     pub fn build(status: http::StatusCode) -> HttpResponseBuilder {
+//         HttpResponseBuilder(dev::BaseHttpResponse::build(status))
+//     }
+
+//     /// Constructs a response
+//     #[inline]
+//     pub fn new(status: http::StatusCode) -> HttpResponse {
+//         HttpResponse(dev::BaseHttpResponse::new(status))
+//     }
+
+//     /// Constructs an error response
+//     #[inline]
+//     pub fn from_error(error: Error) -> HttpResponse {
+//         HttpResponse(dev::BaseHttpResponse::from_error(error))
+//     }
+// }
+
+// impl ops::Deref for HttpResponse {
+//     type Target = dev::BaseHttpResponse;
+
+//     fn deref(&self) -> &Self::Target {
+//         &self.0
+//     }
+// }
+
+// impl ops::DerefMut for HttpResponse {
+//     fn deref_mut(&mut self) -> &mut Self::Target {
+//         &mut self.0
+//     }
+// }
+
+// impl<B> From<HttpResponse<B>> for dev::BaseHttpResponse<B> {
+//     fn from(res: HttpResponse<B>) -> Self {
+//         res.0
+//     }
+// }
+
+/// An HTTP response builder.
+///
+/// This type can be used to construct an instance of `Response` through a builder-like pattern.
+pub struct HttpResponseBuilder {
+    head: Option<ResponseHead>,
+    err: Option<HttpError>,
+}
+
+impl HttpResponseBuilder {
+    #[inline]
+    /// Create response builder
+    pub fn new(status: StatusCode) -> Self {
+        Self {
+            head: Some(ResponseHead::new(status)),
+            err: None,
+        }
+    }
+
+    /// Set HTTP status code of this response.
+    #[inline]
+    pub fn status(&mut self, status: StatusCode) -> &mut Self {
+        if let Some(parts) = self.parts() {
+            parts.status = status;
+        }
+        self
+    }
+
+    /// Insert a header, replacing any that were set with an equivalent field name.
+    ///
+    /// ```
+    /// # use actix_http::Response;
+    /// use actix_http::http::header;
+    ///
+    /// Response::Ok()
+    ///     .insert_header((header::CONTENT_TYPE, mime::APPLICATION_JSON))
+    ///     .insert_header(("X-TEST", "value"))
+    ///     .finish();
+    /// ```
+    pub fn insert_header<H>(&mut self, header: H) -> &mut Self
+    where
+        H: IntoHeaderPair,
+    {
+        if let Some(parts) = self.parts() {
+            match header.try_into_header_pair() {
+                Ok((key, value)) => {
+                    parts.headers.insert(key, value);
+                }
+                Err(e) => self.err = Some(e.into()),
+            };
+        }
+
+        self
+    }
+
+    /// Append a header, keeping any that were set with an equivalent field name.
+    ///
+    /// ```
+    /// # use actix_http::Response;
+    /// use actix_http::http::header;
+    ///
+    /// Response::Ok()
+    ///     .append_header((header::CONTENT_TYPE, mime::APPLICATION_JSON))
+    ///     .append_header(("X-TEST", "value1"))
+    ///     .append_header(("X-TEST", "value2"))
+    ///     .finish();
+    /// ```
+    pub fn append_header<H>(&mut self, header: H) -> &mut Self
+    where
+        H: IntoHeaderPair,
+    {
+        if let Some(parts) = self.parts() {
+            match header.try_into_header_pair() {
+                Ok((key, value)) => parts.headers.append(key, value),
+                Err(e) => self.err = Some(e.into()),
+            };
+        }
+
+        self
+    }
+
+    /// Replaced with [`Self::insert_header()`].
+    #[deprecated = "Replaced with `insert_header((key, value))`."]
+    pub fn set_header<K, V>(&mut self, key: K, value: V) -> &mut Self
+    where
+        K: TryInto<HeaderName>,
+        K::Error: Into<HttpError>,
+        V: IntoHeaderValue,
+    {
+        if self.err.is_some() {
+            return self;
+        }
+
+        match (key.try_into(), value.try_into_value()) {
+            (Ok(name), Ok(value)) => return self.insert_header((name, value)),
+            (Err(err), _) => self.err = Some(err.into()),
+            (_, Err(err)) => self.err = Some(err.into()),
+        }
+
+        self
+    }
+
+    /// Replaced with [`Self::append_header()`].
+    #[deprecated = "Replaced with `append_header((key, value))`."]
+    pub fn header<K, V>(&mut self, key: K, value: V) -> &mut Self
+    where
+        K: TryInto<HeaderName>,
+        K::Error: Into<HttpError>,
+        V: IntoHeaderValue,
+    {
+        if self.err.is_some() {
+            return self;
+        }
+
+        match (key.try_into(), value.try_into_value()) {
+            (Ok(name), Ok(value)) => return self.append_header((name, value)),
+            (Err(err), _) => self.err = Some(err.into()),
+            (_, Err(err)) => self.err = Some(err.into()),
+        }
+
+        self
+    }
+
+    /// Set the custom reason for the response.
+    #[inline]
+    pub fn reason(&mut self, reason: &'static str) -> &mut Self {
+        if let Some(parts) = self.parts() {
+            parts.reason = Some(reason);
+        }
+        self
+    }
+
+    /// Set connection type to KeepAlive
+    #[inline]
+    pub fn keep_alive(&mut self) -> &mut Self {
+        if let Some(parts) = self.parts() {
+            parts.set_connection_type(ConnectionType::KeepAlive);
+        }
+        self
+    }
+
+    /// Set connection type to Upgrade
+    #[inline]
+    pub fn upgrade<V>(&mut self, value: V) -> &mut Self
+    where
+        V: IntoHeaderValue,
+    {
+        if let Some(parts) = self.parts() {
+            parts.set_connection_type(ConnectionType::Upgrade);
+        }
+
+        if let Ok(value) = value.try_into_value() {
+            self.insert_header((header::UPGRADE, value));
+        }
+
+        self
+    }
+
+    /// Force close connection, even if it is marked as keep-alive
+    #[inline]
+    pub fn force_close(&mut self) -> &mut Self {
+        if let Some(parts) = self.parts() {
+            parts.set_connection_type(ConnectionType::Close);
+        }
+        self
+    }
+
+    /// Disable chunked transfer encoding for HTTP/1.1 streaming responses.
+    #[inline]
+    pub fn no_chunking(&mut self, len: u64) -> &mut Self {
+        let mut buf = itoa::Buffer::new();
+        self.insert_header((header::CONTENT_LENGTH, buf.format(len)));
+
+        if let Some(parts) = self.parts() {
+            parts.no_chunking(true);
+        }
+        self
+    }
+
+    /// Set response content type.
+    #[inline]
+    pub fn content_type<V>(&mut self, value: V) -> &mut Self
+    where
+        V: IntoHeaderValue,
+    {
+        if let Some(parts) = self.parts() {
+            match value.try_into_value() {
+                Ok(value) => {
+                    parts.headers.insert(header::CONTENT_TYPE, value);
+                }
+                Err(e) => self.err = Some(e.into()),
+            };
+        }
+        self
+    }
+
+    /// Responses extensions
+    #[inline]
+    pub fn extensions(&self) -> Ref<'_, Extensions> {
+        let head = self.head.as_ref().expect("cannot reuse response builder");
+        head.extensions()
+    }
+
+    /// Mutable reference to a the response's extensions
+    #[inline]
+    pub fn extensions_mut(&mut self) -> RefMut<'_, Extensions> {
+        let head = self.head.as_ref().expect("cannot reuse response builder");
+        head.extensions_mut()
+    }
+
+    /// Set a body and generate `Response`.
+    ///
+    /// `ResponseBuilder` can not be used after this call.
+    #[inline]
+    pub fn body<B: Into<Body>>(&mut self, body: B) -> Response {
+        self.message_body(body.into())
+    }
+
+    /// Set a body and generate `Response`.
+    ///
+    /// `ResponseBuilder` can not be used after this call.
+    pub fn message_body<B>(&mut self, body: B) -> Response<B> {
+        if let Some(e) = self.err.take() {
+            return Response::from(Error::from(e)).into_body();
+        }
+
+        // allow unused mut when cookies feature is disabled
+        #[allow(unused_mut)]
+        let mut head = self.head.take().expect("cannot reuse response builder");
+
+        let mut res = Response::with_body(StatusCode::OK, body);
+        *res.head_mut() = head;
+        res
+    }
+
+    /// Set a streaming body and generate `Response`.
+    ///
+    /// `ResponseBuilder` can not be used after this call.
+    #[inline]
+    pub fn streaming<S, E>(&mut self, stream: S) -> Response
+    where
+        S: Stream<Item = Result<Bytes, E>> + Unpin + 'static,
+        E: Into<Error> + 'static,
+    {
+        self.body(Body::from_message(BodyStream::new(stream)))
+    }
+
+    /// Set a json body and generate `Response`
+    ///
+    /// `ResponseBuilder` can not be used after this call.
+    pub fn json(&mut self, value: impl Serialize) -> Response {
+        match serde_json::to_string(&value) {
+            Ok(body) => {
+                let contains = if let Some(parts) = self.parts() {
+                    parts.headers.contains_key(header::CONTENT_TYPE)
+                } else {
+                    true
+                };
+
+                if !contains {
+                    self.insert_header((header::CONTENT_TYPE, mime::APPLICATION_JSON));
+                }
+
+                self.body(Body::from(body))
+            }
+            Err(e) => Error::from(e).into(),
+        }
+    }
+
+    /// Set an empty body and generate `Response`
+    ///
+    /// `ResponseBuilder` can not be used after this call.
+    #[inline]
+    pub fn finish(&mut self) -> Response {
+        self.body(Body::Empty)
+    }
+
+    /// This method construct new `ResponseBuilder`
+    pub fn take(&mut self) -> Self {
+        Self {
+            head: self.head.take(),
+            err: self.err.take(),
+        }
+    }
+
+    #[inline]
+    fn parts(&mut self) -> Option<&mut ResponseHead> {
+        if self.err.is_some() {
+            return None;
+        }
+
+        self.head.as_mut()
+    }
+}
+
+// mod http_codes {
+//     //! Status code based HTTP response builders.
+
+//     use actix_http::http::StatusCode;
+
+//     use super::{HttpResponse, HttpResponseBuilder};
+
+//     macro_rules! static_resp {
+//         ($name:ident, $status:expr) => {
+//             #[allow(non_snake_case, missing_docs)]
+//             pub fn $name() -> HttpResponseBuilder {
+//                 HttpResponseBuilder::new($status)
+//             }
+//         };
+//     }
+
+//     impl HttpResponse {
+//         static_resp!(Continue, StatusCode::CONTINUE);
+//         static_resp!(SwitchingProtocols, StatusCode::SWITCHING_PROTOCOLS);
+//         static_resp!(Processing, StatusCode::PROCESSING);
+
+//         static_resp!(Ok, StatusCode::OK);
+//         static_resp!(Created, StatusCode::CREATED);
+//         static_resp!(Accepted, StatusCode::ACCEPTED);
+//         static_resp!(
+//             NonAuthoritativeInformation,
+//             StatusCode::NON_AUTHORITATIVE_INFORMATION
+//         );
+
+//         static_resp!(NoContent, StatusCode::NO_CONTENT);
+//         static_resp!(ResetContent, StatusCode::RESET_CONTENT);
+//         static_resp!(PartialContent, StatusCode::PARTIAL_CONTENT);
+//         static_resp!(MultiStatus, StatusCode::MULTI_STATUS);
+//         static_resp!(AlreadyReported, StatusCode::ALREADY_REPORTED);
+
+//         static_resp!(MultipleChoices, StatusCode::MULTIPLE_CHOICES);
+//         static_resp!(MovedPermanently, StatusCode::MOVED_PERMANENTLY);
+//         static_resp!(Found, StatusCode::FOUND);
+//         static_resp!(SeeOther, StatusCode::SEE_OTHER);
+//         static_resp!(NotModified, StatusCode::NOT_MODIFIED);
+//         static_resp!(UseProxy, StatusCode::USE_PROXY);
+//         static_resp!(TemporaryRedirect, StatusCode::TEMPORARY_REDIRECT);
+//         static_resp!(PermanentRedirect, StatusCode::PERMANENT_REDIRECT);
+
+//         static_resp!(BadRequest, StatusCode::BAD_REQUEST);
+//         static_resp!(NotFound, StatusCode::NOT_FOUND);
+//         static_resp!(Unauthorized, StatusCode::UNAUTHORIZED);
+//         static_resp!(PaymentRequired, StatusCode::PAYMENT_REQUIRED);
+//         static_resp!(Forbidden, StatusCode::FORBIDDEN);
+//         static_resp!(MethodNotAllowed, StatusCode::METHOD_NOT_ALLOWED);
+//         static_resp!(NotAcceptable, StatusCode::NOT_ACCEPTABLE);
+//         static_resp!(
+//             ProxyAuthenticationRequired,
+//             StatusCode::PROXY_AUTHENTICATION_REQUIRED
+//         );
+//         static_resp!(RequestTimeout, StatusCode::REQUEST_TIMEOUT);
+//         static_resp!(Conflict, StatusCode::CONFLICT);
+//         static_resp!(Gone, StatusCode::GONE);
+//         static_resp!(LengthRequired, StatusCode::LENGTH_REQUIRED);
+//         static_resp!(PreconditionFailed, StatusCode::PRECONDITION_FAILED);
+//         static_resp!(PreconditionRequired, StatusCode::PRECONDITION_REQUIRED);
+//         static_resp!(PayloadTooLarge, StatusCode::PAYLOAD_TOO_LARGE);
+//         static_resp!(UriTooLong, StatusCode::URI_TOO_LONG);
+//         static_resp!(UnsupportedMediaType, StatusCode::UNSUPPORTED_MEDIA_TYPE);
+//         static_resp!(RangeNotSatisfiable, StatusCode::RANGE_NOT_SATISFIABLE);
+//         static_resp!(ExpectationFailed, StatusCode::EXPECTATION_FAILED);
+//         static_resp!(UnprocessableEntity, StatusCode::UNPROCESSABLE_ENTITY);
+//         static_resp!(TooManyRequests, StatusCode::TOO_MANY_REQUESTS);
+//         static_resp!(
+//             RequestHeaderFieldsTooLarge,
+//             StatusCode::REQUEST_HEADER_FIELDS_TOO_LARGE
+//         );
+//         static_resp!(
+//             UnavailableForLegalReasons,
+//             StatusCode::UNAVAILABLE_FOR_LEGAL_REASONS
+//         );
+
+//         static_resp!(InternalServerError, StatusCode::INTERNAL_SERVER_ERROR);
+//         static_resp!(NotImplemented, StatusCode::NOT_IMPLEMENTED);
+//         static_resp!(BadGateway, StatusCode::BAD_GATEWAY);
+//         static_resp!(ServiceUnavailable, StatusCode::SERVICE_UNAVAILABLE);
+//         static_resp!(GatewayTimeout, StatusCode::GATEWAY_TIMEOUT);
+//         static_resp!(VersionNotSupported, StatusCode::HTTP_VERSION_NOT_SUPPORTED);
+//         static_resp!(VariantAlsoNegotiates, StatusCode::VARIANT_ALSO_NEGOTIATES);
+//         static_resp!(InsufficientStorage, StatusCode::INSUFFICIENT_STORAGE);
+//         static_resp!(LoopDetected, StatusCode::LOOP_DETECTED);
+//     }
+
+//     #[cfg(test)]
+//     mod tests {
+//         use crate::dev::Body;
+//         use crate::http::StatusCode;
+//         use crate::HttpRespone;
+
+//         #[test]
+//         fn test_build() {
+//             let resp = HttpResponse::Ok().body(Body::Empty);
+//             assert_eq!(resp.status(), StatusCode::OK);
+//         }
+//     }
+// }

--- a/src/test.rs
+++ b/src/test.rs
@@ -520,7 +520,7 @@ impl TestRequest {
                 .cookies
                 .delta()
                 // ensure only name=value is written to cookie header
-                .map(|c| Cookie::new(c.name(), c.value()).encoded().to_string())
+                .map(|c| c.stripped().encoded().to_string())
                 .collect::<Vec<_>>()
                 .join("; ");
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -28,7 +28,7 @@ use crate::{
     rmap::ResourceMap,
     service::{ServiceRequest, ServiceResponse},
     web::{Bytes, BytesMut},
-    Error, HttpRequest, HttpResponse,
+    Error, HttpRequest, HttpResponse, HttpResponseBuilder,
 };
 
 /// Create service that always responds with `HttpResponse::Ok()` and no body.
@@ -42,7 +42,7 @@ pub fn default_service(
     status_code: StatusCode,
 ) -> impl Service<ServiceRequest, Response = ServiceResponse<Body>, Error = Error> {
     (move |req: ServiceRequest| {
-        ok(req.into_response(HttpResponse::build(status_code).finish()))
+        ok(req.into_response(HttpResponseBuilder::new(status_code).finish()))
     })
     .into_service()
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -2,8 +2,6 @@
 
 use std::{net::SocketAddr, rc::Rc};
 
-#[cfg(feature = "cookies")]
-use actix_http::cookie::Cookie;
 pub use actix_http::test::TestBuffer;
 use actix_http::{
     http::{header::IntoHeaderPair, Method, StatusCode, Uri, Version},
@@ -444,7 +442,7 @@ impl TestRequest {
 
     /// Set cookie for this request.
     #[cfg(feature = "cookies")]
-    pub fn cookie(mut self, cookie: Cookie<'_>) -> Self {
+    pub fn cookie(mut self, cookie: crate::cookie::Cookie<'_>) -> Self {
         self.req.cookie(cookie);
         self
     }

--- a/src/types/json.rs
+++ b/src/types/json.rs
@@ -233,7 +233,7 @@ where
 ///     .content_type(|mime| mime == mime::TEXT_PLAIN)
 ///     // use custom error handler
 ///     .error_handler(|err, req| {
-///         error::InternalError::from_response(err, HttpResponse::Conflict().finish()).into()
+///         error::InternalError::from_response(err, HttpResponse::Conflict().into()).into()
 ///     });
 ///
 /// App::new()
@@ -494,7 +494,7 @@ mod tests {
                 };
                 let resp =
                     HttpResponse::BadRequest().body(serde_json::to_string(&msg).unwrap());
-                InternalError::from_response(err, resp).into()
+                InternalError::from_response(err, resp.into()).into()
             }))
             .to_http_parts();
 

--- a/src/types/path.rs
+++ b/src/types/path.rs
@@ -155,7 +155,7 @@ where
 ///             .app_data(PathConfig::default().error_handler(|err, req| {
 ///                 error::InternalError::from_response(
 ///                     err,
-///                     HttpResponse::Conflict().finish(),
+///                     HttpResponse::Conflict().into(),
 ///                 )
 ///                 .into()
 ///             }))
@@ -298,15 +298,18 @@ mod tests {
     async fn test_custom_err_handler() {
         let (req, mut pl) = TestRequest::with_uri("/name/user1/")
             .app_data(PathConfig::default().error_handler(|err, _| {
-                error::InternalError::from_response(err, HttpResponse::Conflict().finish())
-                    .into()
+                error::InternalError::from_response(
+                    err,
+                    HttpResponse::Conflict().finish().into(),
+                )
+                .into()
             }))
             .to_http_parts();
 
         let s = Path::<(usize,)>::from_request(&req, &mut pl)
             .await
             .unwrap_err();
-        let res: HttpResponse = s.into();
+        let res = HttpResponse::from_error(s.into());
 
         assert_eq!(res.status(), http::StatusCode::CONFLICT);
     }

--- a/src/types/query.rs
+++ b/src/types/query.rs
@@ -172,7 +172,7 @@ where
 /// let query_cfg = web::QueryConfig::default()
 ///     // use custom error handler
 ///     .error_handler(|err, req| {
-///         error::InternalError::from_response(err, HttpResponse::Conflict().finish()).into()
+///         error::InternalError::from_response(err, HttpResponse::Conflict().into()).into()
 ///     });
 ///
 /// App::new()
@@ -267,7 +267,7 @@ mod tests {
         let req = TestRequest::with_uri("/name/user1/")
             .app_data(QueryConfig::default().error_handler(|e, _| {
                 let resp = HttpResponse::UnprocessableEntity().finish();
-                InternalError::from_response(e, resp).into()
+                InternalError::from_response(e, resp.into()).into()
             }))
             .to_srv_request();
 

--- a/tests/test_server.rs
+++ b/tests/test_server.rs
@@ -826,7 +826,7 @@ mod plus_rustls {
 
 #[actix_rt::test]
 async fn test_server_cookies() {
-    use actix_web::{http, HttpMessage};
+    use actix_web::http;
 
     let srv = actix_test::start(|| {
         App::new().default_service(web::to(|| {

--- a/tests/test_server.rs
+++ b/tests/test_server.rs
@@ -15,6 +15,7 @@ use actix_http::http::header::{
 };
 use brotli2::write::{BrotliDecoder, BrotliEncoder};
 use bytes::Bytes;
+use cookie::{Cookie, CookieBuilder};
 use flate2::{
     read::GzDecoder,
     write::{GzEncoder, ZlibDecoder, ZlibEncoder},
@@ -832,12 +833,12 @@ async fn test_server_cookies() {
         App::new().default_service(web::to(|| {
             HttpResponse::Ok()
                 .cookie(
-                    http::CookieBuilder::new("first", "first_value")
+                    CookieBuilder::new("first", "first_value")
                         .http_only(true)
                         .finish(),
                 )
-                .cookie(http::Cookie::new("second", "first_value"))
-                .cookie(http::Cookie::new("second", "second_value"))
+                .cookie(Cookie::new("second", "first_value"))
+                .cookie(Cookie::new("second", "second_value"))
                 .finish()
         }))
     });
@@ -846,10 +847,10 @@ async fn test_server_cookies() {
     let res = req.send().await.unwrap();
     assert!(res.status().is_success());
 
-    let first_cookie = http::CookieBuilder::new("first", "first_value")
+    let first_cookie = CookieBuilder::new("first", "first_value")
         .http_only(true)
         .finish();
-    let second_cookie = http::Cookie::new("second", "second_value");
+    let second_cookie = Cookie::new("second", "second_value");
 
     let cookies = res.cookies().expect("To have cookies");
     assert_eq!(cookies.len(), 2);


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Improvement


## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
Removes cookie features from -http. Part of this effort necessarily included creating a response and response builder structs in -web; as far as I can see, the changes in this PR are as small as possible to achieve it.
