### PR TITLE
fix routes in Path documentation

### DIFF
--- a/src/types/path.rs
+++ b/src/types/path.rs
@@ -20,7 +20,7 @@ use crate::{dev::Payload, error::PathError, FromRequest, HttpRequest};
 /// // extract path info from "/{name}/{count}/index.html" into tuple
 /// // {name}  - deserialize a String
 /// // {count} - deserialize a u32
-/// #[get("/")]
+/// #[get("/{name}/{count}/index.html")]
 /// async fn index(path: web::Path<(String, u32)>) -> String {
 ///     let (name, count) = path.into_inner();
 ///     format!("Welcome {}! {}", name, count)
@@ -40,7 +40,7 @@ use crate::{dev::Payload, error::PathError, FromRequest, HttpRequest};
 /// }
 ///
 /// // extract `Info` from a path using serde
-/// #[get("/")]
+/// #[get("/{name}")]
 /// async fn index(info: web::Path<Info>) -> String {
 ///     format!("Welcome {}!", info.name)
 /// }


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
Documentation

## PR Checklist
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
The example in the documentation for `actix_web::web::Path` uses the `#[get()]` to set the url, but with wrong urls
I don't really know how relevant it is to ad such a insignificant doc change, should it be added too?