### PR TITLE
Reduce the level of the emitted log line from `error` to `debug`.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## Unreleased - 2021-xx-xx
 ### Changed
 * Update `language-tags` to `0.3`.
+* Reduce the level from `error` to `debug` for the log line that is emitted when a `500 Internal Server Error` occurs.
 
 
 ## 4.0.0-beta.6 - 2021-04-17

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 ### Changed
 * Update `language-tags` to `0.3`.
 
+
 ## 4.0.0-beta.6 - 2021-04-17
 ### Added
 * `HttpResponse` and `HttpResponseBuilder` structs. [#2065]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,8 +3,6 @@
 ## Unreleased - 2021-xx-xx
 ### Changed
 * Update `language-tags` to `0.3`.
-* Reduce the level from `error` to `debug` for the log line that is emitted when a `500 Internal Server Error` occurs.
-
 
 ## 4.0.0-beta.6 - 2021-04-17
 ### Added

--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -10,6 +10,7 @@
 * `header` mod is now public. [#2171]
 * `uri` mod is now public. [#2171]
 * Update `language-tags` to `0.3`.
+* Reduce the level from `error` to `debug` for the log line that is emitted when a `500 Internal Server Error` is built using `HttpResponse::from_error`.
 
 ### Removed
 * Stop re-exporting `http` crate's `HeaderMap` types in addition to ours. [#2171]

--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -10,12 +10,13 @@
 * `header` mod is now public. [#2171]
 * `uri` mod is now public. [#2171]
 * Update `language-tags` to `0.3`.
-* Reduce the level from `error` to `debug` for the log line that is emitted when a `500 Internal Server Error` is built using `HttpResponse::from_error`.
+* Reduce the level from `error` to `debug` for the log line that is emitted when a `500 Internal Server Error` is built using `HttpResponse::from_error`. [#2196]
 
 ### Removed
 * Stop re-exporting `http` crate's `HeaderMap` types in addition to ours. [#2171]
 
 [#2171]: https://github.com/actix/actix-web/pull/2171
+[#2196]: https://github.com/actix/actix-web/pull/2196
 
 
 ## 3.0.0-beta.6 - 2021-04-17

--- a/actix-http/src/response.rs
+++ b/actix-http/src/response.rs
@@ -78,7 +78,7 @@ impl Response<Body> {
     pub fn from_error(error: Error) -> Response<Body> {
         let mut resp = error.as_response_error().error_response();
         if resp.head.status == StatusCode::INTERNAL_SERVER_ERROR {
-            error!("Internal Server Error: {:?}", error);
+            debug!("Internal Server Error: {:?}", error);
         }
         resp.error = Some(error);
         resp


### PR DESCRIPTION
## PR Type

Other


## PR Checklist

- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview

The framework already provides a `Logger` middleware for this purpose - there is no need to add another concern to `from_error`. Furthermore, it leads to a duplicate log line when a logging middleware is used, with no option to silence this particular log record.

