### PR TITLE
Reexport actix_rt::main macro

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,6 +100,7 @@ pub use actix_http::Response as BaseHttpResponse;
 pub use actix_http::{body, Error, HttpMessage, ResponseError, Result};
 #[doc(inline)]
 pub use actix_rt as rt;
+pub use actix_rt::main;
 pub use actix_web_codegen::*;
 #[cfg(feature = "cookies")]
 pub use cookie;


### PR DESCRIPTION
## PR Type
Refactor

## PR Checklist
- [x] Documentation comments have been added / updated.
- [x] Format code with the latest stable rustfmt.

## Overview
Re-export the `actix_rt::main` macro instead of duplicating the code.