### PR TITLE
enable fn index(web::Path((id, name)): web::Path<(u32, String)>)

### DIFF
--- a/src/types/path.rs
+++ b/src/types/path.rs
@@ -46,7 +46,7 @@ use crate::{dev::Payload, error::PathError, FromRequest, HttpRequest};
 /// }
 /// ```
 #[derive(PartialEq, Eq, PartialOrd, Ord)]
-pub struct Path<T>(T);
+pub struct Path<T>(pub T);
 
 impl<T> Path<T> {
     /// Unwrap into inner `T` value.


### PR DESCRIPTION
## PR Type
Bug Fix

## PR Checklist
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [ ] (Team) Label with affected crates and semver status.

## Overview
Use of the Path extractor is documented in README.md, which says this is valid:
`async fn index(web::Path((id, name)): web::Path<(u32, String)>) -> impl Responder {`

The above fails to compile.  Earlier versions of actix-web supported Path de-structuring.  The example in README.md and any users' code that uses the Path de-structuring will fail to compile without this PR.

One of the motivations for using the path de-structuring, is to make it easier to review code and ensure that the mapping of path items to corresponding variables, for example:
```
#[get("/foo/{limit}/{offset}")]
pub async fn foo(
    web::Path((limit, offset)): web::Path<(i64, i64)>,
) -> HttpResponse {
```
I fee this is easier to maintain.

I'd be glad to add more tests, documentation or whatever else is needed.