### PR TITLE
move logical error handling to -web 

### DIFF
--- a/actix-http/examples/hello-world.rs
+++ b/actix-http/examples/hello-world.rs
@@ -1,6 +1,6 @@
 use std::{env, io};
 
-use actix_http::{http::StatusCode, HttpService, Response};
+use actix_http::{http::StatusCode, Error, HttpService, Response};
 use actix_server::Server;
 use actix_utils::future;
 use http::header::HeaderValue;
@@ -23,7 +23,7 @@ async fn main() -> io::Result<()> {
                         "x-head",
                         HeaderValue::from_static("dummy value!"),
                     ));
-                    future::ok::<_, ()>(res.body("Hello world!"))
+                    future::ok::<_, Error>(res.body("Hello world!"))
                 })
                 .tcp()
         })?

--- a/actix-http/src/builder.rs
+++ b/actix-http/src/builder.rs
@@ -5,9 +5,8 @@ use std::{fmt, net};
 use actix_codec::Framed;
 use actix_service::{IntoServiceFactory, Service, ServiceFactory};
 
-use crate::body::MessageBody;
+use crate::body::{Body, MessageBody};
 use crate::config::{KeepAlive, ServiceConfig};
-use crate::error::Error;
 use crate::h1::{Codec, ExpectHandler, H1Service, UpgradeHandler};
 use crate::h2::H2Service;
 use crate::request::Request;
@@ -34,7 +33,7 @@ pub struct HttpServiceBuilder<T, S, X = ExpectHandler, U = UpgradeHandler> {
 impl<T, S> HttpServiceBuilder<T, S, ExpectHandler, UpgradeHandler>
 where
     S: ServiceFactory<Request, Config = ()>,
-    S::Error: Into<Error> + 'static,
+    S::Error: Into<Response<Body>> + 'static,
     S::InitError: fmt::Debug,
     <S::Service as Service<Request>>::Future: 'static,
 {
@@ -57,11 +56,11 @@ where
 impl<T, S, X, U> HttpServiceBuilder<T, S, X, U>
 where
     S: ServiceFactory<Request, Config = ()>,
-    S::Error: Into<Error> + 'static,
+    S::Error: Into<Response<Body>> + 'static,
     S::InitError: fmt::Debug,
     <S::Service as Service<Request>>::Future: 'static,
     X: ServiceFactory<Request, Config = (), Response = Request>,
-    X::Error: Into<Error>,
+    X::Error: Into<Response<Body>>,
     X::InitError: fmt::Debug,
     U: ServiceFactory<(Request, Framed<T, Codec>), Config = (), Response = ()>,
     U::Error: fmt::Display,
@@ -123,7 +122,7 @@ where
     where
         F: IntoServiceFactory<X1, Request>,
         X1: ServiceFactory<Request, Config = (), Response = Request>,
-        X1::Error: Into<Error>,
+        X1::Error: Into<Response<Body>>,
         X1::InitError: fmt::Debug,
     {
         HttpServiceBuilder {
@@ -181,7 +180,7 @@ where
     where
         B: MessageBody,
         F: IntoServiceFactory<S, Request>,
-        S::Error: Into<Error>,
+        S::Error: Into<Response<Body>>,
         S::InitError: fmt::Debug,
         S::Response: Into<Response<B>>,
     {
@@ -204,7 +203,7 @@ where
     where
         B: MessageBody + 'static,
         F: IntoServiceFactory<S, Request>,
-        S::Error: Into<Error> + 'static,
+        S::Error: Into<Response<Body>> + 'static,
         S::InitError: fmt::Debug,
         S::Response: Into<Response<B>> + 'static,
     {
@@ -225,7 +224,7 @@ where
     where
         B: MessageBody + 'static,
         F: IntoServiceFactory<S, Request>,
-        S::Error: Into<Error> + 'static,
+        S::Error: Into<Response<Body>> + 'static,
         S::InitError: fmt::Debug,
         S::Response: Into<Response<B>> + 'static,
     {

--- a/actix-http/src/error.rs
+++ b/actix-http/src/error.rs
@@ -111,7 +111,7 @@ impl From<std::convert::Infallible> for Error {
     }
 }
 
-/// Convert `Error` to a `Response` instance
+/// Convert `Error` to a `Response` instance.
 impl From<Error> for Response<Body> {
     fn from(err: Error) -> Self {
         Response::from_error(err)

--- a/actix-http/src/lib.rs
+++ b/actix-http/src/lib.rs
@@ -34,7 +34,10 @@ pub mod client;
 mod config;
 #[cfg(feature = "compress")]
 pub mod encoding;
+pub mod error;
 mod extensions;
+pub mod h1;
+pub mod h2;
 pub mod header;
 mod helpers;
 mod http_message;
@@ -44,12 +47,8 @@ mod request;
 mod response;
 mod response_builder;
 mod service;
-mod time_parser;
-
-pub mod error;
-pub mod h1;
-pub mod h2;
 pub mod test;
+mod time_parser;
 pub mod ws;
 
 pub use self::builder::HttpServiceBuilder;

--- a/actix-http/tests/test_client.rs
+++ b/actix-http/tests/test_client.rs
@@ -1,5 +1,7 @@
 use actix_http::{
-    error, http, http::StatusCode, HttpMessage, HttpService, Request, Response,
+    error::{self, Error},
+    http::{self, StatusCode},
+    HttpMessage, HttpService, Request, Response,
 };
 use actix_http_test::test_server;
 use actix_service::ServiceFactoryExt;
@@ -33,7 +35,7 @@ const STR: &str = "Hello World Hello World Hello World Hello World Hello World \
 async fn test_h1_v2() {
     let srv = test_server(move || {
         HttpService::build()
-            .finish(|_| future::ok::<_, ()>(Response::ok().set_body(STR)))
+            .finish(|_| future::ok::<_, Error>(Response::ok().set_body(STR)))
             .tcp()
     })
     .await;
@@ -61,7 +63,7 @@ async fn test_h1_v2() {
 async fn test_connection_close() {
     let srv = test_server(move || {
         HttpService::build()
-            .finish(|_| future::ok::<_, ()>(Response::ok().set_body(STR)))
+            .finish(|_| future::ok::<_, Error>(Response::ok().set_body(STR)))
             .tcp()
             .map(|_| ())
     })
@@ -77,9 +79,9 @@ async fn test_with_query_parameter() {
         HttpService::build()
             .finish(|req: Request| {
                 if req.uri().query().unwrap().contains("qp=") {
-                    future::ok::<_, ()>(Response::ok())
+                    future::ok::<_, Error>(Response::ok())
                 } else {
-                    future::ok::<_, ()>(Response::bad_request())
+                    future::ok::<_, Error>(Response::bad_request())
                 }
             })
             .tcp()
@@ -112,7 +114,7 @@ async fn test_h1_expect() {
                 let str = std::str::from_utf8(&buf).unwrap();
                 assert_eq!(str, "expect body");
 
-                Ok::<_, ()>(Response::ok())
+                Ok::<_, Error>(Response::ok())
             })
             .tcp()
     })

--- a/actix-http/tests/test_openssl.rs
+++ b/actix-http/tests/test_openssl.rs
@@ -135,7 +135,7 @@ async fn test_h2_content_length() {
                     StatusCode::OK,
                     StatusCode::NOT_FOUND,
                 ];
-                ok::<_, ()>(Response::new(statuses[idx]))
+                ok::<_, Error>(Response::new(statuses[idx]))
             })
             .openssl(tls_config())
             .map_err(|_| ())
@@ -205,7 +205,7 @@ async fn test_h2_headers() {
                         TEST TEST TEST TEST TEST TEST TEST TEST TEST TEST TEST TEST TEST TEST ",
                 ));
             }
-            ok::<_, ()>(builder.body(data.clone()))
+            ok::<_, Error>(builder.body(data.clone()))
         })
             .openssl(tls_config())
                     .map_err(|_| ())
@@ -245,7 +245,7 @@ const STR: &str = "Hello World Hello World Hello World Hello World Hello World \
 async fn test_h2_body2() {
     let mut srv = test_server(move || {
         HttpService::build()
-            .h2(|_| ok::<_, ()>(Response::ok().set_body(STR)))
+            .h2(|_| ok::<_, Error>(Response::ok().set_body(STR)))
             .openssl(tls_config())
             .map_err(|_| ())
     })
@@ -263,7 +263,7 @@ async fn test_h2_body2() {
 async fn test_h2_head_empty() {
     let mut srv = test_server(move || {
         HttpService::build()
-            .finish(|_| ok::<_, ()>(Response::ok().set_body(STR)))
+            .finish(|_| ok::<_, Error>(Response::ok().set_body(STR)))
             .openssl(tls_config())
             .map_err(|_| ())
     })
@@ -287,7 +287,7 @@ async fn test_h2_head_empty() {
 async fn test_h2_head_binary() {
     let mut srv = test_server(move || {
         HttpService::build()
-            .h2(|_| ok::<_, ()>(Response::ok().set_body(STR)))
+            .h2(|_| ok::<_, Error>(Response::ok().set_body(STR)))
             .openssl(tls_config())
             .map_err(|_| ())
     })
@@ -310,7 +310,7 @@ async fn test_h2_head_binary() {
 async fn test_h2_head_binary2() {
     let srv = test_server(move || {
         HttpService::build()
-            .h2(|_| ok::<_, ()>(Response::ok().set_body(STR)))
+            .h2(|_| ok::<_, Error>(Response::ok().set_body(STR)))
             .openssl(tls_config())
             .map_err(|_| ())
     })
@@ -331,7 +331,7 @@ async fn test_h2_body_length() {
         HttpService::build()
             .h2(|_| {
                 let body = once(ok(Bytes::from_static(STR.as_ref())));
-                ok::<_, ()>(
+                ok::<_, Error>(
                     Response::ok().set_body(SizedStream::new(STR.len() as u64, body)),
                 )
             })
@@ -354,7 +354,7 @@ async fn test_h2_body_chunked_explicit() {
         HttpService::build()
             .h2(|_| {
                 let body = once(ok::<_, Error>(Bytes::from_static(STR.as_ref())));
-                ok::<_, ()>(
+                ok::<_, Error>(
                     Response::build(StatusCode::OK)
                         .insert_header((header::TRANSFER_ENCODING, "chunked"))
                         .streaming(body),
@@ -382,7 +382,7 @@ async fn test_h2_response_http_error_handling() {
         HttpService::build()
             .h2(fn_service(|_| {
                 let broken_header = Bytes::from_static(b"\0\0\0");
-                ok::<_, ()>(
+                ok::<_, Error>(
                     Response::build(StatusCode::OK)
                         .insert_header((header::CONTENT_TYPE, broken_header))
                         .body(STR),
@@ -428,7 +428,7 @@ async fn test_h2_on_connect() {
             })
             .h2(|req: Request| {
                 assert!(req.extensions().contains::<isize>());
-                ok::<_, ()>(Response::ok())
+                ok::<_, Error>(Response::ok())
             })
             .openssl(tls_config())
             .map_err(|_| ())

--- a/actix-http/tests/test_rustls.rs
+++ b/actix-http/tests/test_rustls.rs
@@ -149,7 +149,7 @@ async fn test_h2_content_length() {
                     StatusCode::OK,
                     StatusCode::NOT_FOUND,
                 ];
-                ok::<_, ()>(Response::new(statuses[indx]))
+                ok::<_, Error>(Response::new(statuses[indx]))
             })
             .rustls(tls_config())
     })
@@ -218,7 +218,7 @@ async fn test_h2_headers() {
                         TEST TEST TEST TEST TEST TEST TEST TEST TEST TEST TEST TEST TEST TEST ",
                 ));
             }
-            ok::<_, ()>(config.body(data.clone()))
+            ok::<_, Error>(config.body(data.clone()))
         })
             .rustls(tls_config())
     }).await;
@@ -257,7 +257,7 @@ const STR: &str = "Hello World Hello World Hello World Hello World Hello World \
 async fn test_h2_body2() {
     let mut srv = test_server(move || {
         HttpService::build()
-            .h2(|_| ok::<_, ()>(Response::ok().set_body(STR)))
+            .h2(|_| ok::<_, Error>(Response::ok().set_body(STR)))
             .rustls(tls_config())
     })
     .await;
@@ -274,7 +274,7 @@ async fn test_h2_body2() {
 async fn test_h2_head_empty() {
     let mut srv = test_server(move || {
         HttpService::build()
-            .finish(|_| ok::<_, ()>(Response::ok().set_body(STR)))
+            .finish(|_| ok::<_, Error>(Response::ok().set_body(STR)))
             .rustls(tls_config())
     })
     .await;
@@ -300,7 +300,7 @@ async fn test_h2_head_empty() {
 async fn test_h2_head_binary() {
     let mut srv = test_server(move || {
         HttpService::build()
-            .h2(|_| ok::<_, ()>(Response::ok().set_body(STR)))
+            .h2(|_| ok::<_, Error>(Response::ok().set_body(STR)))
             .rustls(tls_config())
     })
     .await;
@@ -325,7 +325,7 @@ async fn test_h2_head_binary() {
 async fn test_h2_head_binary2() {
     let srv = test_server(move || {
         HttpService::build()
-            .h2(|_| ok::<_, ()>(Response::ok().set_body(STR)))
+            .h2(|_| ok::<_, Error>(Response::ok().set_body(STR)))
             .rustls(tls_config())
     })
     .await;
@@ -348,7 +348,7 @@ async fn test_h2_body_length() {
         HttpService::build()
             .h2(|_| {
                 let body = once(ok(Bytes::from_static(STR.as_ref())));
-                ok::<_, ()>(
+                ok::<_, Error>(
                     Response::ok().set_body(SizedStream::new(STR.len() as u64, body)),
                 )
             })
@@ -370,7 +370,7 @@ async fn test_h2_body_chunked_explicit() {
         HttpService::build()
             .h2(|_| {
                 let body = once(ok::<_, Error>(Bytes::from_static(STR.as_ref())));
-                ok::<_, ()>(
+                ok::<_, Error>(
                     Response::build(StatusCode::OK)
                         .insert_header((header::TRANSFER_ENCODING, "chunked"))
                         .streaming(body),
@@ -396,9 +396,9 @@ async fn test_h2_response_http_error_handling() {
     let mut srv = test_server(move || {
         HttpService::build()
             .h2(fn_factory_with_config(|_: ()| {
-                ok::<_, ()>(fn_service(|_| {
+                ok::<_, Error>(fn_service(|_| {
                     let broken_header = Bytes::from_static(b"\0\0\0");
-                    ok::<_, ()>(
+                    ok::<_, Error>(
                         Response::build(StatusCode::OK)
                             .insert_header((http::header::CONTENT_TYPE, broken_header))
                             .body(STR),

--- a/actix-http/tests/test_server.rs
+++ b/actix-http/tests/test_server.rs
@@ -28,7 +28,7 @@ async fn test_h1() {
             .client_disconnect(1000)
             .h1(|req: Request| {
                 assert!(req.peer_addr().is_some());
-                ok::<_, ()>(Response::ok())
+                ok::<_, Error>(Response::ok())
             })
             .tcp()
     })
@@ -48,7 +48,7 @@ async fn test_h1_2() {
             .finish(|req: Request| {
                 assert!(req.peer_addr().is_some());
                 assert_eq!(req.version(), http::Version::HTTP_11);
-                ok::<_, ()>(Response::ok())
+                ok::<_, Error>(Response::ok())
             })
             .tcp()
     })
@@ -69,7 +69,7 @@ async fn test_expect_continue() {
                     err(error::ErrorPreconditionFailed("error"))
                 }
             }))
-            .finish(|_| ok::<_, ()>(Response::ok()))
+            .finish(|_| ok::<_, Error>(Response::ok()))
             .tcp()
     })
     .await;
@@ -100,7 +100,7 @@ async fn test_expect_continue_h1() {
                     }
                 })
             }))
-            .h1(fn_service(|_| ok::<_, ()>(Response::ok())))
+            .h1(fn_service(|_| ok::<_, Error>(Response::ok())))
             .tcp()
     })
     .await;
@@ -181,7 +181,7 @@ async fn test_slow_request() {
     let srv = test_server(|| {
         HttpService::build()
             .client_timeout(100)
-            .finish(|_| ok::<_, ()>(Response::ok()))
+            .finish(|_| ok::<_, Error>(Response::ok()))
             .tcp()
     })
     .await;
@@ -197,7 +197,7 @@ async fn test_slow_request() {
 async fn test_http1_malformed_request() {
     let srv = test_server(|| {
         HttpService::build()
-            .h1(|_| ok::<_, ()>(Response::ok()))
+            .h1(|_| ok::<_, Error>(Response::ok()))
             .tcp()
     })
     .await;
@@ -213,7 +213,7 @@ async fn test_http1_malformed_request() {
 async fn test_http1_keepalive() {
     let srv = test_server(|| {
         HttpService::build()
-            .h1(|_| ok::<_, ()>(Response::ok()))
+            .h1(|_| ok::<_, Error>(Response::ok()))
             .tcp()
     })
     .await;
@@ -235,7 +235,7 @@ async fn test_http1_keepalive_timeout() {
     let srv = test_server(|| {
         HttpService::build()
             .keep_alive(1)
-            .h1(|_| ok::<_, ()>(Response::ok()))
+            .h1(|_| ok::<_, Error>(Response::ok()))
             .tcp()
     })
     .await;
@@ -256,7 +256,7 @@ async fn test_http1_keepalive_timeout() {
 async fn test_http1_keepalive_close() {
     let srv = test_server(|| {
         HttpService::build()
-            .h1(|_| ok::<_, ()>(Response::ok()))
+            .h1(|_| ok::<_, Error>(Response::ok()))
             .tcp()
     })
     .await;
@@ -277,7 +277,7 @@ async fn test_http1_keepalive_close() {
 async fn test_http10_keepalive_default_close() {
     let srv = test_server(|| {
         HttpService::build()
-            .h1(|_| ok::<_, ()>(Response::ok()))
+            .h1(|_| ok::<_, Error>(Response::ok()))
             .tcp()
     })
     .await;
@@ -297,7 +297,7 @@ async fn test_http10_keepalive_default_close() {
 async fn test_http10_keepalive() {
     let srv = test_server(|| {
         HttpService::build()
-            .h1(|_| ok::<_, ()>(Response::ok()))
+            .h1(|_| ok::<_, Error>(Response::ok()))
             .tcp()
     })
     .await;
@@ -325,7 +325,7 @@ async fn test_http1_keepalive_disabled() {
     let srv = test_server(|| {
         HttpService::build()
             .keep_alive(KeepAlive::Disabled)
-            .h1(|_| ok::<_, ()>(Response::ok()))
+            .h1(|_| ok::<_, Error>(Response::ok()))
             .tcp()
     })
     .await;
@@ -360,7 +360,7 @@ async fn test_content_length() {
                     StatusCode::OK,
                     StatusCode::NOT_FOUND,
                 ];
-                ok::<_, ()>(Response::new(statuses[indx]))
+                ok::<_, Error>(Response::new(statuses[indx]))
             })
             .tcp()
     })
@@ -415,7 +415,7 @@ async fn test_h1_headers() {
                         TEST TEST TEST TEST TEST TEST TEST TEST TEST TEST TEST TEST TEST TEST ",
                 ));
             }
-            ok::<_, ()>(builder.body(data.clone()))
+            ok::<_, Error>(builder.body(data.clone()))
         }).tcp()
     }).await;
 
@@ -453,7 +453,7 @@ const STR: &str = "Hello World Hello World Hello World Hello World Hello World \
 async fn test_h1_body() {
     let mut srv = test_server(|| {
         HttpService::build()
-            .h1(|_| ok::<_, ()>(Response::ok().set_body(STR)))
+            .h1(|_| ok::<_, Error>(Response::ok().set_body(STR)))
             .tcp()
     })
     .await;
@@ -470,7 +470,7 @@ async fn test_h1_body() {
 async fn test_h1_head_empty() {
     let mut srv = test_server(|| {
         HttpService::build()
-            .h1(|_| ok::<_, ()>(Response::ok().set_body(STR)))
+            .h1(|_| ok::<_, Error>(Response::ok().set_body(STR)))
             .tcp()
     })
     .await;
@@ -495,7 +495,7 @@ async fn test_h1_head_empty() {
 async fn test_h1_head_binary() {
     let mut srv = test_server(|| {
         HttpService::build()
-            .h1(|_| ok::<_, ()>(Response::ok().set_body(STR)))
+            .h1(|_| ok::<_, Error>(Response::ok().set_body(STR)))
             .tcp()
     })
     .await;
@@ -520,7 +520,7 @@ async fn test_h1_head_binary() {
 async fn test_h1_head_binary2() {
     let srv = test_server(|| {
         HttpService::build()
-            .h1(|_| ok::<_, ()>(Response::ok().set_body(STR)))
+            .h1(|_| ok::<_, Error>(Response::ok().set_body(STR)))
             .tcp()
     })
     .await;
@@ -543,7 +543,7 @@ async fn test_h1_body_length() {
         HttpService::build()
             .h1(|_| {
                 let body = once(ok(Bytes::from_static(STR.as_ref())));
-                ok::<_, ()>(
+                ok::<_, Error>(
                     Response::ok().set_body(SizedStream::new(STR.len() as u64, body)),
                 )
             })
@@ -565,7 +565,7 @@ async fn test_h1_body_chunked_explicit() {
         HttpService::build()
             .h1(|_| {
                 let body = once(ok::<_, Error>(Bytes::from_static(STR.as_ref())));
-                ok::<_, ()>(
+                ok::<_, Error>(
                     Response::build(StatusCode::OK)
                         .insert_header((header::TRANSFER_ENCODING, "chunked"))
                         .streaming(body),
@@ -600,7 +600,7 @@ async fn test_h1_body_chunked_implicit() {
         HttpService::build()
             .h1(|_| {
                 let body = once(ok::<_, Error>(Bytes::from_static(STR.as_ref())));
-                ok::<_, ()>(Response::build(StatusCode::OK).streaming(body))
+                ok::<_, Error>(Response::build(StatusCode::OK).streaming(body))
             })
             .tcp()
     })
@@ -629,7 +629,7 @@ async fn test_h1_response_http_error_handling() {
         HttpService::build()
             .h1(fn_service(|_| {
                 let broken_header = Bytes::from_static(b"\0\0\0");
-                ok::<_, ()>(
+                ok::<_, Error>(
                     Response::build(StatusCode::OK)
                         .insert_header((http::header::CONTENT_TYPE, broken_header))
                         .body(STR),
@@ -673,7 +673,7 @@ async fn test_h1_on_connect() {
             })
             .h1(|req: Request| {
                 assert!(req.extensions().contains::<isize>());
-                ok::<_, ()>(Response::ok())
+                ok::<_, Error>(Response::ok())
             })
             .tcp()
     })

--- a/actix-http/tests/test_ws.rs
+++ b/actix-http/tests/test_ws.rs
@@ -91,7 +91,7 @@ async fn test_simple() {
             let ws_service = ws_service.clone();
             HttpService::build()
                 .upgrade(fn_factory(move || future::ok::<_, ()>(ws_service.clone())))
-                .finish(|_| future::ok::<_, ()>(Response::not_found()))
+                .finish(|_| future::ok::<_, Error>(Response::not_found()))
                 .tcp()
         }
     })

--- a/actix-test/src/lib.rs
+++ b/actix-test/src/lib.rs
@@ -36,13 +36,14 @@ use std::{fmt, net, sync::mpsc, thread, time};
 use actix_codec::{AsyncRead, AsyncWrite, Framed};
 pub use actix_http::test::TestBuffer;
 use actix_http::{
+    body::Body,
     http::{HeaderMap, Method},
     ws, HttpService, Request, Response,
 };
 use actix_service::{map_config, IntoServiceFactory, ServiceFactory};
 use actix_web::{
     dev::{AppConfig, MessageBody, Server, Service},
-    rt, web, Error,
+    rt, web,
 };
 use awc::{error::PayloadError, Client, ClientRequest, ClientResponse, Connector};
 use futures_core::Stream;
@@ -81,7 +82,7 @@ where
     F: Fn() -> I + Send + Clone + 'static,
     I: IntoServiceFactory<S, Request>,
     S: ServiceFactory<Request, Config = AppConfig> + 'static,
-    S::Error: Into<Error> + 'static,
+    S::Error: Into<Response<Body>> + 'static,
     S::InitError: fmt::Debug,
     S::Response: Into<Response<B>> + 'static,
     <S::Service as Service<Request>>::Future: 'static,
@@ -120,7 +121,7 @@ where
     F: Fn() -> I + Send + Clone + 'static,
     I: IntoServiceFactory<S, Request>,
     S: ServiceFactory<Request, Config = AppConfig> + 'static,
-    S::Error: Into<Error> + 'static,
+    S::Error: Into<Response<Body>> + 'static,
     S::InitError: fmt::Debug,
     S::Response: Into<Response<B>> + 'static,
     <S::Service as Service<Request>>::Future: 'static,

--- a/awc/tests/test_ws.rs
+++ b/awc/tests/test_ws.rs
@@ -33,7 +33,9 @@ async fn test_simple() {
 
                     // start WebSocket service
                     let framed = framed.replace_codec(ws::Codec::new());
-                    ws::Dispatcher::with(framed, ws_service).await
+                    ws::Dispatcher::with(framed, ws_service)
+                        .await
+                        .map_err(Error::from)
                 }
             })
             .finish(|_| ok::<_, Error>(Response::not_found()))

--- a/src/response/builder.rs
+++ b/src/response/builder.rs
@@ -328,6 +328,7 @@ impl HttpResponseBuilder {
             .expect("cannot reuse response builder")
             .set_body(body);
 
+        // allow unused mut when cookies feature is disabled
         #[allow(unused_mut)]
         let mut res = HttpResponse::from(res);
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -7,7 +7,8 @@ use std::{
 };
 
 use actix_http::{
-    body::MessageBody, Error, Extensions, HttpService, KeepAlive, Request, Response,
+    body::{Body, MessageBody},
+    Extensions, HttpService, KeepAlive, Request, Response,
 };
 use actix_server::{Server, ServerBuilder};
 use actix_service::{map_config, IntoServiceFactory, Service, ServiceFactory};
@@ -53,7 +54,7 @@ where
     F: Fn() -> I + Send + Clone + 'static,
     I: IntoServiceFactory<S, Request>,
     S: ServiceFactory<Request, Config = AppConfig>,
-    S::Error: Into<Error>,
+    S::Error: Into<Response<Body>>,
     S::InitError: fmt::Debug,
     S::Response: Into<Response<B>>,
     B: MessageBody,
@@ -74,7 +75,7 @@ where
 
     S: ServiceFactory<Request, Config = AppConfig> + 'static,
     // S::Future: 'static,
-    S::Error: Into<Error> + 'static,
+    S::Error: Into<Response<Body>> + 'static,
     S::InitError: fmt::Debug,
     S::Response: Into<Response<B>> + 'static,
     <S::Service as Service<Request>>::Future: 'static,
@@ -574,7 +575,7 @@ where
     F: Fn() -> I + Send + Clone + 'static,
     I: IntoServiceFactory<S, Request>,
     S: ServiceFactory<Request, Config = AppConfig>,
-    S::Error: Into<Error>,
+    S::Error: Into<Response<Body>>,
     S::InitError: fmt::Debug,
     S::Response: Into<Response<B>>,
     S::Service: 'static,


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Refactor


## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [ ] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
The rationale is that -http should be concerned with Request -> Response only (except it's own errors) and delegate higher level error handling to user or downstream lib.

Therefore, -http's service builders and dispatchers now expect `Service::Error` types to be `Into<Response<Body>>` instead of `Into<Error>` (which `Error` is). These are almost the same from perspective of this lib.

The upside is that it will reduce API surface of -http by moving Error struct and ResponseError trait to -web, where more ergonomic errors can be produced. As seen in the fallout from -web beta.6, there are many people who implement ResponseError trait and requiring it to build a -http Response was too burdensome.