### PR TITLE
files: Don't use canonical path when serving file

### DIFF
--- a/actix-files/CHANGES.md
+++ b/actix-files/CHANGES.md
@@ -1,6 +1,9 @@
 # Changes
 
 ## Unreleased - 2021-xx-xx
+* For symbolic links, `Content-Disposition` header no longer shows the filename of the original file. [#2156]
+
+[#2156]: https://github.com/actix/actix-web/pull/2156
 
 
 ## 0.6.0-beta.4 - 2021-04-02

--- a/actix-files/src/lib.rs
+++ b/actix-files/src/lib.rs
@@ -754,4 +754,19 @@ mod tests {
         let res = test::call_service(&srv, req).await;
         assert_eq!(res.status(), StatusCode::OK);
     }
+
+    #[actix_rt::test]
+    async fn test_symlinks() {
+        let srv = test::init_service(App::new().service(Files::new("test", "."))).await;
+
+        let req = TestRequest::get()
+            .uri("/test/tests/symlink-test.png")
+            .to_request();
+        let res = test::call_service(&srv, req).await;
+        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(
+            res.headers().get(header::CONTENT_DISPOSITION).unwrap(),
+            "inline; filename=\"symlink-test.png\""
+        );
+    }
 }

--- a/actix-files/src/service.rs
+++ b/actix-files/src/service.rs
@@ -83,10 +83,10 @@ impl Service<ServiceRequest> for FilesService {
             };
 
         // full file path
-        let path = match self.directory.join(&real_path).canonicalize() {
-            Ok(path) => path,
-            Err(err) => return Box::pin(self.handle_err(err, req)),
-        };
+        let path = self.directory.join(&real_path);
+        if let Err(err) = path.canonicalize() {
+            return Box::pin(self.handle_err(err, req));
+        }
 
         if path.is_dir() {
             if let Some(ref redir_index) = self.index {

--- a/actix-files/tests/symlink-test.png
+++ b/actix-files/tests/symlink-test.png
@@ -1,0 +1,1 @@
+test.png


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Bug Fix


## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Otherwise, for symlink files, the content-disposition header would be set to the filename of the pointed-to file.

<!-- If this PR fixes or closes an issue, reference it here. -->
Closes #2128 
