### PR TITLE
Static middleware futures

### DIFF
--- a/src/middleware/condition.rs
+++ b/src/middleware/condition.rs
@@ -6,7 +6,6 @@ use std::task::{Context, Poll};
 
 use actix_service::{Service, Transform};
 use actix_utils::future::Either;
-
 use futures_core::ready;
 
 /// Middleware for conditionally enabling other middleware.

--- a/src/middleware/err_handlers.rs
+++ b/src/middleware/err_handlers.rs
@@ -9,7 +9,10 @@ use std::{
 
 use actix_service::{Service, Transform};
 use ahash::AHashMap;
-use futures_core::{future::LocalBoxFuture, ready};
+use futures_util::{
+    future::{ok, LocalBoxFuture, Ready},
+    ready,
+};
 
 use crate::{
     dev::{ServiceRequest, ServiceResponse},
@@ -97,11 +100,11 @@ where
     type Error = Error;
     type Transform = ErrorHandlersMiddleware<S, B>;
     type InitError = ();
-    type Future = LocalBoxFuture<'static, Result<Self::Transform, Self::InitError>>;
+    type Future = Ready<Result<Self::Transform, Self::InitError>>;
 
     fn new_transform(&self, service: S) -> Self::Future {
         let handlers = self.handlers.clone();
-        Box::pin(async move { Ok(ErrorHandlersMiddleware { service, handlers }) })
+        ok(ErrorHandlersMiddleware { service, handlers })
     }
 }
 


### PR DESCRIPTION
## PR Type
Refactor


## PR Checklist
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
Replace boxed future with a custom future type in `Compat`, `Condition`, and `ErrHandler` middlewares. All middlewares now use static future types.
