### PR TITLE
[Fix] HttpResponse -> Error conversion

### DIFF
--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -14,6 +14,9 @@
 ### Removed
 * Stop re-exporting `http` crate's `HeaderMap` types in addition to ours. [#2171]
 
+### Fixed
+* Converting an `HttpResponse` to an `Error` return the underlying `Error` if `HttpResponse` was built using `HttpResponse::from_error`.
+
 [#2171]: https://github.com/actix/actix-web/pull/2171
 
 

--- a/actix-http/src/error.rs
+++ b/actix-http/src/error.rs
@@ -130,7 +130,11 @@ impl<T: ResponseError + 'static> From<T> for Error {
 /// Convert Response to a Error
 impl From<Response<Body>> for Error {
     fn from(res: Response<Body>) -> Error {
-        InternalError::from_response("", res).into()
+        if res.error.is_some() {
+            res.error.unwrap()
+        } else {
+            InternalError::from_response("", res).into()
+        }
     }
 }
 

--- a/actix-http/src/response.rs
+++ b/actix-http/src/response.rs
@@ -341,6 +341,7 @@ mod tests {
     use super::*;
     use crate::body::Body;
     use crate::http::header::{HeaderValue, CONTENT_TYPE, COOKIE};
+    use crate::ResponseError;
 
     #[test]
     fn test_debug() {
@@ -350,6 +351,26 @@ mod tests {
             .finish();
         let dbg = format!("{:?}", resp);
         assert!(dbg.contains("Response"));
+    }
+
+    #[test]
+    fn test_response_error_conversions() {
+        #[derive(Debug, Clone, PartialEq, Eq)]
+        pub struct MyError;
+
+        impl std::fmt::Display for MyError {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "An error")
+            }
+        }
+
+        impl ResponseError for MyError {}
+
+        let error = MyError;
+        let response = Response::from_error(error.clone().into());
+        let actix_error: crate::Error = response.into();
+
+        assert_eq!(actix_error.as_error::<MyError>(), Some(&error));
     }
 
     #[test]


### PR DESCRIPTION
## PR Type
Bug fix


## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- ~[ ] Documentation comments have been added / updated.~
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [ ] (Team) Label with affected crates and semver status.


## Overview

If `HttpResponse` is already wrapping an `Error`, return the underlying `Error` instead of generating a new one losing the error source.
This fixes an issue related to error propagation: if the request converts an `Error` into an `HttpResponse` using `HttpResponse::from_error` the framework will then convert it back into an `Error` losing all context about the underlying error, affecting logging and (potentially) control flow in middlewares.
