### PR TITLE
remove http-codes builders from actix-http

### DIFF
--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -3,6 +3,7 @@
 ## Unreleased - 2021-xx-xx
 ### Added
 * `impl<T: MessageBody> MessageBody for Pin<Box<T>>`. [#2152]
+* `Response::{ok, bad_request, not_found, internal_server_error}`. [#????]
 
 ### Changes
 * The type parameter of `Response` no longer has a default. [#2152]
@@ -18,10 +19,13 @@
 * `ResponseBuilder::json`. [#2148]
 * `ResponseBuilder::{set_header, header}`. [#2148]
 * `impl From<serde_json::Value> for Body`. [#2148]
+* `Response::build_from`. [#????]
+* Most of the status code builders on `Response`. [#????]
 
 [#2065]: https://github.com/actix/actix-web/pull/2065
 [#2148]: https://github.com/actix/actix-web/pull/2148
 [#2152]: https://github.com/actix/actix-web/pull/2152
+[#????]: https://github.com/actix/actix-web/pull/????
 
 
 ## 3.0.0-beta.5 - 2021-04-02

--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -3,7 +3,7 @@
 ## Unreleased - 2021-xx-xx
 ### Added
 * `impl<T: MessageBody> MessageBody for Pin<Box<T>>`. [#2152]
-* `Response::{ok, bad_request, not_found, internal_server_error}`. [#????]
+* `Response::{ok, bad_request, not_found, internal_server_error}`. [#2159]
 
 ### Changes
 * The type parameter of `Response` no longer has a default. [#2152]
@@ -19,13 +19,13 @@
 * `ResponseBuilder::json`. [#2148]
 * `ResponseBuilder::{set_header, header}`. [#2148]
 * `impl From<serde_json::Value> for Body`. [#2148]
-* `Response::build_from`. [#????]
-* Most of the status code builders on `Response`. [#????]
+* `Response::build_from`. [#2159]
+* Most of the status code builders on `Response`. [#2159]
 
 [#2065]: https://github.com/actix/actix-web/pull/2065
 [#2148]: https://github.com/actix/actix-web/pull/2148
 [#2152]: https://github.com/actix/actix-web/pull/2152
-[#????]: https://github.com/actix/actix-web/pull/????
+[#2159]: https://github.com/actix/actix-web/pull/2159
 
 
 ## 3.0.0-beta.5 - 2021-04-02

--- a/actix-http/examples/echo.rs
+++ b/actix-http/examples/echo.rs
@@ -1,6 +1,6 @@
 use std::{env, io};
 
-use actix_http::{Error, HttpService, Request, Response};
+use actix_http::{http::StatusCode, Error, HttpService, Request, Response};
 use actix_server::Server;
 use bytes::BytesMut;
 use futures_util::StreamExt as _;
@@ -25,7 +25,7 @@ async fn main() -> io::Result<()> {
 
                     info!("request body: {:?}", body);
                     Ok::<_, Error>(
-                        Response::Ok()
+                        Response::build(StatusCode::OK)
                             .insert_header((
                                 "x-head",
                                 HeaderValue::from_static("dummy value!"),

--- a/actix-http/examples/echo2.rs
+++ b/actix-http/examples/echo2.rs
@@ -1,6 +1,6 @@
 use std::{env, io};
 
-use actix_http::{body::Body, http::HeaderValue};
+use actix_http::{body::Body, http::HeaderValue, http::StatusCode};
 use actix_http::{Error, HttpService, Request, Response};
 use actix_server::Server;
 use bytes::BytesMut;
@@ -14,7 +14,7 @@ async fn handle_request(mut req: Request) -> Result<Response<Body>, Error> {
     }
 
     info!("request body: {:?}", body);
-    Ok(Response::Ok()
+    Ok(Response::build(StatusCode::OK)
         .insert_header(("x-head", HeaderValue::from_static("dummy value!")))
         .body(body))
 }

--- a/actix-http/examples/hello-world.rs
+++ b/actix-http/examples/hello-world.rs
@@ -1,6 +1,6 @@
 use std::{env, io};
 
-use actix_http::{HttpService, Response};
+use actix_http::{http::StatusCode, HttpService, Response};
 use actix_server::Server;
 use actix_utils::future;
 use http::header::HeaderValue;
@@ -18,7 +18,7 @@ async fn main() -> io::Result<()> {
                 .client_disconnect(1000)
                 .finish(|_req| {
                     info!("{:?}", _req);
-                    let mut res = Response::Ok();
+                    let mut res = Response::build(StatusCode::OK);
                     res.insert_header((
                         "x-head",
                         HeaderValue::from_static("dummy value!"),

--- a/actix-http/src/error.rs
+++ b/actix-http/src/error.rs
@@ -1021,8 +1021,7 @@ mod tests {
 
     #[test]
     fn test_internal_error() {
-        let err =
-            InternalError::from_response(ParseError::Method, Response::Ok().into());
+        let err = InternalError::from_response(ParseError::Method, Response::ok());
         let resp: Response<Body> = err.error_response();
         assert_eq!(resp.status(), StatusCode::OK);
     }

--- a/actix-http/src/h1/dispatcher.rs
+++ b/actix-http/src/h1/dispatcher.rs
@@ -21,6 +21,7 @@ use crate::body::{Body, BodySize, MessageBody, ResponseBody};
 use crate::config::ServiceConfig;
 use crate::error::{DispatchError, Error};
 use crate::error::{ParseError, PayloadError};
+use crate::http::StatusCode;
 use crate::request::Request;
 use crate::response::Response;
 use crate::service::HttpFlow;
@@ -562,7 +563,7 @@ where
                                 );
                                 this.flags.insert(Flags::READ_DISCONNECT);
                                 this.messages.push_back(DispatcherMessage::Error(
-                                    Response::InternalServerError().finish().drop_body(),
+                                    Response::internal_server_error().drop_body(),
                                 ));
                                 *this.error = Some(DispatchError::InternalError);
                                 break;
@@ -575,7 +576,7 @@ where
                                 error!("Internal server error: unexpected eof");
                                 this.flags.insert(Flags::READ_DISCONNECT);
                                 this.messages.push_back(DispatcherMessage::Error(
-                                    Response::InternalServerError().finish().drop_body(),
+                                    Response::internal_server_error().drop_body(),
                                 ));
                                 *this.error = Some(DispatchError::InternalError);
                                 break;
@@ -598,7 +599,8 @@ where
                     }
                     // Requests overflow buffer size should be responded with 431
                     this.messages.push_back(DispatcherMessage::Error(
-                        Response::RequestHeaderFieldsTooLarge().finish().drop_body(),
+                        Response::new(StatusCode::REQUEST_HEADER_FIELDS_TOO_LARGE)
+                            .drop_body(),
                     ));
                     this.flags.insert(Flags::READ_DISCONNECT);
                     *this.error = Some(ParseError::TooLarge.into());
@@ -611,7 +613,7 @@ where
 
                     // Malformed requests should be responded with 400
                     this.messages.push_back(DispatcherMessage::Error(
-                        Response::BadRequest().finish().drop_body(),
+                        Response::bad_request().drop_body(),
                     ));
                     this.flags.insert(Flags::READ_DISCONNECT);
                     *this.error = Some(err.into());
@@ -684,7 +686,8 @@ where
                                 if !this.flags.contains(Flags::STARTED) {
                                     trace!("Slow request timeout");
                                     let _ = self.as_mut().send_response(
-                                        Response::RequestTimeout().finish().drop_body(),
+                                        Response::new(StatusCode::REQUEST_TIMEOUT)
+                                            .drop_body(),
                                         ResponseBody::Other(Body::Empty),
                                     );
                                     this = self.project();
@@ -951,6 +954,7 @@ mod tests {
 
     use actix_service::fn_service;
     use actix_utils::future::{ready, Ready};
+    use bytes::Bytes;
     use futures_util::future::lazy;
 
     use super::*;
@@ -979,19 +983,21 @@ mod tests {
     }
 
     fn ok_service() -> impl Service<Request, Response = Response<Body>, Error = Error> {
-        fn_service(|_req: Request| ready(Ok::<_, Error>(Response::Ok().finish())))
+        fn_service(|_req: Request| ready(Ok::<_, Error>(Response::ok())))
     }
 
     fn echo_path_service(
     ) -> impl Service<Request, Response = Response<Body>, Error = Error> {
         fn_service(|req: Request| {
             let path = req.path().as_bytes();
-            ready(Ok::<_, Error>(Response::Ok().body(Body::from_slice(path))))
+            ready(Ok::<_, Error>(
+                Response::ok().set_body(Body::from_slice(path)),
+            ))
         })
     }
 
     fn echo_payload_service(
-    ) -> impl Service<Request, Response = Response<Body>, Error = Error> {
+    ) -> impl Service<Request, Response = Response<Bytes>, Error = Error> {
         fn_service(|mut req: Request| {
             Box::pin(async move {
                 use futures_util::stream::StreamExt as _;
@@ -1002,7 +1008,7 @@ mod tests {
                     body.extend_from_slice(chunk.unwrap().chunk())
                 }
 
-                Ok::<_, Error>(Response::Ok().body(body))
+                Ok::<_, Error>(Response::ok().set_body(body.freeze()))
             })
         })
     }

--- a/actix-http/src/lib.rs
+++ b/actix-http/src/lib.rs
@@ -37,7 +37,6 @@ pub mod encoding;
 mod extensions;
 mod header;
 mod helpers;
-mod http_codes;
 mod http_message;
 mod message;
 mod payload;

--- a/actix-http/src/response.rs
+++ b/actix-http/src/response.rs
@@ -29,18 +29,6 @@ pub struct Response<B> {
 }
 
 impl Response<Body> {
-    /// Create HTTP response builder with specific status.
-    #[inline]
-    pub fn build(status: StatusCode) -> ResponseBuilder {
-        ResponseBuilder::new(status)
-    }
-
-    /// Create HTTP response builder
-    #[inline]
-    pub fn build_from<T: Into<ResponseBuilder>>(source: T) -> ResponseBuilder {
-        source.into()
-    }
-
     /// Constructs a response
     #[inline]
     pub fn new(status: StatusCode) -> Response<Body> {
@@ -50,6 +38,41 @@ impl Response<Body> {
             error: None,
         }
     }
+
+    /// Create HTTP response builder with specific status.
+    #[inline]
+    pub fn build(status: StatusCode) -> ResponseBuilder {
+        ResponseBuilder::new(status)
+    }
+
+    // just a couple frequently used shortcuts
+    // this list should not grow larger than a few
+
+    /// Creates a new response with status 200 OK.
+    #[inline]
+    pub fn ok() -> Response<Body> {
+        Response::new(StatusCode::OK)
+    }
+
+    /// Creates a new response with status 400 Bad Request.
+    #[inline]
+    pub fn bad_request() -> Response<Body> {
+        Response::new(StatusCode::OK)
+    }
+
+    /// Creates a new response with status 404 Not Found.
+    #[inline]
+    pub fn not_found() -> Response<Body> {
+        Response::new(StatusCode::NOT_FOUND)
+    }
+
+    /// Creates a new response with status 500 Internal Server Error.
+    #[inline]
+    pub fn internal_server_error() -> Response<Body> {
+        Response::new(StatusCode::INTERNAL_SERVER_ERROR)
+    }
+
+    // end shortcuts
 
     /// Constructs an error response
     #[inline]
@@ -283,7 +306,7 @@ impl ResponseBuilder {
     /// # use actix_http::Response;
     /// use actix_http::http::header;
     ///
-    /// Response::Ok()
+    /// Response::build(StatusCode::OK)
     ///     .insert_header((header::CONTENT_TYPE, mime::APPLICATION_JSON))
     ///     .insert_header(("X-TEST", "value"))
     ///     .finish();
@@ -310,7 +333,7 @@ impl ResponseBuilder {
     /// # use actix_http::Response;
     /// use actix_http::http::header;
     ///
-    /// Response::Ok()
+    /// Response::build(StatusCode::OK)
     ///     .append_header((header::CONTENT_TYPE, mime::APPLICATION_JSON))
     ///     .append_header(("X-TEST", "value1"))
     ///     .append_header(("X-TEST", "value2"))
@@ -557,7 +580,7 @@ impl From<ResponseBuilder> for Response<Body> {
 
 impl From<&'static str> for Response<Body> {
     fn from(val: &'static str) -> Self {
-        Response::Ok()
+        Response::build(StatusCode::OK)
             .content_type(mime::TEXT_PLAIN_UTF_8)
             .body(val)
     }
@@ -565,7 +588,7 @@ impl From<&'static str> for Response<Body> {
 
 impl From<&'static [u8]> for Response<Body> {
     fn from(val: &'static [u8]) -> Self {
-        Response::Ok()
+        Response::build(StatusCode::OK)
             .content_type(mime::APPLICATION_OCTET_STREAM)
             .body(val)
     }
@@ -573,7 +596,7 @@ impl From<&'static [u8]> for Response<Body> {
 
 impl From<String> for Response<Body> {
     fn from(val: String) -> Self {
-        Response::Ok()
+        Response::build(StatusCode::OK)
             .content_type(mime::TEXT_PLAIN_UTF_8)
             .body(val)
     }
@@ -581,7 +604,7 @@ impl From<String> for Response<Body> {
 
 impl<'a> From<&'a String> for Response<Body> {
     fn from(val: &'a String) -> Self {
-        Response::Ok()
+        Response::build(StatusCode::OK)
             .content_type(mime::TEXT_PLAIN_UTF_8)
             .body(val)
     }
@@ -589,7 +612,7 @@ impl<'a> From<&'a String> for Response<Body> {
 
 impl From<Bytes> for Response<Body> {
     fn from(val: Bytes) -> Self {
-        Response::Ok()
+        Response::build(StatusCode::OK)
             .content_type(mime::APPLICATION_OCTET_STREAM)
             .body(val)
     }
@@ -597,7 +620,7 @@ impl From<Bytes> for Response<Body> {
 
 impl From<BytesMut> for Response<Body> {
     fn from(val: BytesMut) -> Self {
-        Response::Ok()
+        Response::build(StatusCode::OK)
             .content_type(mime::APPLICATION_OCTET_STREAM)
             .body(val)
     }
@@ -611,7 +634,7 @@ mod tests {
 
     #[test]
     fn test_debug() {
-        let resp = Response::Ok()
+        let resp = Response::build(StatusCode::OK)
             .append_header((COOKIE, HeaderValue::from_static("cookie1=value1; ")))
             .append_header((COOKIE, HeaderValue::from_static("cookie2=value2; ")))
             .finish();
@@ -621,7 +644,9 @@ mod tests {
 
     #[test]
     fn test_basic_builder() {
-        let resp = Response::Ok().insert_header(("X-TEST", "value")).finish();
+        let resp = Response::build(StatusCode::OK)
+            .insert_header(("X-TEST", "value"))
+            .finish();
         assert_eq!(resp.status(), StatusCode::OK);
     }
 
@@ -741,7 +766,7 @@ mod tests {
 
     #[test]
     fn response_builder_header_insert_kv() {
-        let mut res = Response::Ok();
+        let mut res = Response::build(StatusCode::OK);
         res.insert_header(("Content-Type", "application/octet-stream"));
         let res = res.finish();
 
@@ -753,7 +778,7 @@ mod tests {
 
     #[test]
     fn response_builder_header_insert_typed() {
-        let mut res = Response::Ok();
+        let mut res = Response::build(StatusCode::OK);
         res.insert_header((header::CONTENT_TYPE, mime::APPLICATION_OCTET_STREAM));
         let res = res.finish();
 
@@ -765,7 +790,7 @@ mod tests {
 
     #[test]
     fn response_builder_header_append_kv() {
-        let mut res = Response::Ok();
+        let mut res = Response::build(StatusCode::OK);
         res.append_header(("Content-Type", "application/octet-stream"));
         res.append_header(("Content-Type", "application/json"));
         let res = res.finish();
@@ -778,7 +803,7 @@ mod tests {
 
     #[test]
     fn response_builder_header_append_typed() {
-        let mut res = Response::Ok();
+        let mut res = Response::build(StatusCode::OK);
         res.append_header((header::CONTENT_TYPE, mime::APPLICATION_OCTET_STREAM));
         res.append_header((header::CONTENT_TYPE, mime::APPLICATION_JSON));
         let res = res.finish();

--- a/actix-http/src/response.rs
+++ b/actix-http/src/response.rs
@@ -57,7 +57,7 @@ impl Response<Body> {
     /// Creates a new response with status 400 Bad Request.
     #[inline]
     pub fn bad_request() -> Response<Body> {
-        Response::new(StatusCode::OK)
+        Response::new(StatusCode::BAD_REQUEST)
     }
 
     /// Creates a new response with status 404 Not Found.
@@ -304,7 +304,7 @@ impl ResponseBuilder {
     ///
     /// ```
     /// # use actix_http::Response;
-    /// use actix_http::http::header;
+    /// use actix_http::http::{header, StatusCode};
     ///
     /// Response::build(StatusCode::OK)
     ///     .insert_header((header::CONTENT_TYPE, mime::APPLICATION_JSON))
@@ -331,7 +331,7 @@ impl ResponseBuilder {
     ///
     /// ```
     /// # use actix_http::Response;
-    /// use actix_http::http::header;
+    /// use actix_http::http::{header, StatusCode};
     ///
     /// Response::build(StatusCode::OK)
     ///     .append_header((header::CONTENT_TYPE, mime::APPLICATION_JSON))

--- a/actix-http/src/ws/mod.rs
+++ b/actix-http/src/ws/mod.rs
@@ -101,29 +101,37 @@ pub enum HandshakeError {
 impl ResponseError for HandshakeError {
     fn error_response(&self) -> Response<Body> {
         match self {
-            HandshakeError::GetMethodRequired => Response::MethodNotAllowed()
-                .insert_header((header::ALLOW, "GET"))
-                .finish(),
+            HandshakeError::GetMethodRequired => {
+                Response::build(StatusCode::METHOD_NOT_ALLOWED)
+                    .insert_header((header::ALLOW, "GET"))
+                    .finish()
+            }
 
-            HandshakeError::NoWebsocketUpgrade => Response::BadRequest()
-                .reason("No WebSocket Upgrade header found")
-                .finish(),
+            HandshakeError::NoWebsocketUpgrade => {
+                Response::build(StatusCode::BAD_REQUEST)
+                    .reason("No WebSocket Upgrade header found")
+                    .finish()
+            }
 
-            HandshakeError::NoConnectionUpgrade => Response::BadRequest()
-                .reason("No Connection upgrade")
-                .finish(),
+            HandshakeError::NoConnectionUpgrade => {
+                Response::build(StatusCode::BAD_REQUEST)
+                    .reason("No Connection upgrade")
+                    .finish()
+            }
 
-            HandshakeError::NoVersionHeader => Response::BadRequest()
+            HandshakeError::NoVersionHeader => Response::build(StatusCode::BAD_REQUEST)
                 .reason("WebSocket version header is required")
                 .finish(),
 
-            HandshakeError::UnsupportedVersion => Response::BadRequest()
-                .reason("Unsupported WebSocket version")
-                .finish(),
-
-            HandshakeError::BadWebsocketKey => {
-                Response::BadRequest().reason("Handshake error").finish()
+            HandshakeError::UnsupportedVersion => {
+                Response::build(StatusCode::BAD_REQUEST)
+                    .reason("Unsupported WebSocket version")
+                    .finish()
             }
+
+            HandshakeError::BadWebsocketKey => Response::build(StatusCode::BAD_REQUEST)
+                .reason("Handshake error")
+                .finish(),
         }
     }
 }

--- a/actix-http/tests/test_client.rs
+++ b/actix-http/tests/test_client.rs
@@ -33,7 +33,7 @@ const STR: &str = "Hello World Hello World Hello World Hello World Hello World \
 async fn test_h1_v2() {
     let srv = test_server(move || {
         HttpService::build()
-            .finish(|_| future::ok::<_, ()>(Response::Ok().body(STR)))
+            .finish(|_| future::ok::<_, ()>(Response::ok().set_body(STR)))
             .tcp()
     })
     .await;
@@ -61,7 +61,7 @@ async fn test_h1_v2() {
 async fn test_connection_close() {
     let srv = test_server(move || {
         HttpService::build()
-            .finish(|_| future::ok::<_, ()>(Response::Ok().body(STR)))
+            .finish(|_| future::ok::<_, ()>(Response::ok().set_body(STR)))
             .tcp()
             .map(|_| ())
     })
@@ -77,9 +77,9 @@ async fn test_with_query_parameter() {
         HttpService::build()
             .finish(|req: Request| {
                 if req.uri().query().unwrap().contains("qp=") {
-                    future::ok::<_, ()>(Response::Ok().finish())
+                    future::ok::<_, ()>(Response::ok())
                 } else {
-                    future::ok::<_, ()>(Response::BadRequest().finish())
+                    future::ok::<_, ()>(Response::bad_request())
                 }
             })
             .tcp()
@@ -112,7 +112,7 @@ async fn test_h1_expect() {
                 let str = std::str::from_utf8(&buf).unwrap();
                 assert_eq!(str, "expect body");
 
-                Ok::<_, ()>(Response::Ok().finish())
+                Ok::<_, ()>(Response::ok())
             })
             .tcp()
     })

--- a/actix-http/tests/test_openssl.rs
+++ b/actix-http/tests/test_openssl.rs
@@ -71,7 +71,7 @@ fn tls_config() -> SslAcceptor {
 async fn test_h2() -> io::Result<()> {
     let srv = test_server(move || {
         HttpService::build()
-            .h2(|_| ok::<_, Error>(Response::Ok().finish()))
+            .h2(|_| ok::<_, Error>(Response::ok()))
             .openssl(tls_config())
             .map_err(|_| ())
     })
@@ -89,7 +89,7 @@ async fn test_h2_1() -> io::Result<()> {
             .finish(|req: Request| {
                 assert!(req.peer_addr().is_some());
                 assert_eq!(req.version(), Version::HTTP_2);
-                ok::<_, Error>(Response::Ok().finish())
+                ok::<_, Error>(Response::ok())
             })
             .openssl(tls_config())
             .map_err(|_| ())
@@ -108,7 +108,7 @@ async fn test_h2_body() -> io::Result<()> {
         HttpService::build()
             .h2(|mut req: Request<_>| async move {
                 let body = load_body(req.take_payload()).await?;
-                Ok::<_, Error>(Response::Ok().body(body))
+                Ok::<_, Error>(Response::build(StatusCode::OK).body(body))
             })
             .openssl(tls_config())
             .map_err(|_| ())
@@ -186,7 +186,7 @@ async fn test_h2_headers() {
     let mut srv = test_server(move || {
         let data = data.clone();
         HttpService::build().h2(move |_| {
-            let mut builder = Response::Ok();
+            let mut builder = Response::build(StatusCode::OK);
             for idx in 0..90 {
                 builder.insert_header(
                     (format!("X-TEST-{}", idx).as_str(),
@@ -245,7 +245,7 @@ const STR: &str = "Hello World Hello World Hello World Hello World Hello World \
 async fn test_h2_body2() {
     let mut srv = test_server(move || {
         HttpService::build()
-            .h2(|_| ok::<_, ()>(Response::Ok().body(STR)))
+            .h2(|_| ok::<_, ()>(Response::build(StatusCode::OK).body(STR)))
             .openssl(tls_config())
             .map_err(|_| ())
     })
@@ -263,7 +263,7 @@ async fn test_h2_body2() {
 async fn test_h2_head_empty() {
     let mut srv = test_server(move || {
         HttpService::build()
-            .finish(|_| ok::<_, ()>(Response::Ok().body(STR)))
+            .finish(|_| ok::<_, ()>(Response::build(StatusCode::OK).body(STR)))
             .openssl(tls_config())
             .map_err(|_| ())
     })
@@ -287,7 +287,7 @@ async fn test_h2_head_empty() {
 async fn test_h2_head_binary() {
     let mut srv = test_server(move || {
         HttpService::build()
-            .h2(|_| ok::<_, ()>(Response::Ok().body(STR)))
+            .h2(|_| ok::<_, ()>(Response::build(StatusCode::OK).body(STR)))
             .openssl(tls_config())
             .map_err(|_| ())
     })
@@ -310,7 +310,7 @@ async fn test_h2_head_binary() {
 async fn test_h2_head_binary2() {
     let srv = test_server(move || {
         HttpService::build()
-            .h2(|_| ok::<_, ()>(Response::Ok().body(STR)))
+            .h2(|_| ok::<_, ()>(Response::build(StatusCode::OK).body(STR)))
             .openssl(tls_config())
             .map_err(|_| ())
     })
@@ -332,7 +332,8 @@ async fn test_h2_body_length() {
             .h2(|_| {
                 let body = once(ok(Bytes::from_static(STR.as_ref())));
                 ok::<_, ()>(
-                    Response::Ok().body(SizedStream::new(STR.len() as u64, body)),
+                    Response::build(StatusCode::OK)
+                        .body(SizedStream::new(STR.len() as u64, body)),
                 )
             })
             .openssl(tls_config())
@@ -355,7 +356,7 @@ async fn test_h2_body_chunked_explicit() {
             .h2(|_| {
                 let body = once(ok::<_, Error>(Bytes::from_static(STR.as_ref())));
                 ok::<_, ()>(
-                    Response::Ok()
+                    Response::build(StatusCode::OK)
                         .insert_header((header::TRANSFER_ENCODING, "chunked"))
                         .streaming(body),
                 )
@@ -383,7 +384,7 @@ async fn test_h2_response_http_error_handling() {
             .h2(fn_service(|_| {
                 let broken_header = Bytes::from_static(b"\0\0\0");
                 ok::<_, ()>(
-                    Response::Ok()
+                    Response::build(StatusCode::OK)
                         .insert_header((header::CONTENT_TYPE, broken_header))
                         .body(STR),
                 )
@@ -428,7 +429,7 @@ async fn test_h2_on_connect() {
             })
             .h2(|req: Request| {
                 assert!(req.extensions().contains::<isize>());
-                ok::<_, ()>(Response::Ok().finish())
+                ok::<_, ()>(Response::ok())
             })
             .openssl(tls_config())
             .map_err(|_| ())

--- a/actix-http/tests/test_openssl.rs
+++ b/actix-http/tests/test_openssl.rs
@@ -332,8 +332,7 @@ async fn test_h2_body_length() {
             .h2(|_| {
                 let body = once(ok(Bytes::from_static(STR.as_ref())));
                 ok::<_, ()>(
-                    Response::build(StatusCode::OK)
-                        .body(SizedStream::new(STR.len() as u64, body)),
+                    Response::ok().set_body(SizedStream::new(STR.len() as u64, body)),
                 )
             })
             .openssl(tls_config())

--- a/actix-http/tests/test_openssl.rs
+++ b/actix-http/tests/test_openssl.rs
@@ -108,7 +108,7 @@ async fn test_h2_body() -> io::Result<()> {
         HttpService::build()
             .h2(|mut req: Request<_>| async move {
                 let body = load_body(req.take_payload()).await?;
-                Ok::<_, Error>(Response::build(StatusCode::OK).body(body))
+                Ok::<_, Error>(Response::ok().set_body(body))
             })
             .openssl(tls_config())
             .map_err(|_| ())
@@ -245,7 +245,7 @@ const STR: &str = "Hello World Hello World Hello World Hello World Hello World \
 async fn test_h2_body2() {
     let mut srv = test_server(move || {
         HttpService::build()
-            .h2(|_| ok::<_, ()>(Response::build(StatusCode::OK).body(STR)))
+            .h2(|_| ok::<_, ()>(Response::ok().set_body(STR)))
             .openssl(tls_config())
             .map_err(|_| ())
     })
@@ -263,7 +263,7 @@ async fn test_h2_body2() {
 async fn test_h2_head_empty() {
     let mut srv = test_server(move || {
         HttpService::build()
-            .finish(|_| ok::<_, ()>(Response::build(StatusCode::OK).body(STR)))
+            .finish(|_| ok::<_, ()>(Response::ok().set_body(STR)))
             .openssl(tls_config())
             .map_err(|_| ())
     })
@@ -287,7 +287,7 @@ async fn test_h2_head_empty() {
 async fn test_h2_head_binary() {
     let mut srv = test_server(move || {
         HttpService::build()
-            .h2(|_| ok::<_, ()>(Response::build(StatusCode::OK).body(STR)))
+            .h2(|_| ok::<_, ()>(Response::ok().set_body(STR)))
             .openssl(tls_config())
             .map_err(|_| ())
     })
@@ -310,7 +310,7 @@ async fn test_h2_head_binary() {
 async fn test_h2_head_binary2() {
     let srv = test_server(move || {
         HttpService::build()
-            .h2(|_| ok::<_, ()>(Response::build(StatusCode::OK).body(STR)))
+            .h2(|_| ok::<_, ()>(Response::ok().set_body(STR)))
             .openssl(tls_config())
             .map_err(|_| ())
     })

--- a/actix-http/tests/test_rustls.rs
+++ b/actix-http/tests/test_rustls.rs
@@ -56,7 +56,7 @@ fn tls_config() -> RustlsServerConfig {
 async fn test_h1() -> io::Result<()> {
     let srv = test_server(move || {
         HttpService::build()
-            .h1(|_| ok::<_, Error>(Response::Ok().finish()))
+            .h1(|_| ok::<_, Error>(Response::ok()))
             .rustls(tls_config())
     })
     .await;
@@ -70,7 +70,7 @@ async fn test_h1() -> io::Result<()> {
 async fn test_h2() -> io::Result<()> {
     let srv = test_server(move || {
         HttpService::build()
-            .h2(|_| ok::<_, Error>(Response::Ok().finish()))
+            .h2(|_| ok::<_, Error>(Response::ok()))
             .rustls(tls_config())
     })
     .await;
@@ -87,7 +87,7 @@ async fn test_h1_1() -> io::Result<()> {
             .h1(|req: Request| {
                 assert!(req.peer_addr().is_some());
                 assert_eq!(req.version(), Version::HTTP_11);
-                ok::<_, Error>(Response::Ok().finish())
+                ok::<_, Error>(Response::ok())
             })
             .rustls(tls_config())
     })
@@ -105,7 +105,7 @@ async fn test_h2_1() -> io::Result<()> {
             .finish(|req: Request| {
                 assert!(req.peer_addr().is_some());
                 assert_eq!(req.version(), Version::HTTP_2);
-                ok::<_, Error>(Response::Ok().finish())
+                ok::<_, Error>(Response::ok())
             })
             .rustls(tls_config())
     })
@@ -123,7 +123,7 @@ async fn test_h2_body1() -> io::Result<()> {
         HttpService::build()
             .h2(|mut req: Request<_>| async move {
                 let body = load_body(req.take_payload()).await?;
-                Ok::<_, Error>(Response::Ok().body(body))
+                Ok::<_, Error>(Response::build(StatusCode::OK).body(body))
             })
             .rustls(tls_config())
     })
@@ -199,7 +199,7 @@ async fn test_h2_headers() {
     let mut srv = test_server(move || {
         let data = data.clone();
         HttpService::build().h2(move |_| {
-            let mut config = Response::Ok();
+            let mut config = Response::build(StatusCode::OK);
             for idx in 0..90 {
                 config.insert_header((
                     format!("X-TEST-{}", idx).as_str(),
@@ -257,7 +257,7 @@ const STR: &str = "Hello World Hello World Hello World Hello World Hello World \
 async fn test_h2_body2() {
     let mut srv = test_server(move || {
         HttpService::build()
-            .h2(|_| ok::<_, ()>(Response::Ok().body(STR)))
+            .h2(|_| ok::<_, ()>(Response::build(StatusCode::OK).body(STR)))
             .rustls(tls_config())
     })
     .await;
@@ -274,7 +274,7 @@ async fn test_h2_body2() {
 async fn test_h2_head_empty() {
     let mut srv = test_server(move || {
         HttpService::build()
-            .finish(|_| ok::<_, ()>(Response::Ok().body(STR)))
+            .finish(|_| ok::<_, ()>(Response::build(StatusCode::OK).body(STR)))
             .rustls(tls_config())
     })
     .await;
@@ -300,7 +300,7 @@ async fn test_h2_head_empty() {
 async fn test_h2_head_binary() {
     let mut srv = test_server(move || {
         HttpService::build()
-            .h2(|_| ok::<_, ()>(Response::Ok().body(STR)))
+            .h2(|_| ok::<_, ()>(Response::build(StatusCode::OK).body(STR)))
             .rustls(tls_config())
     })
     .await;
@@ -325,7 +325,7 @@ async fn test_h2_head_binary() {
 async fn test_h2_head_binary2() {
     let srv = test_server(move || {
         HttpService::build()
-            .h2(|_| ok::<_, ()>(Response::Ok().body(STR)))
+            .h2(|_| ok::<_, ()>(Response::build(StatusCode::OK).body(STR)))
             .rustls(tls_config())
     })
     .await;
@@ -349,7 +349,8 @@ async fn test_h2_body_length() {
             .h2(|_| {
                 let body = once(ok(Bytes::from_static(STR.as_ref())));
                 ok::<_, ()>(
-                    Response::Ok().body(SizedStream::new(STR.len() as u64, body)),
+                    Response::build(StatusCode::OK)
+                        .body(SizedStream::new(STR.len() as u64, body)),
                 )
             })
             .rustls(tls_config())
@@ -371,7 +372,7 @@ async fn test_h2_body_chunked_explicit() {
             .h2(|_| {
                 let body = once(ok::<_, Error>(Bytes::from_static(STR.as_ref())));
                 ok::<_, ()>(
-                    Response::Ok()
+                    Response::build(StatusCode::OK)
                         .insert_header((header::TRANSFER_ENCODING, "chunked"))
                         .streaming(body),
                 )
@@ -399,7 +400,7 @@ async fn test_h2_response_http_error_handling() {
                 ok::<_, ()>(fn_service(|_| {
                     let broken_header = Bytes::from_static(b"\0\0\0");
                     ok::<_, ()>(
-                        Response::Ok()
+                        Response::build(StatusCode::OK)
                             .insert_header((http::header::CONTENT_TYPE, broken_header))
                             .body(STR),
                     )

--- a/actix-http/tests/test_rustls.rs
+++ b/actix-http/tests/test_rustls.rs
@@ -123,7 +123,7 @@ async fn test_h2_body1() -> io::Result<()> {
         HttpService::build()
             .h2(|mut req: Request<_>| async move {
                 let body = load_body(req.take_payload()).await?;
-                Ok::<_, Error>(Response::build(StatusCode::OK).body(body))
+                Ok::<_, Error>(Response::ok().set_body(body))
             })
             .rustls(tls_config())
     })
@@ -257,7 +257,7 @@ const STR: &str = "Hello World Hello World Hello World Hello World Hello World \
 async fn test_h2_body2() {
     let mut srv = test_server(move || {
         HttpService::build()
-            .h2(|_| ok::<_, ()>(Response::build(StatusCode::OK).body(STR)))
+            .h2(|_| ok::<_, ()>(Response::ok().set_body(STR)))
             .rustls(tls_config())
     })
     .await;
@@ -274,7 +274,7 @@ async fn test_h2_body2() {
 async fn test_h2_head_empty() {
     let mut srv = test_server(move || {
         HttpService::build()
-            .finish(|_| ok::<_, ()>(Response::build(StatusCode::OK).body(STR)))
+            .finish(|_| ok::<_, ()>(Response::ok().set_body(STR)))
             .rustls(tls_config())
     })
     .await;
@@ -300,7 +300,7 @@ async fn test_h2_head_empty() {
 async fn test_h2_head_binary() {
     let mut srv = test_server(move || {
         HttpService::build()
-            .h2(|_| ok::<_, ()>(Response::build(StatusCode::OK).body(STR)))
+            .h2(|_| ok::<_, ()>(Response::ok().set_body(STR)))
             .rustls(tls_config())
     })
     .await;
@@ -325,7 +325,7 @@ async fn test_h2_head_binary() {
 async fn test_h2_head_binary2() {
     let srv = test_server(move || {
         HttpService::build()
-            .h2(|_| ok::<_, ()>(Response::build(StatusCode::OK).body(STR)))
+            .h2(|_| ok::<_, ()>(Response::ok().set_body(STR)))
             .rustls(tls_config())
     })
     .await;

--- a/actix-http/tests/test_rustls.rs
+++ b/actix-http/tests/test_rustls.rs
@@ -349,8 +349,7 @@ async fn test_h2_body_length() {
             .h2(|_| {
                 let body = once(ok(Bytes::from_static(STR.as_ref())));
                 ok::<_, ()>(
-                    Response::build(StatusCode::OK)
-                        .body(SizedStream::new(STR.len() as u64, body)),
+                    Response::ok().set_body(SizedStream::new(STR.len() as u64, body)),
                 )
             })
             .rustls(tls_config())

--- a/actix-http/tests/test_server.rs
+++ b/actix-http/tests/test_server.rs
@@ -14,8 +14,8 @@ use regex::Regex;
 use actix_http::HttpMessage;
 use actix_http::{
     body::{Body, SizedStream},
-    error, http,
-    http::header,
+    error,
+    http::{self, header, StatusCode},
     Error, HttpService, KeepAlive, Request, Response,
 };
 
@@ -28,7 +28,7 @@ async fn test_h1() {
             .client_disconnect(1000)
             .h1(|req: Request| {
                 assert!(req.peer_addr().is_some());
-                ok::<_, ()>(Response::Ok().finish())
+                ok::<_, ()>(Response::ok())
             })
             .tcp()
     })
@@ -48,7 +48,7 @@ async fn test_h1_2() {
             .finish(|req: Request| {
                 assert!(req.peer_addr().is_some());
                 assert_eq!(req.version(), http::Version::HTTP_11);
-                ok::<_, ()>(Response::Ok().finish())
+                ok::<_, ()>(Response::ok())
             })
             .tcp()
     })
@@ -69,7 +69,7 @@ async fn test_expect_continue() {
                     err(error::ErrorPreconditionFailed("error"))
                 }
             }))
-            .finish(|_| ok::<_, ()>(Response::Ok().finish()))
+            .finish(|_| ok::<_, ()>(Response::ok()))
             .tcp()
     })
     .await;
@@ -100,7 +100,7 @@ async fn test_expect_continue_h1() {
                     }
                 })
             }))
-            .h1(fn_service(|_| ok::<_, ()>(Response::Ok().finish())))
+            .h1(fn_service(|_| ok::<_, ()>(Response::ok())))
             .tcp()
     })
     .await;
@@ -134,7 +134,10 @@ async fn test_chunked_payload() {
                     })
                     .fold(0usize, |acc, chunk| ready(acc + chunk.len()))
                     .map(|req_size| {
-                        Ok::<_, Error>(Response::Ok().body(format!("size={}", req_size)))
+                        Ok::<_, Error>(
+                            Response::build(StatusCode::OK)
+                                .body(format!("size={}", req_size)),
+                        )
                     })
             }))
             .tcp()
@@ -179,7 +182,7 @@ async fn test_slow_request() {
     let srv = test_server(|| {
         HttpService::build()
             .client_timeout(100)
-            .finish(|_| ok::<_, ()>(Response::Ok().finish()))
+            .finish(|_| ok::<_, ()>(Response::ok()))
             .tcp()
     })
     .await;
@@ -195,7 +198,7 @@ async fn test_slow_request() {
 async fn test_http1_malformed_request() {
     let srv = test_server(|| {
         HttpService::build()
-            .h1(|_| ok::<_, ()>(Response::Ok().finish()))
+            .h1(|_| ok::<_, ()>(Response::ok()))
             .tcp()
     })
     .await;
@@ -211,7 +214,7 @@ async fn test_http1_malformed_request() {
 async fn test_http1_keepalive() {
     let srv = test_server(|| {
         HttpService::build()
-            .h1(|_| ok::<_, ()>(Response::Ok().finish()))
+            .h1(|_| ok::<_, ()>(Response::ok()))
             .tcp()
     })
     .await;
@@ -233,7 +236,7 @@ async fn test_http1_keepalive_timeout() {
     let srv = test_server(|| {
         HttpService::build()
             .keep_alive(1)
-            .h1(|_| ok::<_, ()>(Response::Ok().finish()))
+            .h1(|_| ok::<_, ()>(Response::ok()))
             .tcp()
     })
     .await;
@@ -254,7 +257,7 @@ async fn test_http1_keepalive_timeout() {
 async fn test_http1_keepalive_close() {
     let srv = test_server(|| {
         HttpService::build()
-            .h1(|_| ok::<_, ()>(Response::Ok().finish()))
+            .h1(|_| ok::<_, ()>(Response::ok()))
             .tcp()
     })
     .await;
@@ -275,7 +278,7 @@ async fn test_http1_keepalive_close() {
 async fn test_http10_keepalive_default_close() {
     let srv = test_server(|| {
         HttpService::build()
-            .h1(|_| ok::<_, ()>(Response::Ok().finish()))
+            .h1(|_| ok::<_, ()>(Response::ok()))
             .tcp()
     })
     .await;
@@ -295,7 +298,7 @@ async fn test_http10_keepalive_default_close() {
 async fn test_http10_keepalive() {
     let srv = test_server(|| {
         HttpService::build()
-            .h1(|_| ok::<_, ()>(Response::Ok().finish()))
+            .h1(|_| ok::<_, ()>(Response::ok()))
             .tcp()
     })
     .await;
@@ -323,7 +326,7 @@ async fn test_http1_keepalive_disabled() {
     let srv = test_server(|| {
         HttpService::build()
             .keep_alive(KeepAlive::Disabled)
-            .h1(|_| ok::<_, ()>(Response::Ok().finish()))
+            .h1(|_| ok::<_, ()>(Response::ok()))
             .tcp()
     })
     .await;
@@ -394,7 +397,7 @@ async fn test_h1_headers() {
     let mut srv = test_server(move || {
         let data = data.clone();
         HttpService::build().h1(move |_| {
-            let mut builder = Response::Ok();
+            let mut builder = Response::build(StatusCode::OK);
             for idx in 0..90 {
                 builder.insert_header((
                     format!("X-TEST-{}", idx).as_str(),
@@ -451,7 +454,7 @@ const STR: &str = "Hello World Hello World Hello World Hello World Hello World \
 async fn test_h1_body() {
     let mut srv = test_server(|| {
         HttpService::build()
-            .h1(|_| ok::<_, ()>(Response::Ok().body(STR)))
+            .h1(|_| ok::<_, ()>(Response::build(StatusCode::OK).body(STR)))
             .tcp()
     })
     .await;
@@ -468,7 +471,7 @@ async fn test_h1_body() {
 async fn test_h1_head_empty() {
     let mut srv = test_server(|| {
         HttpService::build()
-            .h1(|_| ok::<_, ()>(Response::Ok().body(STR)))
+            .h1(|_| ok::<_, ()>(Response::build(StatusCode::OK).body(STR)))
             .tcp()
     })
     .await;
@@ -493,7 +496,7 @@ async fn test_h1_head_empty() {
 async fn test_h1_head_binary() {
     let mut srv = test_server(|| {
         HttpService::build()
-            .h1(|_| ok::<_, ()>(Response::Ok().body(STR)))
+            .h1(|_| ok::<_, ()>(Response::build(StatusCode::OK).body(STR)))
             .tcp()
     })
     .await;
@@ -518,7 +521,7 @@ async fn test_h1_head_binary() {
 async fn test_h1_head_binary2() {
     let srv = test_server(|| {
         HttpService::build()
-            .h1(|_| ok::<_, ()>(Response::Ok().body(STR)))
+            .h1(|_| ok::<_, ()>(Response::build(StatusCode::OK).body(STR)))
             .tcp()
     })
     .await;
@@ -542,7 +545,8 @@ async fn test_h1_body_length() {
             .h1(|_| {
                 let body = once(ok(Bytes::from_static(STR.as_ref())));
                 ok::<_, ()>(
-                    Response::Ok().body(SizedStream::new(STR.len() as u64, body)),
+                    Response::build(StatusCode::OK)
+                        .body(SizedStream::new(STR.len() as u64, body)),
                 )
             })
             .tcp()
@@ -564,7 +568,7 @@ async fn test_h1_body_chunked_explicit() {
             .h1(|_| {
                 let body = once(ok::<_, Error>(Bytes::from_static(STR.as_ref())));
                 ok::<_, ()>(
-                    Response::Ok()
+                    Response::build(StatusCode::OK)
                         .insert_header((header::TRANSFER_ENCODING, "chunked"))
                         .streaming(body),
                 )
@@ -598,7 +602,7 @@ async fn test_h1_body_chunked_implicit() {
         HttpService::build()
             .h1(|_| {
                 let body = once(ok::<_, Error>(Bytes::from_static(STR.as_ref())));
-                ok::<_, ()>(Response::Ok().streaming(body))
+                ok::<_, ()>(Response::build(StatusCode::OK).streaming(body))
             })
             .tcp()
     })
@@ -628,7 +632,7 @@ async fn test_h1_response_http_error_handling() {
             .h1(fn_service(|_| {
                 let broken_header = Bytes::from_static(b"\0\0\0");
                 ok::<_, ()>(
-                    Response::Ok()
+                    Response::build(StatusCode::OK)
                         .insert_header((http::header::CONTENT_TYPE, broken_header))
                         .body(STR),
                 )
@@ -671,7 +675,7 @@ async fn test_h1_on_connect() {
             })
             .h1(|req: Request| {
                 assert!(req.extensions().contains::<isize>());
-                ok::<_, ()>(Response::Ok().finish())
+                ok::<_, ()>(Response::ok())
             })
             .tcp()
     })

--- a/actix-http/tests/test_server.rs
+++ b/actix-http/tests/test_server.rs
@@ -454,7 +454,7 @@ const STR: &str = "Hello World Hello World Hello World Hello World Hello World \
 async fn test_h1_body() {
     let mut srv = test_server(|| {
         HttpService::build()
-            .h1(|_| ok::<_, ()>(Response::build(StatusCode::OK).body(STR)))
+            .h1(|_| ok::<_, ()>(Response::ok().set_body(STR)))
             .tcp()
     })
     .await;
@@ -471,7 +471,7 @@ async fn test_h1_body() {
 async fn test_h1_head_empty() {
     let mut srv = test_server(|| {
         HttpService::build()
-            .h1(|_| ok::<_, ()>(Response::build(StatusCode::OK).body(STR)))
+            .h1(|_| ok::<_, ()>(Response::ok().set_body(STR)))
             .tcp()
     })
     .await;
@@ -496,7 +496,7 @@ async fn test_h1_head_empty() {
 async fn test_h1_head_binary() {
     let mut srv = test_server(|| {
         HttpService::build()
-            .h1(|_| ok::<_, ()>(Response::build(StatusCode::OK).body(STR)))
+            .h1(|_| ok::<_, ()>(Response::ok().set_body(STR)))
             .tcp()
     })
     .await;
@@ -521,7 +521,7 @@ async fn test_h1_head_binary() {
 async fn test_h1_head_binary2() {
     let srv = test_server(|| {
         HttpService::build()
-            .h1(|_| ok::<_, ()>(Response::build(StatusCode::OK).body(STR)))
+            .h1(|_| ok::<_, ()>(Response::ok().set_body(STR)))
             .tcp()
     })
     .await;

--- a/actix-http/tests/test_server.rs
+++ b/actix-http/tests/test_server.rs
@@ -135,8 +135,7 @@ async fn test_chunked_payload() {
                     .fold(0usize, |acc, chunk| ready(acc + chunk.len()))
                     .map(|req_size| {
                         Ok::<_, Error>(
-                            Response::build(StatusCode::OK)
-                                .body(format!("size={}", req_size)),
+                            Response::ok().set_body(format!("size={}", req_size)),
                         )
                     })
             }))
@@ -545,8 +544,7 @@ async fn test_h1_body_length() {
             .h1(|_| {
                 let body = once(ok(Bytes::from_static(STR.as_ref())));
                 ok::<_, ()>(
-                    Response::build(StatusCode::OK)
-                        .body(SizedStream::new(STR.len() as u64, body)),
+                    Response::ok().set_body(SizedStream::new(STR.len() as u64, body)),
                 )
             })
             .tcp()

--- a/actix-http/tests/test_ws.rs
+++ b/actix-http/tests/test_ws.rs
@@ -91,7 +91,7 @@ async fn test_simple() {
             let ws_service = ws_service.clone();
             HttpService::build()
                 .upgrade(fn_factory(move || future::ok::<_, ()>(ws_service.clone())))
-                .finish(|_| future::ok::<_, ()>(Response::NotFound()))
+                .finish(|_| future::ok::<_, ()>(Response::not_found()))
                 .tcp()
         }
     })

--- a/awc/tests/test_ws.rs
+++ b/awc/tests/test_ws.rs
@@ -36,7 +36,7 @@ async fn test_simple() {
                     ws::Dispatcher::with(framed, ws_service).await
                 }
             })
-            .finish(|_| ok::<_, Error>(Response::NotFound()))
+            .finish(|_| ok::<_, Error>(Response::not_found()))
             .tcp()
     })
     .await;

--- a/src/app_service.rs
+++ b/src/app_service.rs
@@ -1,20 +1,23 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use actix_http::{Extensions, Request, Response};
+use actix_http::{Extensions, Request};
 use actix_router::{Path, ResourceDef, Router, Url};
 use actix_service::boxed::{self, BoxService, BoxServiceFactory};
 use actix_service::{fn_service, Service, ServiceFactory};
 use futures_core::future::LocalBoxFuture;
 use futures_util::future::join_all;
 
-use crate::config::{AppConfig, AppService};
 use crate::data::FnDataFactory;
 use crate::error::Error;
 use crate::guard::Guard;
 use crate::request::{HttpRequest, HttpRequestPool};
 use crate::rmap::ResourceMap;
 use crate::service::{AppServiceFactory, ServiceRequest, ServiceResponse};
+use crate::{
+    config::{AppConfig, AppService},
+    HttpResponse,
+};
 
 type Guards = Vec<Box<dyn Guard>>;
 type HttpService = BoxService<ServiceRequest, ServiceResponse, Error>;
@@ -64,7 +67,7 @@ where
         // if no user defined default service exists.
         let default = self.default.clone().unwrap_or_else(|| {
             Rc::new(boxed::factory(fn_service(|req: ServiceRequest| async {
-                Ok(req.into_response(Response::NotFound().finish()))
+                Ok(req.into_response(HttpResponse::NotFound()))
             })))
         });
 

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use std::future::Future;
 use std::rc::Rc;
 
-use actix_http::{Error, Extensions, Response};
+use actix_http::{Error, Extensions};
 use actix_router::IntoPattern;
 use actix_service::boxed::{self, BoxService, BoxServiceFactory};
 use actix_service::{
@@ -13,7 +13,6 @@ use actix_service::{
 use futures_core::future::LocalBoxFuture;
 use futures_util::future::join_all;
 
-use crate::data::Data;
 use crate::dev::{insert_slash, AppService, HttpServiceFactory, ResourceDef};
 use crate::extract::FromRequest;
 use crate::guard::Guard;
@@ -21,6 +20,7 @@ use crate::handler::Handler;
 use crate::responder::Responder;
 use crate::route::{Route, RouteService};
 use crate::service::{ServiceRequest, ServiceResponse};
+use crate::{data::Data, HttpResponse};
 
 type HttpService = BoxService<ServiceRequest, ServiceResponse, Error>;
 type HttpNewService = BoxServiceFactory<(), ServiceRequest, ServiceResponse, Error, ()>;
@@ -71,7 +71,7 @@ impl Resource {
             guards: Vec::new(),
             app_data: None,
             default: boxed::factory(fn_service(|req: ServiceRequest| async {
-                Ok(req.into_response(Response::MethodNotAllowed().finish()))
+                Ok(req.into_response(HttpResponse::MethodNotAllowed()))
             })),
         }
     }

--- a/src/response/builder.rs
+++ b/src/response/builder.rs
@@ -1,17 +1,15 @@
 use std::{
     cell::{Ref, RefMut},
     convert::TryInto,
-    fmt,
     future::Future,
-    mem,
     pin::Pin,
     task::{Context, Poll},
 };
 
 use actix_http::{
-    body::{Body, BodyStream, MessageBody, ResponseBody},
+    body::{Body, BodyStream},
     http::{
-        header::{self, HeaderMap, HeaderName, IntoHeaderPair, IntoHeaderValue},
+        header::{self, HeaderName, IntoHeaderPair, IntoHeaderValue},
         ConnectionType, Error as HttpError, StatusCode,
     },
     Extensions, Response, ResponseHead,
@@ -25,282 +23,10 @@ use actix_http::http::header::HeaderValue;
 #[cfg(feature = "cookies")]
 use cookie::{Cookie, CookieJar};
 
-use crate::error::{Error, JsonPayloadError};
-
-/// An HTTP Response
-pub struct HttpResponse<B = Body> {
-    res: Response<B>,
-    error: Option<Error>,
-}
-
-impl HttpResponse<Body> {
-    /// Create HTTP response builder with specific status.
-    #[inline]
-    pub fn build(status: StatusCode) -> HttpResponseBuilder {
-        HttpResponseBuilder::new(status)
-    }
-
-    /// Create HTTP response builder
-    #[inline]
-    pub fn build_from<T: Into<HttpResponseBuilder>>(source: T) -> HttpResponseBuilder {
-        source.into()
-    }
-
-    /// Create a response.
-    #[inline]
-    pub fn new(status: StatusCode) -> Self {
-        Self {
-            res: Response::new(status),
-            error: None,
-        }
-    }
-
-    /// Create an error response.
-    #[inline]
-    pub fn from_error(error: Error) -> Self {
-        let res = error.as_response_error().error_response();
-
-        Self {
-            res,
-            error: Some(error),
-        }
-    }
-
-    /// Convert response to response with body
-    pub fn into_body<B>(self) -> HttpResponse<B> {
-        HttpResponse {
-            res: self.res.into_body(),
-            error: self.error,
-        }
-    }
-}
-
-impl<B> HttpResponse<B> {
-    /// Constructs a response with body
-    #[inline]
-    pub fn with_body(status: StatusCode, body: B) -> Self {
-        Self {
-            res: Response::with_body(status, body),
-            error: None,
-        }
-    }
-
-    /// Returns a reference to response head.
-    #[inline]
-    pub fn head(&self) -> &ResponseHead {
-        self.res.head()
-    }
-
-    /// Returns a mutable reference to response head.
-    #[inline]
-    pub fn head_mut(&mut self) -> &mut ResponseHead {
-        self.res.head_mut()
-    }
-
-    /// The source `error` for this response
-    #[inline]
-    pub fn error(&self) -> Option<&Error> {
-        self.error.as_ref()
-    }
-
-    /// Get the response status code
-    #[inline]
-    pub fn status(&self) -> StatusCode {
-        self.res.status()
-    }
-
-    /// Set the `StatusCode` for this response
-    #[inline]
-    pub fn status_mut(&mut self) -> &mut StatusCode {
-        self.res.status_mut()
-    }
-
-    /// Get the headers from the response
-    #[inline]
-    pub fn headers(&self) -> &HeaderMap {
-        self.res.headers()
-    }
-
-    /// Get a mutable reference to the headers
-    #[inline]
-    pub fn headers_mut(&mut self) -> &mut HeaderMap {
-        self.res.headers_mut()
-    }
-
-    /// Get an iterator for the cookies set by this response.
-    #[cfg(feature = "cookies")]
-    pub fn cookies(&self) -> CookieIter<'_> {
-        CookieIter {
-            iter: self.headers().get_all(header::SET_COOKIE),
-        }
-    }
-
-    /// Add a cookie to this response
-    #[cfg(feature = "cookies")]
-    pub fn add_cookie(&mut self, cookie: &Cookie<'_>) -> Result<(), HttpError> {
-        HeaderValue::from_str(&cookie.to_string())
-            .map(|c| {
-                self.headers_mut().append(header::SET_COOKIE, c);
-            })
-            .map_err(|e| e.into())
-    }
-
-    /// Remove all cookies with the given name from this response. Returns
-    /// the number of cookies removed.
-    #[cfg(feature = "cookies")]
-    pub fn del_cookie(&mut self, name: &str) -> usize {
-        let headers = self.headers_mut();
-
-        let vals: Vec<HeaderValue> = headers
-            .get_all(header::SET_COOKIE)
-            .map(|v| v.to_owned())
-            .collect();
-
-        headers.remove(header::SET_COOKIE);
-
-        let mut count: usize = 0;
-        for v in vals {
-            if let Ok(s) = v.to_str() {
-                if let Ok(c) = Cookie::parse_encoded(s) {
-                    if c.name() == name {
-                        count += 1;
-                        continue;
-                    }
-                }
-            }
-
-            // put set-cookie header head back if it does not validate
-            headers.append(header::SET_COOKIE, v);
-        }
-
-        count
-    }
-
-    /// Connection upgrade status
-    #[inline]
-    pub fn upgrade(&self) -> bool {
-        self.res.upgrade()
-    }
-
-    /// Keep-alive status for this connection
-    pub fn keep_alive(&self) -> bool {
-        self.res.keep_alive()
-    }
-
-    /// Responses extensions
-    #[inline]
-    pub fn extensions(&self) -> Ref<'_, Extensions> {
-        self.res.extensions()
-    }
-
-    /// Mutable reference to a the response's extensions
-    #[inline]
-    pub fn extensions_mut(&mut self) -> RefMut<'_, Extensions> {
-        self.res.extensions_mut()
-    }
-
-    /// Get body of this response
-    #[inline]
-    pub fn body(&self) -> &ResponseBody<B> {
-        self.res.body()
-    }
-
-    /// Set a body
-    pub fn set_body<B2>(self, body: B2) -> HttpResponse<B2> {
-        HttpResponse {
-            res: self.res.set_body(body),
-            error: None,
-            // error: self.error, ??
-        }
-    }
-
-    /// Split response and body
-    pub fn into_parts(self) -> (HttpResponse<()>, ResponseBody<B>) {
-        let (head, body) = self.res.into_parts();
-
-        (
-            HttpResponse {
-                res: head,
-                error: None,
-            },
-            body,
-        )
-    }
-
-    /// Drop request's body
-    pub fn drop_body(self) -> HttpResponse<()> {
-        HttpResponse {
-            res: self.res.drop_body(),
-            error: None,
-        }
-    }
-
-    /// Set a body and return previous body value
-    pub fn map_body<F, B2>(self, f: F) -> HttpResponse<B2>
-    where
-        F: FnOnce(&mut ResponseHead, ResponseBody<B>) -> ResponseBody<B2>,
-    {
-        HttpResponse {
-            res: self.res.map_body(f),
-            error: self.error,
-        }
-    }
-
-    /// Extract response body
-    pub fn take_body(&mut self) -> ResponseBody<B> {
-        self.res.take_body()
-    }
-}
-
-impl<B: MessageBody> fmt::Debug for HttpResponse<B> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("HttpResponse")
-            .field("error", &self.error)
-            .field("res", &self.res)
-            .finish()
-    }
-}
-
-impl<B> From<Response<B>> for HttpResponse<B> {
-    fn from(res: Response<B>) -> Self {
-        HttpResponse { res, error: None }
-    }
-}
-
-impl From<Error> for HttpResponse {
-    fn from(err: Error) -> Self {
-        HttpResponse::from_error(err)
-    }
-}
-
-impl<B> From<HttpResponse<B>> for Response<B> {
-    fn from(res: HttpResponse<B>) -> Self {
-        // this impl will always be called as part of dispatcher
-
-        // TODO: expose cause somewhere?
-        // if let Some(err) = res.error {
-        //     eprintln!("impl<B> From<HttpResponse<B>> for Response<B> let Some(err)");
-        //     return Response::from_error(err).into_body();
-        // }
-
-        res.res
-    }
-}
-
-impl Future for HttpResponse {
-    type Output = Result<Response<Body>, Error>;
-
-    fn poll(mut self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Self::Output> {
-        if let Some(err) = self.error.take() {
-            return Poll::Ready(Ok(Response::from_error(err).into_body()));
-        }
-
-        Poll::Ready(Ok(mem::replace(
-            &mut self.res,
-            Response::new(StatusCode::default()),
-        )))
-    }
-}
+use crate::{
+    error::{Error, JsonPayloadError},
+    HttpResponse,
+};
 
 /// An HTTP response builder.
 ///
@@ -695,145 +421,27 @@ impl Future for HttpResponseBuilder {
     }
 }
 
-#[cfg(feature = "cookies")]
-pub struct CookieIter<'a> {
-    iter: header::GetAll<'a>,
-}
-
-#[cfg(feature = "cookies")]
-impl<'a> Iterator for CookieIter<'a> {
-    type Item = Cookie<'a>;
-
-    #[inline]
-    fn next(&mut self) -> Option<Cookie<'a>> {
-        for v in self.iter.by_ref() {
-            if let Ok(c) = Cookie::parse_encoded(v.to_str().ok()?) {
-                return Some(c);
-            }
-        }
-        None
-    }
-}
-
-mod http_codes {
-    //! Status code based HTTP response builders.
-
-    use actix_http::http::StatusCode;
-
-    use super::{HttpResponse, HttpResponseBuilder};
-
-    macro_rules! static_resp {
-        ($name:ident, $status:expr) => {
-            #[allow(non_snake_case, missing_docs)]
-            pub fn $name() -> HttpResponseBuilder {
-                HttpResponseBuilder::new($status)
-            }
-        };
-    }
-
-    impl HttpResponse {
-        static_resp!(Continue, StatusCode::CONTINUE);
-        static_resp!(SwitchingProtocols, StatusCode::SWITCHING_PROTOCOLS);
-        static_resp!(Processing, StatusCode::PROCESSING);
-
-        static_resp!(Ok, StatusCode::OK);
-        static_resp!(Created, StatusCode::CREATED);
-        static_resp!(Accepted, StatusCode::ACCEPTED);
-        static_resp!(
-            NonAuthoritativeInformation,
-            StatusCode::NON_AUTHORITATIVE_INFORMATION
-        );
-
-        static_resp!(NoContent, StatusCode::NO_CONTENT);
-        static_resp!(ResetContent, StatusCode::RESET_CONTENT);
-        static_resp!(PartialContent, StatusCode::PARTIAL_CONTENT);
-        static_resp!(MultiStatus, StatusCode::MULTI_STATUS);
-        static_resp!(AlreadyReported, StatusCode::ALREADY_REPORTED);
-
-        static_resp!(MultipleChoices, StatusCode::MULTIPLE_CHOICES);
-        static_resp!(MovedPermanently, StatusCode::MOVED_PERMANENTLY);
-        static_resp!(Found, StatusCode::FOUND);
-        static_resp!(SeeOther, StatusCode::SEE_OTHER);
-        static_resp!(NotModified, StatusCode::NOT_MODIFIED);
-        static_resp!(UseProxy, StatusCode::USE_PROXY);
-        static_resp!(TemporaryRedirect, StatusCode::TEMPORARY_REDIRECT);
-        static_resp!(PermanentRedirect, StatusCode::PERMANENT_REDIRECT);
-
-        static_resp!(BadRequest, StatusCode::BAD_REQUEST);
-        static_resp!(NotFound, StatusCode::NOT_FOUND);
-        static_resp!(Unauthorized, StatusCode::UNAUTHORIZED);
-        static_resp!(PaymentRequired, StatusCode::PAYMENT_REQUIRED);
-        static_resp!(Forbidden, StatusCode::FORBIDDEN);
-        static_resp!(MethodNotAllowed, StatusCode::METHOD_NOT_ALLOWED);
-        static_resp!(NotAcceptable, StatusCode::NOT_ACCEPTABLE);
-        static_resp!(
-            ProxyAuthenticationRequired,
-            StatusCode::PROXY_AUTHENTICATION_REQUIRED
-        );
-        static_resp!(RequestTimeout, StatusCode::REQUEST_TIMEOUT);
-        static_resp!(Conflict, StatusCode::CONFLICT);
-        static_resp!(Gone, StatusCode::GONE);
-        static_resp!(LengthRequired, StatusCode::LENGTH_REQUIRED);
-        static_resp!(PreconditionFailed, StatusCode::PRECONDITION_FAILED);
-        static_resp!(PreconditionRequired, StatusCode::PRECONDITION_REQUIRED);
-        static_resp!(PayloadTooLarge, StatusCode::PAYLOAD_TOO_LARGE);
-        static_resp!(UriTooLong, StatusCode::URI_TOO_LONG);
-        static_resp!(UnsupportedMediaType, StatusCode::UNSUPPORTED_MEDIA_TYPE);
-        static_resp!(RangeNotSatisfiable, StatusCode::RANGE_NOT_SATISFIABLE);
-        static_resp!(ExpectationFailed, StatusCode::EXPECTATION_FAILED);
-        static_resp!(UnprocessableEntity, StatusCode::UNPROCESSABLE_ENTITY);
-        static_resp!(TooManyRequests, StatusCode::TOO_MANY_REQUESTS);
-        static_resp!(
-            RequestHeaderFieldsTooLarge,
-            StatusCode::REQUEST_HEADER_FIELDS_TOO_LARGE
-        );
-        static_resp!(
-            UnavailableForLegalReasons,
-            StatusCode::UNAVAILABLE_FOR_LEGAL_REASONS
-        );
-
-        static_resp!(InternalServerError, StatusCode::INTERNAL_SERVER_ERROR);
-        static_resp!(NotImplemented, StatusCode::NOT_IMPLEMENTED);
-        static_resp!(BadGateway, StatusCode::BAD_GATEWAY);
-        static_resp!(ServiceUnavailable, StatusCode::SERVICE_UNAVAILABLE);
-        static_resp!(GatewayTimeout, StatusCode::GATEWAY_TIMEOUT);
-        static_resp!(VersionNotSupported, StatusCode::HTTP_VERSION_NOT_SUPPORTED);
-        static_resp!(VariantAlsoNegotiates, StatusCode::VARIANT_ALSO_NEGOTIATES);
-        static_resp!(InsufficientStorage, StatusCode::INSUFFICIENT_STORAGE);
-        static_resp!(LoopDetected, StatusCode::LOOP_DETECTED);
-    }
-
-    #[cfg(test)]
-    mod tests {
-        use crate::dev::Body;
-        use crate::http::StatusCode;
-        use crate::HttpResponse;
-
-        #[test]
-        fn test_build() {
-            let resp = HttpResponse::Ok().body(Body::Empty);
-            assert_eq!(resp.status(), StatusCode::OK);
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use bytes::{Bytes, BytesMut};
 
-    use super::{HttpResponse, HttpResponseBuilder};
+    use super::*;
     use crate::dev::{Body, MessageBody, ResponseBody};
-    use crate::http::header::{self, HeaderValue, CONTENT_TYPE, COOKIE};
+    use crate::http::header::{self, HeaderValue, CONTENT_TYPE};
     use crate::http::StatusCode;
 
-    #[test]
-    fn test_debug() {
-        let resp = HttpResponse::Ok()
-            .append_header((COOKIE, HeaderValue::from_static("cookie1=value1; ")))
-            .append_header((COOKIE, HeaderValue::from_static("cookie2=value2; ")))
-            .finish();
-        let dbg = format!("{:?}", resp);
-        assert!(dbg.contains("HttpResponse"));
+    // TODO: replace with body::to_bytes when merged
+    pub async fn read_body<B>(mut body: ResponseBody<B>) -> Bytes
+    where
+        B: MessageBody + Unpin,
+    {
+        use futures_util::StreamExt as _;
+
+        let mut bytes = BytesMut::new();
+        while let Some(item) = body.next().await {
+            bytes.extend_from_slice(&item.unwrap());
+        }
+        bytes.freeze()
     }
 
     #[test]
@@ -870,19 +478,6 @@ mod tests {
             .content_type("text/plain")
             .body(Body::Empty);
         assert_eq!(resp.headers().get(CONTENT_TYPE).unwrap(), "text/plain")
-    }
-
-    pub async fn read_body<B>(mut body: ResponseBody<B>) -> Bytes
-    where
-        B: MessageBody + Unpin,
-    {
-        use futures_util::StreamExt as _;
-
-        let mut bytes = BytesMut::new();
-        while let Some(item) = body.next().await {
-            bytes.extend_from_slice(&item.unwrap());
-        }
-        bytes.freeze()
     }
 
     #[actix_rt::test]

--- a/src/response/http_codes.rs
+++ b/src/response/http_codes.rs
@@ -1,24 +1,19 @@
 //! Status code based HTTP response builders.
 
-#![allow(non_upper_case_globals)]
+use actix_http::http::StatusCode;
 
-use http::StatusCode;
-
-use crate::{
-    body::Body,
-    response::{Response, ResponseBuilder},
-};
+use crate::{HttpResponse, HttpResponseBuilder};
 
 macro_rules! static_resp {
     ($name:ident, $status:expr) => {
         #[allow(non_snake_case, missing_docs)]
-        pub fn $name() -> ResponseBuilder {
-            ResponseBuilder::new($status)
+        pub fn $name() -> HttpResponseBuilder {
+            HttpResponseBuilder::new($status)
         }
     };
 }
 
-impl Response<Body> {
+impl HttpResponse {
     static_resp!(Continue, StatusCode::CONTINUE);
     static_resp!(SwitchingProtocols, StatusCode::SWITCHING_PROTOCOLS);
     static_resp!(Processing, StatusCode::PROCESSING);
@@ -92,13 +87,13 @@ impl Response<Body> {
 
 #[cfg(test)]
 mod tests {
-    use crate::body::Body;
-    use crate::response::Response;
-    use http::StatusCode;
+    use crate::dev::Body;
+    use crate::http::StatusCode;
+    use crate::HttpResponse;
 
     #[test]
     fn test_build() {
-        let resp = Response::Ok().body(Body::Empty);
+        let resp = HttpResponse::Ok().body(Body::Empty);
         assert_eq!(resp.status(), StatusCode::OK);
     }
 }

--- a/src/response/mod.rs
+++ b/src/response/mod.rs
@@ -1,0 +1,7 @@
+mod builder;
+mod http_codes;
+#[allow(clippy::module_inception)]
+mod response;
+
+pub use self::builder::HttpResponseBuilder;
+pub use self::response::{CookieIter, HttpResponse};

--- a/src/response/mod.rs
+++ b/src/response/mod.rs
@@ -4,4 +4,7 @@ mod http_codes;
 mod response;
 
 pub use self::builder::HttpResponseBuilder;
-pub use self::response::{CookieIter, HttpResponse};
+pub use self::response::HttpResponse;
+
+#[cfg(feature = "cookies")]
+pub use self::response::CookieIter;

--- a/src/response/response.rs
+++ b/src/response/response.rs
@@ -1,0 +1,329 @@
+use std::{
+    cell::{Ref, RefMut},
+    fmt,
+    future::Future,
+    mem,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use actix_http::{
+    body::{Body, MessageBody, ResponseBody},
+    http::{
+        header::{self, HeaderMap},
+        Error as HttpError, StatusCode,
+    },
+    Extensions, Response, ResponseHead,
+};
+
+#[cfg(feature = "cookies")]
+use actix_http::http::header::HeaderValue;
+#[cfg(feature = "cookies")]
+use cookie::Cookie;
+
+use crate::{error::Error, HttpResponseBuilder};
+
+/// An HTTP Response
+pub struct HttpResponse<B = Body> {
+    res: Response<B>,
+    error: Option<Error>,
+}
+
+impl HttpResponse<Body> {
+    /// Create HTTP response builder with specific status.
+    #[inline]
+    pub fn build(status: StatusCode) -> HttpResponseBuilder {
+        HttpResponseBuilder::new(status)
+    }
+
+    /// Create a response.
+    #[inline]
+    pub fn new(status: StatusCode) -> Self {
+        Self {
+            res: Response::new(status),
+            error: None,
+        }
+    }
+
+    /// Create an error response.
+    #[inline]
+    pub fn from_error(error: Error) -> Self {
+        let res = error.as_response_error().error_response();
+
+        Self {
+            res,
+            error: Some(error),
+        }
+    }
+
+    /// Convert response to response with body
+    pub fn into_body<B>(self) -> HttpResponse<B> {
+        HttpResponse {
+            res: self.res.into_body(),
+            error: self.error,
+        }
+    }
+}
+
+impl<B> HttpResponse<B> {
+    /// Constructs a response with body
+    #[inline]
+    pub fn with_body(status: StatusCode, body: B) -> Self {
+        Self {
+            res: Response::with_body(status, body),
+            error: None,
+        }
+    }
+
+    /// Returns a reference to response head.
+    #[inline]
+    pub fn head(&self) -> &ResponseHead {
+        self.res.head()
+    }
+
+    /// Returns a mutable reference to response head.
+    #[inline]
+    pub fn head_mut(&mut self) -> &mut ResponseHead {
+        self.res.head_mut()
+    }
+
+    /// The source `error` for this response
+    #[inline]
+    pub fn error(&self) -> Option<&Error> {
+        self.error.as_ref()
+    }
+
+    /// Get the response status code
+    #[inline]
+    pub fn status(&self) -> StatusCode {
+        self.res.status()
+    }
+
+    /// Set the `StatusCode` for this response
+    #[inline]
+    pub fn status_mut(&mut self) -> &mut StatusCode {
+        self.res.status_mut()
+    }
+
+    /// Get the headers from the response
+    #[inline]
+    pub fn headers(&self) -> &HeaderMap {
+        self.res.headers()
+    }
+
+    /// Get a mutable reference to the headers
+    #[inline]
+    pub fn headers_mut(&mut self) -> &mut HeaderMap {
+        self.res.headers_mut()
+    }
+
+    /// Get an iterator for the cookies set by this response.
+    #[cfg(feature = "cookies")]
+    pub fn cookies(&self) -> CookieIter<'_> {
+        CookieIter {
+            iter: self.headers().get_all(header::SET_COOKIE),
+        }
+    }
+
+    /// Add a cookie to this response
+    #[cfg(feature = "cookies")]
+    pub fn add_cookie(&mut self, cookie: &Cookie<'_>) -> Result<(), HttpError> {
+        HeaderValue::from_str(&cookie.to_string())
+            .map(|c| {
+                self.headers_mut().append(header::SET_COOKIE, c);
+            })
+            .map_err(|e| e.into())
+    }
+
+    /// Remove all cookies with the given name from this response. Returns
+    /// the number of cookies removed.
+    #[cfg(feature = "cookies")]
+    pub fn del_cookie(&mut self, name: &str) -> usize {
+        let headers = self.headers_mut();
+
+        let vals: Vec<HeaderValue> = headers
+            .get_all(header::SET_COOKIE)
+            .map(|v| v.to_owned())
+            .collect();
+
+        headers.remove(header::SET_COOKIE);
+
+        let mut count: usize = 0;
+        for v in vals {
+            if let Ok(s) = v.to_str() {
+                if let Ok(c) = Cookie::parse_encoded(s) {
+                    if c.name() == name {
+                        count += 1;
+                        continue;
+                    }
+                }
+            }
+
+            // put set-cookie header head back if it does not validate
+            headers.append(header::SET_COOKIE, v);
+        }
+
+        count
+    }
+
+    /// Connection upgrade status
+    #[inline]
+    pub fn upgrade(&self) -> bool {
+        self.res.upgrade()
+    }
+
+    /// Keep-alive status for this connection
+    pub fn keep_alive(&self) -> bool {
+        self.res.keep_alive()
+    }
+
+    /// Responses extensions
+    #[inline]
+    pub fn extensions(&self) -> Ref<'_, Extensions> {
+        self.res.extensions()
+    }
+
+    /// Mutable reference to a the response's extensions
+    #[inline]
+    pub fn extensions_mut(&mut self) -> RefMut<'_, Extensions> {
+        self.res.extensions_mut()
+    }
+
+    /// Get body of this response
+    #[inline]
+    pub fn body(&self) -> &ResponseBody<B> {
+        self.res.body()
+    }
+
+    /// Set a body
+    pub fn set_body<B2>(self, body: B2) -> HttpResponse<B2> {
+        HttpResponse {
+            res: self.res.set_body(body),
+            error: None,
+            // error: self.error, ??
+        }
+    }
+
+    /// Split response and body
+    pub fn into_parts(self) -> (HttpResponse<()>, ResponseBody<B>) {
+        let (head, body) = self.res.into_parts();
+
+        (
+            HttpResponse {
+                res: head,
+                error: None,
+            },
+            body,
+        )
+    }
+
+    /// Drop request's body
+    pub fn drop_body(self) -> HttpResponse<()> {
+        HttpResponse {
+            res: self.res.drop_body(),
+            error: None,
+        }
+    }
+
+    /// Set a body and return previous body value
+    pub fn map_body<F, B2>(self, f: F) -> HttpResponse<B2>
+    where
+        F: FnOnce(&mut ResponseHead, ResponseBody<B>) -> ResponseBody<B2>,
+    {
+        HttpResponse {
+            res: self.res.map_body(f),
+            error: self.error,
+        }
+    }
+
+    /// Extract response body
+    pub fn take_body(&mut self) -> ResponseBody<B> {
+        self.res.take_body()
+    }
+}
+
+impl<B: MessageBody> fmt::Debug for HttpResponse<B> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HttpResponse")
+            .field("error", &self.error)
+            .field("res", &self.res)
+            .finish()
+    }
+}
+
+impl<B> From<Response<B>> for HttpResponse<B> {
+    fn from(res: Response<B>) -> Self {
+        HttpResponse { res, error: None }
+    }
+}
+
+impl From<Error> for HttpResponse {
+    fn from(err: Error) -> Self {
+        HttpResponse::from_error(err)
+    }
+}
+
+impl<B> From<HttpResponse<B>> for Response<B> {
+    fn from(res: HttpResponse<B>) -> Self {
+        // this impl will always be called as part of dispatcher
+
+        // TODO: expose cause somewhere?
+        // if let Some(err) = res.error {
+        //     eprintln!("impl<B> From<HttpResponse<B>> for Response<B> let Some(err)");
+        //     return Response::from_error(err).into_body();
+        // }
+
+        res.res
+    }
+}
+
+impl Future for HttpResponse {
+    type Output = Result<Response<Body>, Error>;
+
+    fn poll(mut self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Self::Output> {
+        if let Some(err) = self.error.take() {
+            return Poll::Ready(Ok(Response::from_error(err).into_body()));
+        }
+
+        Poll::Ready(Ok(mem::replace(
+            &mut self.res,
+            Response::new(StatusCode::default()),
+        )))
+    }
+}
+
+#[cfg(feature = "cookies")]
+pub struct CookieIter<'a> {
+    iter: header::GetAll<'a>,
+}
+
+#[cfg(feature = "cookies")]
+impl<'a> Iterator for CookieIter<'a> {
+    type Item = Cookie<'a>;
+
+    #[inline]
+    fn next(&mut self) -> Option<Cookie<'a>> {
+        for v in self.iter.by_ref() {
+            if let Ok(c) = Cookie::parse_encoded(v.to_str().ok()?) {
+                return Some(c);
+            }
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::http::header::{HeaderValue, COOKIE};
+
+    #[test]
+    fn test_debug() {
+        let resp = HttpResponse::Ok()
+            .append_header((COOKIE, HeaderValue::from_static("cookie1=value1; ")))
+            .append_header((COOKIE, HeaderValue::from_static("cookie2=value2; ")))
+            .finish();
+        let dbg = format!("{:?}", resp);
+        assert!(dbg.contains("HttpResponse"));
+    }
+}

--- a/src/response/response.rs
+++ b/src/response/response.rs
@@ -9,17 +9,18 @@ use std::{
 
 use actix_http::{
     body::{Body, MessageBody, ResponseBody},
-    http::{
-        header::{self, HeaderMap},
-        Error as HttpError, StatusCode,
-    },
+    http::{header::HeaderMap, StatusCode},
     Extensions, Response, ResponseHead,
 };
 
 #[cfg(feature = "cookies")]
-use actix_http::http::header::HeaderValue;
-#[cfg(feature = "cookies")]
-use cookie::Cookie;
+use {
+    actix_http::http::{
+        header::{self, HeaderValue},
+        Error as HttpError,
+    },
+    cookie::Cookie,
+};
 
 use crate::{error::Error, HttpResponseBuilder};
 


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Refactor


## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
Remove the quick builders from -http to promote the explicit and sometimes lower cost constructions of Response.

Note that status code builders are kept on actix_web::HttpResponse.