### PR TITLE
Simplify handler factory macro

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -190,3 +190,5 @@ factory_tuple! { A B C D E F G }
 factory_tuple! { A B C D E F G H }
 factory_tuple! { A B C D E F G H I }
 factory_tuple! { A B C D E F G H I J }
+factory_tuple! { A B C D E F G H I J K }
+factory_tuple! { A B C D E F G H I J K L }


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Refactor


## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->


<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->


This PR simplifies the macro that generates the `Handler` implementation for `T: Fn(...)`. It is just a refactoring of the internal macro with zero semantic change.

EDIT: As per the discussion, this PR also bumps the extractor-per-function limit to 12.