### PR TITLE
`Path`: make content field `pub` again

### DIFF
--- a/src/types/path.rs
+++ b/src/types/path.rs
@@ -46,7 +46,7 @@ use crate::{dev::Payload, error::PathError, FromRequest, HttpRequest};
 /// }
 /// ```
 #[derive(PartialEq, Eq, PartialOrd, Ord, Debug)]
-pub struct Path<T>(T);
+pub struct Path<T>(pub T);
 
 impl<T> Path<T> {
     /// Unwrap into inner `T` value.


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Refactor

## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [ ] (Team) Label with affected crates and semver status.


## Overview
Upgrading to the beta and this seems to have changed from `3.3.5` but no reason is given in #1894 for the change. The content field of `Json` is still public which confuses me as to why `Path` and `Query` got this treatment but `Json` did not.

I recently switched from calling `.into_inner()` to destructuring in the function arguments and it's a lot nicer, especially for singular path arguments such as:

```rust
#[get("/user/{id}")]
async fn get_user(Path(user_id): Path<Uuid>) -> Option<User> {
    // ...
}
```

I really don't want to have to go back to writing `.into_inner()` again. It's just noise.
