### PR TITLE
Publicly use actix_web::app_service::AppEntry as actix_web::AppEntry

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,6 +107,7 @@ pub use actix_rt as rt;
 pub use actix_web_codegen::*;
 
 pub use crate::app::App;
+pub use crate::app_service::AppEntry;
 pub use crate::extract::FromRequest;
 pub use crate::request::HttpRequest;
 pub use crate::resource::Resource;


### PR DESCRIPTION
This allows Actix users to move application to separate function. This may be useful when application is big.

```rust
use actix_web::{get, App, AppEntry, HttpResponse, HttpServer, Responder};

#[actix_web::main]
async fn main() -> std::io::Result<()> {
    HttpServer::new(|| app())
        .bind("127.0.0.1:8000")?
        .run()
        .await
}

fn app() -> actix_web::App<AppEntry, actix_web::body::Body> {
    App::new()
        .service(index)
}

#[get("/")]
fn index() -> impl Responder {
    HttpResponse::Ok().body("Hello, World!")
}
```