### PR TITLE
change behavior of default upgrade handler

### DIFF
--- a/actix-http/src/h1/dispatcher.rs
+++ b/actix-http/src/h1/dispatcher.rs
@@ -662,7 +662,7 @@ where
                     // got timeout during shutdown, drop connection
                     if this.flags.contains(Flags::SHUTDOWN) {
                         return Err(DispatchError::DisconnectTimeout);
-                    // exceed deadline. check for any outstanding tasks
+                        // exceed deadline. check for any outstanding tasks
                     } else if timer.deadline() >= *this.ka_expire {
                         // have no task at hand.
                         if this.state.is_empty() && this.write_buf.is_empty() {
@@ -695,15 +695,15 @@ where
                                 this.flags.insert(Flags::STARTED | Flags::SHUTDOWN);
                                 this.state.set(State::None);
                             }
-                        // still have unfinished task. try to reset and register keep-alive.
+                            // still have unfinished task. try to reset and register keep-alive.
                         } else if let Some(deadline) =
                             this.codec.config().keep_alive_expire()
                         {
                             timer.as_mut().reset(deadline);
                             let _ = timer.poll(cx);
                         }
-                    // timer resolved but still have not met the keep-alive expire deadline.
-                    // reset and register for later wakeup.
+                        // timer resolved but still have not met the keep-alive expire deadline.
+                        // reset and register for later wakeup.
                     } else {
                         timer.as_mut().reset(*this.ka_expire);
                         let _ = timer.poll(cx);
@@ -951,14 +951,15 @@ mod tests {
     use std::str;
 
     use actix_service::fn_service;
-    use futures_util::future::{lazy, ready};
+    use futures_util::future::{lazy, ready, Ready};
 
     use super::*;
-    use crate::test::TestBuffer;
-    use crate::{error::Error, KeepAlive};
     use crate::{
+        error::Error,
         h1::{ExpectHandler, UpgradeHandler},
-        test::TestSeqBuffer,
+        http::Method,
+        test::{TestBuffer, TestSeqBuffer},
+        HttpMessage, KeepAlive,
     };
 
     fn find_slice(haystack: &[u8], needle: &[u8], from: usize) -> Option<usize> {
@@ -1282,14 +1283,30 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_upgrade() {
+        struct TestUpgrade;
+
+        impl<T> Service<(Request, Framed<T, Codec>)> for TestUpgrade {
+            type Response = ();
+            type Error = Error;
+            type Future = Ready<Result<Self::Response, Self::Error>>;
+
+            actix_service::always_ready!();
+
+            fn call(&self, (req, _framed): (Request, Framed<T, Codec>)) -> Self::Future {
+                assert_eq!(req.method(), Method::GET);
+                assert!(req.upgrade());
+                assert_eq!(req.headers().get("upgrade").unwrap(), "websocket");
+                ready(Ok(()))
+            }
+        }
+
         lazy(|cx| {
             let mut buf = TestSeqBuffer::empty();
             let cfg = ServiceConfig::new(KeepAlive::Disabled, 0, 0, false, None);
 
-            let services =
-                HttpFlow::new(ok_service(), ExpectHandler, Some(UpgradeHandler));
+            let services = HttpFlow::new(ok_service(), ExpectHandler, Some(TestUpgrade));
 
-            let h1 = Dispatcher::<_, _, _, _, UpgradeHandler>::new(
+            let h1 = Dispatcher::<_, _, _, _, TestUpgrade>::new(
                 buf.clone(),
                 cfg,
                 services,

--- a/actix-http/src/h1/upgrade.rs
+++ b/actix-http/src/h1/upgrade.rs
@@ -2,7 +2,7 @@ use std::task::Poll;
 
 use actix_codec::Framed;
 use actix_service::{Service, ServiceFactory};
-use futures_util::future::{ready, Ready};
+use futures_core::future::LocalBoxFuture;
 
 use crate::error::Error;
 use crate::h1::Codec;
@@ -16,7 +16,7 @@ impl<T> ServiceFactory<(Request, Framed<T, Codec>)> for UpgradeHandler {
     type Config = ();
     type Service = UpgradeHandler;
     type InitError = Error;
-    type Future = Ready<Result<Self::Service, Self::InitError>>;
+    type Future = LocalBoxFuture<'static, Result<Self::Service, Self::InitError>>;
 
     fn new_service(&self, _: ()) -> Self::Future {
         unimplemented!()
@@ -26,11 +26,11 @@ impl<T> ServiceFactory<(Request, Framed<T, Codec>)> for UpgradeHandler {
 impl<T> Service<(Request, Framed<T, Codec>)> for UpgradeHandler {
     type Response = ();
     type Error = Error;
-    type Future = Ready<Result<Self::Response, Self::Error>>;
+    type Future = LocalBoxFuture<'static, Result<Self::Response, Self::Error>>;
 
     actix_service::always_ready!();
 
     fn call(&self, _: (Request, Framed<T, Codec>)) -> Self::Future {
-        ready(Ok(()))
+        unimplemented!()
     }
 }


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Refactor


## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Change default upgrade handler to panic. Default upgrade handler is meant to be a placeholder service type and when it's used it should notify it's not usable rather than resolve the service call successfully.

Remove a couple of `futures_util` usage.

Remove some unix cfg attr and move the import to function scope.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
