### PR TITLE
fix broken pipe for h2 when client is instantly dropped

### DIFF
--- a/actix-http/src/client/connection.rs
+++ b/actix-http/src/client/connection.rs
@@ -174,7 +174,13 @@ impl H2ConnectionInner {
 /// Cancel spawned connection task on drop.
 impl Drop for H2ConnectionInner {
     fn drop(&mut self) {
-        self.handle.abort();
+        if self
+            .sender
+            .send_request(http::Request::new(()), true)
+            .is_err()
+        {
+            self.handle.abort();
+        }
     }
 }
 

--- a/actix-http/src/client/connection.rs
+++ b/actix-http/src/client/connection.rs
@@ -430,6 +430,8 @@ mod test {
 
         drop(conn);
 
+        actix_rt::task::yield_now().await;
+
         match sender.ready().await {
             Ok(_) => panic!("connection should be gone and can not be ready"),
             Err(e) => assert!(e.is_io()),


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Bug Fix


## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

```rust
    let mut res = awc::Client::new()
        .get("https://www.youtube.com/")
        .send()
        .await
        .unwrap();

    let body = res.body().await.unwrap();
```
This is a broken pipe error because `Client` object is dropped in place and h2 connection is dropped together with it.
This PR would try to send a end of stream in case like this and only force drop h2 connection when `SendRequest` object is broken.

But in general we should encourage reuse client object instead of drop it immediately. This would not cause error even without this patch

```rust
    let client = awc::Client::new();
    let mut res = client
        .get("https://www.youtube.com/")
        .send()
        .await
        .unwrap();

    let body = res.body().await.unwrap();
```
<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
