### PR TITLE
remove json and url encoded form support from -http

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,12 @@
 ### Added
 * `HttpResponse` and `HttpResponseBuilder` structs. [#2065]
 
+### Changed
+* Most error types are now marked `#[non_exhaustive]`. [#2148]
+
 [#2065]: https://github.com/actix/actix-web/pull/2065
+[#2148]: https://github.com/actix/actix-web/pull/2148
+
 
 ## 4.0.0-beta.5 - 2021-04-02
 ### Added

--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -9,6 +9,7 @@
 * Deprecated methods on `ResponseBuilder`: `if_true`, `if_some`. [#2148]
 * `ResponseBuilder::json`. [#2148]
 * `ResponseBuilder::{set_header, header}`. [#2148]
+* `impl From<serde_json::Value> for Body`. [#2148]
 
 [#2065]: https://github.com/actix/actix-web/pull/2065
 [#2148]: https://github.com/actix/actix-web/pull/2148

--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -6,12 +6,12 @@
 * Top-level `cookies` mod (re-export). [#2065]
 * `HttpMessage` trait loses the `cookies` and `cookie` methods. [#2065]
 * `impl ResponseError for CookieParseError`. [#2065]
-* Deprecated methods on `ResponseBuilder`: `if_true`, `if_some`. [#????]
-* `ResponseBuilder::json`. [#????]
-* `ResponseBuilder::{set_header, header}`. [#????]
+* Deprecated methods on `ResponseBuilder`: `if_true`, `if_some`. [#2148]
+* `ResponseBuilder::json`. [#2148]
+* `ResponseBuilder::{set_header, header}`. [#2148]
 
 [#2065]: https://github.com/actix/actix-web/pull/2065
-[#????]: https://github.com/actix/actix-web/pull/????
+[#2148]: https://github.com/actix/actix-web/pull/2148
 
 
 ## 3.0.0-beta.5 - 2021-04-02

--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -6,8 +6,12 @@
 * Top-level `cookies` mod (re-export). [#2065]
 * `HttpMessage` trait loses the `cookies` and `cookie` methods. [#2065]
 * `impl ResponseError for CookieParseError`. [#2065]
+* Deprecated methods on `ResponseBuilder`: `if_true`, `if_some`. [#????]
+* `ResponseBuilder::json`. [#????]
+* `ResponseBuilder::{set_header, header}`. [#????]
 
 [#2065]: https://github.com/actix/actix-web/pull/2065
+[#????]: https://github.com/actix/actix-web/pull/????
 
 
 ## 3.0.0-beta.5 - 2021-04-02

--- a/actix-http/Cargo.toml
+++ b/actix-http/Cargo.toml
@@ -68,8 +68,6 @@ pin-project-lite = "0.2"
 rand = "0.8"
 regex = "1.3"
 serde = "1.0"
-serde_json = "1.0"
-serde_urlencoded = "0.7"
 sha-1 = "0.9"
 smallvec = "1.6"
 time = { version = "0.2.23", default-features = false, features = ["std"] }
@@ -89,6 +87,7 @@ criterion = "0.3"
 env_logger = "0.8"
 rcgen = "0.8"
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 tls-openssl = { version = "0.10", package = "openssl" }
 tls-rustls = { version = "0.19", package = "rustls" }
 

--- a/actix-http/src/body/body.rs
+++ b/actix-http/src/body/body.rs
@@ -132,12 +132,6 @@ impl From<BytesMut> for Body {
     }
 }
 
-impl From<serde_json::Value> for Body {
-    fn from(v: serde_json::Value) -> Body {
-        Body::Bytes(v.to_string().into())
-    }
-}
-
 impl<S> From<SizedStream<S>> for Body
 where
     S: Stream<Item = Result<Bytes, Error>> + Unpin + 'static,

--- a/actix-http/src/body/mod.rs
+++ b/actix-http/src/body/mod.rs
@@ -174,13 +174,15 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_serde_json() {
-        use serde_json::json;
+        use serde_json::{json, Value};
         assert_eq!(
-            Body::from(serde_json::Value::String("test".into())).size(),
+            Body::from(serde_json::to_vec(&Value::String("test".to_owned())).unwrap())
+                .size(),
             BodySize::Sized(6)
         );
         assert_eq!(
-            Body::from(json!({"test-key":"test-value"})).size(),
+            Body::from(serde_json::to_vec(&json!({"test-key":"test-value"})).unwrap())
+                .size(),
             BodySize::Sized(25)
         );
     }

--- a/awc/CHANGES.md
+++ b/awc/CHANGES.md
@@ -1,6 +1,10 @@
 # Changes
 
 ## Unreleased - 2021-xx-xx
+### Removed
+* Deprecated methods on `ClientRequest`: `if_true`, `if_some`. [#2148]
+
+[#2148]: https://github.com/actix/actix-web/pull/2148
 
 
 ## 3.0.0-beta.4 - 2021-04-02

--- a/awc/src/request.rs
+++ b/awc/src/request.rs
@@ -311,34 +311,6 @@ impl ClientRequest {
         self
     }
 
-    /// This method calls provided closure with builder reference if value is `true`.
-    #[doc(hidden)]
-    #[deprecated = "Use an if statement."]
-    pub fn if_true<F>(self, value: bool, f: F) -> Self
-    where
-        F: FnOnce(ClientRequest) -> ClientRequest,
-    {
-        if value {
-            f(self)
-        } else {
-            self
-        }
-    }
-
-    /// This method calls provided closure with builder reference if value is `Some`.
-    #[doc(hidden)]
-    #[deprecated = "Use an if-let construction."]
-    pub fn if_some<T, F>(self, value: Option<T>, f: F) -> Self
-    where
-        F: FnOnce(T, ClientRequest) -> ClientRequest,
-    {
-        if let Some(val) = value {
-            f(val, self)
-        } else {
-            self
-        }
-    }
-
     /// Sets the query part of the request
     pub fn query<T: Serialize>(
         mut self,

--- a/awc/src/sender.rs
+++ b/awc/src/sender.rs
@@ -1,6 +1,6 @@
 use std::{
     future::Future,
-    net,
+    io, net,
     pin::Pin,
     rc::Rc,
     task::{Context, Poll},
@@ -209,7 +209,8 @@ impl RequestSender {
     ) -> SendClientRequest {
         let body = match serde_json::to_string(value) {
             Ok(body) => body,
-            Err(e) => return Error::from(e).into(),
+            // TODO: own error type
+            Err(e) => return Error::from(io::Error::new(io::ErrorKind::Other, e)).into(),
         };
 
         if let Err(e) = self.set_header_if_none(header::CONTENT_TYPE, "application/json") {
@@ -235,7 +236,8 @@ impl RequestSender {
     ) -> SendClientRequest {
         let body = match serde_urlencoded::to_string(value) {
             Ok(body) => body,
-            Err(e) => return Error::from(e).into(),
+            // TODO: own error type
+            Err(e) => return Error::from(io::Error::new(io::ErrorKind::Other, e)).into(),
         };
 
         // set content-type

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,12 +3,15 @@
 pub use actix_http::error::*;
 use derive_more::{Display, Error, From};
 use serde_json::error::Error as JsonError;
+use serde_urlencoded::de::Error as FormDeError;
+use serde_urlencoded::ser::Error as FormError;
 use url::ParseError as UrlParseError;
 
 use crate::http::StatusCode;
 
 /// Errors which can occur when attempting to generate resource uri.
-#[derive(Debug, PartialEq, Display, From)]
+#[derive(Debug, PartialEq, Display, Error, From)]
+#[non_exhaustive]
 pub enum UrlGenerationError {
     /// Resource not found
     #[display(fmt = "Resource not found")]
@@ -23,13 +26,12 @@ pub enum UrlGenerationError {
     ParseError(UrlParseError),
 }
 
-impl std::error::Error for UrlGenerationError {}
-
 /// `InternalServerError` for `UrlGeneratorError`
 impl ResponseError for UrlGenerationError {}
 
 /// A set of errors that can occur during parsing urlencoded payloads
 #[derive(Debug, Display, Error, From)]
+#[non_exhaustive]
 pub enum UrlencodedError {
     /// Can not decode chunked transfer encoding.
     #[display(fmt = "Can not decode chunked transfer encoding.")]
@@ -52,8 +54,16 @@ pub enum UrlencodedError {
     ContentType,
 
     /// Parse error.
-    #[display(fmt = "Parse error.")]
-    Parse,
+    #[display(fmt = "Parse error: {}.", _0)]
+    Parse(FormDeError),
+
+    /// Encoding error.
+    #[display(fmt = "Encoding error.")]
+    Encoding,
+
+    /// Serialize error.
+    #[display(fmt = "Serialize error: {}.", _0)]
+    Serialize(FormError),
 
     /// Payload error.
     #[display(fmt = "Error that occur during reading payload: {}.", _0)]
@@ -63,61 +73,78 @@ pub enum UrlencodedError {
 /// Return `BadRequest` for `UrlencodedError`
 impl ResponseError for UrlencodedError {
     fn status_code(&self) -> StatusCode {
-        match *self {
-            UrlencodedError::Overflow { .. } => StatusCode::PAYLOAD_TOO_LARGE,
-            UrlencodedError::UnknownLength => StatusCode::LENGTH_REQUIRED,
+        match self {
+            Self::Overflow { .. } => StatusCode::PAYLOAD_TOO_LARGE,
+            Self::UnknownLength => StatusCode::LENGTH_REQUIRED,
+            Self::Payload(err) => err.status_code(),
             _ => StatusCode::BAD_REQUEST,
         }
     }
 }
 
 /// A set of errors that can occur during parsing json payloads
-#[derive(Debug, Display, From)]
+#[derive(Debug, Display, Error)]
+#[non_exhaustive]
 pub enum JsonPayloadError {
     /// Payload size is bigger than allowed. (default: 32kB)
     #[display(fmt = "Json payload size is bigger than allowed")]
     Overflow,
+
     /// Content type error
     #[display(fmt = "Content type error")]
     ContentType,
+
     /// Deserialize error
     #[display(fmt = "Json deserialize error: {}", _0)]
     Deserialize(JsonError),
+
+    /// Serialize error
+    #[display(fmt = "Json serialize error: {}", _0)]
+    Serialize(JsonError),
+
     /// Payload error
     #[display(fmt = "Error that occur during reading payload: {}", _0)]
     Payload(PayloadError),
 }
 
-impl std::error::Error for JsonPayloadError {}
+impl From<PayloadError> for JsonPayloadError {
+    fn from(err: PayloadError) -> Self {
+        Self::Payload(err)
+    }
+}
 
 impl ResponseError for JsonPayloadError {
     fn status_code(&self) -> StatusCode {
-        match *self {
-            JsonPayloadError::Overflow => StatusCode::PAYLOAD_TOO_LARGE,
+        match self {
+            Self::Overflow => StatusCode::PAYLOAD_TOO_LARGE,
+            Self::Serialize(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::Payload(err) => err.status_code(),
             _ => StatusCode::BAD_REQUEST,
         }
     }
 }
 
 /// A set of errors that can occur during parsing request paths
-#[derive(Debug, Display, From)]
+#[derive(Debug, Display, Error)]
+#[non_exhaustive]
 pub enum PathError {
     /// Deserialize error
     #[display(fmt = "Path deserialize error: {}", _0)]
     Deserialize(serde::de::value::Error),
 }
 
-impl std::error::Error for PathError {}
-
 /// Return `BadRequest` for `PathError`
 impl ResponseError for PathError {
     fn status_code(&self) -> StatusCode {
-        StatusCode::BAD_REQUEST
+        match self {
+            _ => StatusCode::BAD_REQUEST,
+        }
     }
 }
 
 /// A set of errors that can occur during parsing query strings.
 #[derive(Debug, Display, Error, From)]
+#[non_exhaustive]
 pub enum QueryPayloadError {
     /// Query deserialize error.
     #[display(fmt = "Query deserialize error: {}", _0)]
@@ -132,24 +159,25 @@ impl ResponseError for QueryPayloadError {
 }
 
 /// Error type returned when reading body as lines.
-#[derive(From, Display, Debug)]
+#[derive(Debug, Display, Error, From)]
+#[non_exhaustive]
 pub enum ReadlinesError {
-    /// Error when decoding a line.
     #[display(fmt = "Encoding error")]
     /// Payload size is bigger than allowed. (default: 256kB)
     EncodingError,
+
     /// Payload error.
     #[display(fmt = "Error that occur during reading payload: {}", _0)]
     Payload(PayloadError),
+
     /// Line limit exceeded.
     #[display(fmt = "Line limit exceeded")]
     LimitOverflow,
+
     /// ContentType error.
     #[display(fmt = "Content-type error")]
     ContentTypeError(ContentTypeError),
 }
-
-impl std::error::Error for ReadlinesError {}
 
 /// Return `BadRequest` for `ReadlinesError`
 impl ResponseError for ReadlinesError {

--- a/src/error.rs
+++ b/src/error.rs
@@ -136,9 +136,7 @@ pub enum PathError {
 /// Return `BadRequest` for `PathError`
 impl ResponseError for PathError {
     fn status_code(&self) -> StatusCode {
-        match self {
-            _ => StatusCode::BAD_REQUEST,
-        }
+        StatusCode::BAD_REQUEST
     }
 }
 

--- a/src/types/form.rs
+++ b/src/types/form.rs
@@ -163,7 +163,7 @@ impl<T: Serialize> Responder for Form<T> {
             Ok(body) => HttpResponse::Ok()
                 .content_type(mime::APPLICATION_WWW_FORM_URLENCODED)
                 .body(body),
-            Err(err) => HttpResponse::from_error(err.into()),
+            Err(err) => HttpResponse::from_error(UrlencodedError::Serialize(err).into()),
         }
     }
 }
@@ -346,14 +346,14 @@ where
                 }
 
                 if encoding == UTF_8 {
-                    serde_urlencoded::from_bytes::<T>(&body).map_err(|_| UrlencodedError::Parse)
+                    serde_urlencoded::from_bytes::<T>(&body).map_err(UrlencodedError::Parse)
                 } else {
                     let body = encoding
                         .decode_without_bom_handling_and_without_replacement(&body)
                         .map(|s| s.into_owned())
-                        .ok_or(UrlencodedError::Parse)?;
+                        .ok_or(UrlencodedError::Encoding)?;
 
-                    serde_urlencoded::from_str::<T>(&body).map_err(|_| UrlencodedError::Parse)
+                    serde_urlencoded::from_str::<T>(&body).map_err(UrlencodedError::Parse)
                 }
             }
             .boxed_local(),

--- a/src/types/json.rs
+++ b/src/types/json.rs
@@ -127,7 +127,7 @@ impl<T: Serialize> Responder for Json<T> {
             Ok(body) => HttpResponse::Ok()
                 .content_type(mime::APPLICATION_JSON)
                 .body(body),
-            Err(err) => HttpResponse::from_error(err.into()),
+            Err(err) => HttpResponse::from_error(JsonPayloadError::Serialize(err).into()),
         }
     }
 }
@@ -412,7 +412,8 @@ where
                         }
                     }
                     None => {
-                        let json = serde_json::from_slice::<T>(&buf)?;
+                        let json = serde_json::from_slice::<T>(&buf)
+                            .map_err(JsonPayloadError::Deserialize)?;
                         return Poll::Ready(Ok(json));
                     }
                 }


### PR DESCRIPTION
## PR Type
Dep Reduction


## PR Checklist
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
Further reduce the number of dependencies on -http, making it simpler.

Removes some `Into<Error>` and `ResponseError` impls for each lib's error types. I think this makes sense anyway but need to look at the error system before v4 anyhow, it's possible the response error trait can be moved to -web, too, which would make it possible to re-impl for these types.