### PR TITLE
remove responsebody indirection from response

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: -v --workspace --all-features --no-fail-fast -- --nocapture
+          args: --workspace --all-features --no-fail-fast -- --nocapture
             --skip=test_h2_content_length
             --skip=test_reading_deflate_encoding_large_random_rustls
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,9 +5,17 @@
 * `HttpServer::worker_max_blocking_threads` for setting block thread pool. [#2200]
 
 ### Changed
+* `ServiceResponse::error_response` now uses body type of `Body`. [#2201]
+* `ServiceResponse::checked_expr` now returns a `Result`. [#2201]
 * Update `language-tags` to `0.3`.
+* `ServiceResponse::take_body`. [#2201]
+* `ServiceResponse::map_body` closure receives and returns `B` instead of `ResponseBody<B>` types. [#2201]
+
+### Removed
+* `HttpResponse::take_body` and old `HttpResponse::into_body` method that casted body type. [#2201]
 
 [#2200]: https://github.com/actix/actix-web/pull/2200
+[#2201]: https://github.com/actix/actix-web/pull/2201
 
 
 ## 4.0.0-beta.6 - 2021-04-17

--- a/actix-files/src/service.rs
+++ b/actix-files/src/service.rs
@@ -96,8 +96,7 @@ impl Service<ServiceRequest> for FilesService {
                     return Box::pin(ok(req.into_response(
                         HttpResponse::Found()
                             .insert_header((header::LOCATION, redirect_to))
-                            .body("")
-                            .into_body(),
+                            .finish(),
                     )));
                 }
 

--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -17,10 +17,12 @@
 ### Removed
 * Stop re-exporting `http` crate's `HeaderMap` types in addition to ours. [#2171]
 * Down-casting for `MessageBody` types. [#2183]
+* `error::Result` alias. [#????]
 
 [#2171]: https://github.com/actix/actix-web/pull/2171
 [#2183]: https://github.com/actix/actix-web/pull/2183
 [#2196]: https://github.com/actix/actix-web/pull/2196
+[#????]: https://github.com/actix/actix-web/pull/????
 
 
 ## 3.0.0-beta.6 - 2021-04-17

--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -9,6 +9,7 @@
 
 ### Changed
 * The `MessageBody` trait now has an associated `Error` type. [#2183]
+* Places in `Response` where `ResponseBody<B>` was received or returned now simply use `B`. [#2201]
 * `header` mod is now public. [#2171]
 * `uri` mod is now public. [#2171]
 * Update `language-tags` to `0.3`.
@@ -17,12 +18,12 @@
 ### Removed
 * Stop re-exporting `http` crate's `HeaderMap` types in addition to ours. [#2171]
 * Down-casting for `MessageBody` types. [#2183]
-* `error::Result` alias. [#????]
+* `error::Result` alias. [#2201]
 
 [#2171]: https://github.com/actix/actix-web/pull/2171
 [#2183]: https://github.com/actix/actix-web/pull/2183
 [#2196]: https://github.com/actix/actix-web/pull/2196
-[#????]: https://github.com/actix/actix-web/pull/????
+[#2201]: https://github.com/actix/actix-web/pull/2201
 
 
 ## 3.0.0-beta.6 - 2021-04-17

--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -19,6 +19,7 @@
 * Stop re-exporting `http` crate's `HeaderMap` types in addition to ours. [#2171]
 * Down-casting for `MessageBody` types. [#2183]
 * `error::Result` alias. [#2201]
+* `impl Future` for `Response`. [#2201]
 
 [#2171]: https://github.com/actix/actix-web/pull/2171
 [#2183]: https://github.com/actix/actix-web/pull/2183

--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -6,6 +6,8 @@
 * Re-export `http` crate's `Error` type as `error::HttpError`. [#2171]
 * Re-export `StatusCode`, `Method`, `Version` and `Uri` at the crate root. [#2171]
 * Re-export `ContentEncoding` and `ConnectionType` at the crate root. [#2171]
+* `Response::into_body` that consumes response and returns body type. [#2201]
+* `impl Default` for `Response`. [#2201]
 
 ### Changed
 * The `MessageBody` trait now has an associated `Error` type. [#2183]
@@ -13,13 +15,15 @@
 * `header` mod is now public. [#2171]
 * `uri` mod is now public. [#2171]
 * Update `language-tags` to `0.3`.
-* Reduce the level from `error` to `debug` for the log line that is emitted when a `500 Internal Server Error` is built using `HttpResponse::from_error`. [#2196]
+* Reduce the level from `error` to `debug` for the log line that is emitted when a `500 Internal Server Error` is built using `HttpResponse::from_error`. [#2201]
+* `ResponseBuilder::message_body` now returns a `Result`. [#2201]
 
 ### Removed
 * Stop re-exporting `http` crate's `HeaderMap` types in addition to ours. [#2171]
 * Down-casting for `MessageBody` types. [#2183]
 * `error::Result` alias. [#2201]
 * `impl Future` for `Response`. [#2201]
+* `Response::take_body` and old `Response::into_body` method that casted body type. [#2201]
 
 [#2171]: https://github.com/actix/actix-web/pull/2171
 [#2183]: https://github.com/actix/actix-web/pull/2183

--- a/actix-http/examples/ws.rs
+++ b/actix-http/examples/ws.rs
@@ -40,7 +40,7 @@ async fn handler(req: Request) -> Result<Response<BodyStream<Heartbeat>>, Error>
     // handshake will always fail under HTTP/2
 
     log::info!("responding");
-    Ok(res.message_body(BodyStream::new(Heartbeat::new(ws::Codec::new()))))
+    Ok(res.message_body(BodyStream::new(Heartbeat::new(ws::Codec::new())))?)
 }
 
 struct Heartbeat {

--- a/actix-http/src/body/mod.rs
+++ b/actix-http/src/body/mod.rs
@@ -86,16 +86,6 @@ mod tests {
         }
     }
 
-    impl ResponseBody<Body> {
-        #[allow(dead_code)]
-        pub(crate) fn get_ref(&self) -> &[u8] {
-            match *self {
-                ResponseBody::Body(ref b) => b.get_ref(),
-                ResponseBody::Other(ref b) => b.get_ref(),
-            }
-        }
-    }
-
     #[actix_rt::test]
     async fn test_static_str() {
         assert_eq!(Body::from("").size(), BodySize::Sized(0));

--- a/actix-http/src/body/mod.rs
+++ b/actix-http/src/body/mod.rs
@@ -87,6 +87,7 @@ mod tests {
     }
 
     impl ResponseBody<Body> {
+        #[allow(dead_code)]
         pub(crate) fn get_ref(&self) -> &[u8] {
             match *self {
                 ResponseBody::Body(ref b) => b.get_ref(),

--- a/actix-http/src/error.rs
+++ b/actix-http/src/error.rs
@@ -18,12 +18,6 @@ use crate::{body::Body, helpers::Writer, Response, ResponseBuilder};
 
 pub use http::Error as HttpError;
 
-/// A specialized [`std::result::Result`] for Actix Web operations.
-///
-/// This typedef is generally used to avoid writing out `actix_http::error::Error` directly and is
-/// otherwise a direct mapping to `Result`.
-pub type Result<T, E = Error> = std::result::Result<T, E>;
-
 /// General purpose actix web error.
 ///
 /// An actix web error is used to carry errors from `std::error`

--- a/actix-http/src/error.rs
+++ b/actix-http/src/error.rs
@@ -464,9 +464,8 @@ impl ResponseError for ContentTypeError {
 ///
 /// ```
 /// # use std::io;
-/// # use actix_http::*;
-///
-/// fn index(req: Request) -> Result<&'static str> {
+/// # use actix_http::{error, Request};
+/// fn index(req: Request) -> Result<&'static str, actix_http::Error> {
 ///     Err(error::ErrorBadRequest(io::Error::new(io::ErrorKind::Other, "error")))
 /// }
 /// ```

--- a/actix-http/src/h1/dispatcher.rs
+++ b/actix-http/src/h1/dispatcher.rs
@@ -473,7 +473,7 @@ where
                             }
 
                             Poll::Ready(Some(Err(err))) => {
-                                return Err(DispatchError::Service(err.into()))
+                                return Err(DispatchError::Service(err))
                             }
 
                             Poll::Pending => return Ok(PollResponse::DoNothing),

--- a/actix-http/src/h1/encoder.rs
+++ b/actix-http/src/h1/encoder.rs
@@ -630,8 +630,7 @@ mod tests {
     async fn test_no_content_length() {
         let mut bytes = BytesMut::with_capacity(2048);
 
-        let mut res: Response<()> =
-            Response::new(StatusCode::SWITCHING_PROTOCOLS).into_body::<()>();
+        let mut res = Response::new(StatusCode::SWITCHING_PROTOCOLS).drop_body();
         res.headers_mut().insert(DATE, HeaderValue::from_static(""));
         res.headers_mut()
             .insert(CONTENT_LENGTH, HeaderValue::from_static("0"));

--- a/actix-http/src/h1/encoder.rs
+++ b/actix-http/src/h1/encoder.rs
@@ -630,7 +630,7 @@ mod tests {
     async fn test_no_content_length() {
         let mut bytes = BytesMut::with_capacity(2048);
 
-        let mut res = Response::new(StatusCode::SWITCHING_PROTOCOLS).drop_body();
+        let mut res = Response::with_body(StatusCode::SWITCHING_PROTOCOLS, ());
         res.headers_mut().insert(DATE, HeaderValue::from_static(""));
         res.headers_mut()
             .insert(CONTENT_LENGTH, HeaderValue::from_static("0"));

--- a/actix-http/src/h2/dispatcher.rs
+++ b/actix-http/src/h2/dispatcher.rs
@@ -346,7 +346,7 @@ where
 
             ServiceResponseStateProj::SendErrorPayload(ref mut stream, ref mut body) => {
                 // TODO: de-dupe impl with SendPayload
-                
+
                 loop {
                     match this.buffer {
                         Some(ref mut buffer) => match ready!(stream.poll_capacity(cx)) {

--- a/actix-http/src/header/shared/charset.rs
+++ b/actix-http/src/header/shared/charset.rs
@@ -104,7 +104,7 @@ impl Display for Charset {
 impl FromStr for Charset {
     type Err = crate::Error;
 
-    fn from_str(s: &str) -> crate::Result<Charset> {
+    fn from_str(s: &str) -> Result<Charset, crate::Error> {
         Ok(match s.to_ascii_uppercase().as_ref() {
             "US-ASCII" => Us_Ascii,
             "ISO-8859-1" => Iso_8859_1,

--- a/actix-http/src/lib.rs
+++ b/actix-http/src/lib.rs
@@ -54,7 +54,7 @@ pub mod ws;
 
 pub use self::builder::HttpServiceBuilder;
 pub use self::config::{KeepAlive, ServiceConfig};
-pub use self::error::{Error, ResponseError, Result};
+pub use self::error::{Error, ResponseError};
 pub use self::extensions::Extensions;
 pub use self::header::ContentEncoding;
 pub use self::http_message::HttpMessage;

--- a/actix-http/src/message.rs
+++ b/actix-http/src/message.rs
@@ -389,14 +389,6 @@ impl BoxedResponseHead {
     pub fn new(status: StatusCode) -> Self {
         RESPONSE_POOL.with(|p| p.get_message(status))
     }
-
-    // used in: impl Future for Response
-    #[allow(dead_code)]
-    pub(crate) fn take(&mut self) -> Self {
-        BoxedResponseHead {
-            head: self.head.take(),
-        }
-    }
 }
 
 impl std::ops::Deref for BoxedResponseHead {

--- a/actix-http/src/message.rs
+++ b/actix-http/src/message.rs
@@ -293,14 +293,14 @@ impl ResponseHead {
         }
     }
 
-    #[inline]
     /// Check if keep-alive is enabled
+    #[inline]
     pub fn keep_alive(&self) -> bool {
         self.connection_type() == ConnectionType::KeepAlive
     }
 
-    #[inline]
     /// Check upgrade status of this message
+    #[inline]
     pub fn upgrade(&self) -> bool {
         self.connection_type() == ConnectionType::Upgrade
     }

--- a/actix-http/src/message.rs
+++ b/actix-http/src/message.rs
@@ -389,6 +389,14 @@ impl BoxedResponseHead {
     pub fn new(status: StatusCode) -> Self {
         RESPONSE_POOL.with(|p| p.get_message(status))
     }
+
+    // used in: impl Future for Response
+    #[allow(dead_code)]
+    pub(crate) fn take(&mut self) -> Self {
+        BoxedResponseHead {
+            head: self.head.take(),
+        }
+    }
 }
 
 impl std::ops::Deref for BoxedResponseHead {

--- a/actix-http/src/message.rs
+++ b/actix-http/src/message.rs
@@ -389,12 +389,6 @@ impl BoxedResponseHead {
     pub fn new(status: StatusCode) -> Self {
         RESPONSE_POOL.with(|p| p.get_message(status))
     }
-
-    pub(crate) fn take(&mut self) -> Self {
-        BoxedResponseHead {
-            head: self.head.take(),
-        }
-    }
 }
 
 impl std::ops::Deref for BoxedResponseHead {

--- a/actix-http/src/response.rs
+++ b/actix-http/src/response.rs
@@ -92,25 +92,25 @@ impl<B> Response<B> {
         }
     }
 
-    /// Return a reference to the head of this response.
+    /// Returns a reference to the head of this response.
     #[inline]
     pub fn head(&self) -> &ResponseHead {
         &*self.head
     }
 
-    /// Return a mutable reference to the head of this response.
+    /// Returns a mutable reference to the head of this response.
     #[inline]
     pub fn head_mut(&mut self) -> &mut ResponseHead {
         &mut *self.head
     }
 
-    /// Return the source `error` for this response, if one is set.
+    /// Returns the source `error` for this response, if one is set.
     #[inline]
     pub fn error(&self) -> Option<&Error> {
         self.error.as_ref()
     }
 
-    /// Return the status code of this response.
+    /// Returns the status code of this response.
     #[inline]
     pub fn status(&self) -> StatusCode {
         self.head.status

--- a/actix-http/src/response.rs
+++ b/actix-http/src/response.rs
@@ -19,22 +19,22 @@ use crate::{
 /// An HTTP response.
 pub struct Response<B> {
     pub(crate) head: BoxedResponseHead,
-    pub(crate) body: Option<B>,
+    pub(crate) body: B,
     pub(crate) error: Option<Error>,
 }
 
 impl Response<Body> {
-    /// Constructs a response
+    /// Constructs a new response with default body.
     #[inline]
     pub fn new(status: StatusCode) -> Response<Body> {
         Response {
             head: BoxedResponseHead::new(status),
-            body: Some(Body::Empty),
+            body: Body::Empty,
             error: None,
         }
     }
 
-    /// Create HTTP response builder with specific status.
+    /// Constructs a new response builder.
     #[inline]
     pub fn build(status: StatusCode) -> ResponseBuilder {
         ResponseBuilder::new(status)
@@ -43,25 +43,25 @@ impl Response<Body> {
     // just a couple frequently used shortcuts
     // this list should not grow larger than a few
 
-    /// Creates a new response with status 200 OK.
+    /// Constructs a new response with status 200 OK.
     #[inline]
     pub fn ok() -> Response<Body> {
         Response::new(StatusCode::OK)
     }
 
-    /// Creates a new response with status 400 Bad Request.
+    /// Constructs a new response with status 400 Bad Request.
     #[inline]
     pub fn bad_request() -> Response<Body> {
         Response::new(StatusCode::BAD_REQUEST)
     }
 
-    /// Creates a new response with status 404 Not Found.
+    /// Constructs a new response with status 404 Not Found.
     #[inline]
     pub fn not_found() -> Response<Body> {
         Response::new(StatusCode::NOT_FOUND)
     }
 
-    /// Creates a new response with status 500 Internal Server Error.
+    /// Constructs a new response with status 500 Internal Server Error.
     #[inline]
     pub fn internal_server_error() -> Response<Body> {
         Response::new(StatusCode::INTERNAL_SERVER_ERROR)
@@ -69,7 +69,7 @@ impl Response<Body> {
 
     // end shortcuts
 
-    /// Constructs an error response
+    /// Constructs a new response from an error.
     #[inline]
     pub fn from_error(error: Error) -> Response<Body> {
         let mut resp = error.as_response_error().error_response();
@@ -82,146 +82,139 @@ impl Response<Body> {
 }
 
 impl<B> Response<B> {
-    /// Constructs a response with body
+    /// Constructs a new response with given body.
     #[inline]
     pub fn with_body(status: StatusCode, body: B) -> Response<B> {
         Response {
             head: BoxedResponseHead::new(status),
-            body: Some(body),
+            body: body,
             error: None,
         }
     }
 
+    /// Return a reference to the head of this response.
     #[inline]
-    /// Http message part of the response
     pub fn head(&self) -> &ResponseHead {
         &*self.head
     }
 
+    /// Return a mutable reference to the head of this response.
     #[inline]
-    /// Mutable reference to a HTTP message part of the response
     pub fn head_mut(&mut self) -> &mut ResponseHead {
         &mut *self.head
     }
 
-    /// The source `error` for this response
+    /// Return the source `error` for this response, if one is set.
     #[inline]
     pub fn error(&self) -> Option<&Error> {
         self.error.as_ref()
     }
 
-    /// Get the response status code
+    /// Return the status code of this response.
     #[inline]
     pub fn status(&self) -> StatusCode {
         self.head.status
     }
 
-    /// Set the `StatusCode` for this response
+    /// Returns a mutable reference the status code of this response.
     #[inline]
     pub fn status_mut(&mut self) -> &mut StatusCode {
         &mut self.head.status
     }
 
-    /// Get the headers from the response
+    /// Returns a reference to response headers.
     #[inline]
     pub fn headers(&self) -> &HeaderMap {
         &self.head.headers
     }
 
-    /// Get a mutable reference to the headers
+    /// Returns a mutable reference to response headers.
     #[inline]
     pub fn headers_mut(&mut self) -> &mut HeaderMap {
         &mut self.head.headers
     }
 
-    /// Connection upgrade status
+    /// Returns true if connection upgrade is enabled.
     #[inline]
     pub fn upgrade(&self) -> bool {
         self.head.upgrade()
     }
 
-    /// Keep-alive status for this connection
+    /// Returns true if keep-alive is enabled.
     pub fn keep_alive(&self) -> bool {
         self.head.keep_alive()
     }
 
-    /// Responses extensions
+    /// Returns a reference to the extensions of this response.
     #[inline]
     pub fn extensions(&self) -> Ref<'_, Extensions> {
         self.head.extensions.borrow()
     }
 
-    /// Mutable reference to a the response's extensions
+    /// Returns a mutable reference to the extensions of this response.
     #[inline]
     pub fn extensions_mut(&mut self) -> RefMut<'_, Extensions> {
         self.head.extensions.borrow_mut()
     }
 
-    /// Get body of this response
+    /// Returns a reference to the body of this response.
     #[inline]
     pub fn body(&self) -> &B {
-        self.body.as_ref().unwrap()
+        &self.body
     }
 
-    /// Set a body
+    /// Sets new body.
     pub fn set_body<B2>(self, body: B2) -> Response<B2> {
         Response {
             head: self.head,
-            body: Some(body),
+            body,
             error: None,
         }
     }
 
-    /// Split response and body
-    pub fn into_parts(self) -> (Response<()>, B) {
-        (
-            Response {
-                head: self.head,
-                body: Some(()),
-                error: self.error,
-            },
-            self.body.unwrap(),
-        )
-    }
-
-    /// Drop request's body
+    /// Drops body and returns new response.
     pub fn drop_body(self) -> Response<()> {
-        Response {
-            head: self.head,
-            body: Some(()),
-            error: None,
-        }
+        self.set_body(())
     }
 
-    /// Set a body and return previous body value
+    /// Sets new body, returning new response and previous body value.
     pub(crate) fn replace_body<B2>(self, body: B2) -> (Response<B2>, B) {
         (
             Response {
                 head: self.head,
-                body: Some(body),
+                body,
                 error: self.error,
             },
-            self.body.unwrap(),
+            self.body,
         )
     }
 
-    /// Set a body and return previous body value
+    /// Returns split head and body.
+    ///
+    /// # Implementation Notes
+    /// Due to internal performance optimisations, the first element of the returned tuple is a
+    /// `Response` as well but only contains the head of the response this was called on.
+    pub fn into_parts(self) -> (Response<()>, B) {
+        self.replace_body(())
+    }
+
+    /// Returns new response with mapped body.
     pub fn map_body<F, B2>(mut self, f: F) -> Response<B2>
     where
         F: FnOnce(&mut ResponseHead, B) -> B2,
     {
-        let body = f(&mut self.head, self.body.unwrap());
+        let body = f(&mut self.head, self.body);
 
         Response {
             head: self.head,
-            body: Some(body),
+            body,
             error: self.error,
         }
     }
 
-    /// Extract response body
+    /// Returns body, consuming this response.
     pub fn into_body(self) -> B {
-        self.body.unwrap()
+        self.body
     }
 }
 
@@ -242,7 +235,7 @@ where
         for (key, val) in self.head.headers.iter() {
             let _ = writeln!(f, "    {:?}: {:?}", key, val);
         }
-        let _ = writeln!(f, "  body: {:?}", self.body.as_ref().unwrap().size());
+        let _ = writeln!(f, "  body: {:?}", self.body.size());
         res
     }
 }
@@ -254,31 +247,6 @@ impl<B: Default> Default for Response<B> {
     }
 }
 
-mod fut {
-    use std::{
-        convert::Infallible,
-        future::Future,
-        pin::Pin,
-        task::{Context, Poll},
-    };
-
-    use super::*;
-
-    // TODO: document why this is needed
-    impl<B: Unpin> Future for Response<B> {
-        type Output = Result<Response<B>, Infallible>;
-
-        fn poll(mut self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Self::Output> {
-            Poll::Ready(Ok(Response {
-                head: self.head.take(),
-                body: self.body.take(),
-                error: self.error.take(),
-            }))
-        }
-    }
-}
-
-/// Helper converters
 impl<I: Into<Response<Body>>, E: Into<Error>> From<Result<I, E>> for Response<Body> {
     fn from(res: Result<I, E>) -> Self {
         match res {

--- a/actix-http/src/response.rs
+++ b/actix-http/src/response.rs
@@ -219,11 +219,6 @@ impl<B> Response<B> {
         }
     }
 
-    // /// Extract response body
-    // pub fn take_body(&mut self) -> ResponseBody<B> {
-    //     self.body.take_body()
-    // }
-
     /// Extract response body
     pub fn into_body(self) -> B {
         self.body.unwrap()

--- a/actix-http/src/response_builder.rs
+++ b/actix-http/src/response_builder.rs
@@ -236,10 +236,8 @@ impl ResponseBuilder {
     /// This `ResponseBuilder` will be left in a useless state.
     #[inline]
     pub fn body<B: Into<Body>>(&mut self, body: B) -> Response<Body> {
-        match self.message_body(body.into()) {
-            Ok(res) => res,
-            Err(err) => Response::from_error(err),
-        }
+        self.message_body(body.into())
+            .unwrap_or_else(Response::from_error)
     }
 
     /// Generate response with a body.

--- a/actix-http/src/response_builder.rs
+++ b/actix-http/src/response_builder.rs
@@ -38,10 +38,11 @@ use crate::{
 ///     .body("1234");
 ///
 /// assert_eq!(res.status(), StatusCode::OK);
-/// assert_eq!(body::to_bytes(res.into_body()).await.unwrap(), &b"1234"[..]);
 ///
 /// assert!(res.headers().contains_key("server"));
 /// assert_eq!(res.headers().get_all("set-cookie").count(), 2);
+///
+/// assert_eq!(body::to_bytes(res.into_body()).await.unwrap(), &b"1234"[..]);
 /// # })
 /// ```
 pub struct ResponseBuilder {

--- a/actix-http/src/response_builder.rs
+++ b/actix-http/src/response_builder.rs
@@ -38,7 +38,7 @@ use crate::{
 ///     .body("1234");
 ///
 /// assert_eq!(res.status(), StatusCode::OK);
-/// assert_eq!(body::to_bytes(res.take_body()).await.unwrap(), &b"1234"[..]);
+/// assert_eq!(body::to_bytes(res.into_body()).await.unwrap(), &b"1234"[..]);
 ///
 /// assert!(res.headers().contains_key("server"));
 /// assert_eq!(res.headers().get_all("set-cookie").count(), 2);

--- a/actix-http/src/response_builder.rs
+++ b/actix-http/src/response_builder.rs
@@ -13,7 +13,7 @@ use bytes::Bytes;
 use futures_core::Stream;
 
 use crate::{
-    body::{Body, BodyStream, ResponseBody},
+    body::{Body, BodyStream},
     error::{Error, HttpError},
     header::{self, IntoHeaderPair, IntoHeaderValue},
     message::{BoxedResponseHead, ConnectionType, ResponseHead},
@@ -242,15 +242,16 @@ impl ResponseBuilder {
     ///
     /// This `ResponseBuilder` will be left in a useless state.
     pub fn message_body<B>(&mut self, body: B) -> Response<B> {
-        if let Some(e) = self.err.take() {
-            return Response::from(Error::from(e)).into_body();
-        }
+        // TODO: put error handling back somehow
+        // if let Some(e) = self.err.take() {
+        //     return Response::from(Error::from(e)).into_body();
+        // }
 
         let response = self.head.take().expect("cannot reuse response builder");
 
         Response {
             head: response,
-            body: ResponseBody::Body(body),
+            body,
             error: None,
         }
     }

--- a/actix-http/src/response_builder.rs
+++ b/actix-http/src/response_builder.rs
@@ -251,7 +251,7 @@ impl ResponseBuilder {
 
         Response {
             head: response,
-            body,
+            body: Some(body),
             error: None,
         }
     }

--- a/actix-http/src/response_builder.rs
+++ b/actix-http/src/response_builder.rs
@@ -254,7 +254,7 @@ impl ResponseBuilder {
 
         Ok(Response {
             head: response,
-            body: Some(body),
+            body,
             error: None,
         })
     }

--- a/actix-http/tests/test_ws.rs
+++ b/actix-http/tests/test_ws.rs
@@ -52,7 +52,7 @@ where
 
     fn call(&self, (req, mut framed): (Request, Framed<T, h1::Codec>)) -> Self::Future {
         let fut = async move {
-            let res = ws::handshake(req.head()).unwrap().message_body(());
+            let res = ws::handshake(req.head()).unwrap().message_body(()).unwrap();
 
             framed
                 .send((res, body::BodySize::None).into())

--- a/src/app_service.rs
+++ b/src/app_service.rs
@@ -166,8 +166,7 @@ impl AppInitServiceState {
         Rc::new(AppInitServiceState {
             rmap,
             config,
-            // TODO: AppConfig can be used to pass user defined HttpRequestPool
-            // capacity.
+            // TODO: AppConfig can be used to pass user defined HttpRequestPool capacity.
             pool: HttpRequestPool::default(),
         })
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,6 +9,11 @@ use url::ParseError as UrlParseError;
 
 use crate::http::StatusCode;
 
+/// A convenience [`Result`](std::result::Result) for Actix Web operations.
+///
+/// This type alias is generally used to avoid writing out `actix_http::Error` directly.
+pub type Result<T, E = actix_http::Error> = std::result::Result<T, E>;
+
 /// Errors which can occur when attempting to generate resource uri.
 #[derive(Debug, PartialEq, Display, Error, From)]
 #[non_exhaustive]
@@ -26,7 +31,6 @@ pub enum UrlGenerationError {
     ParseError(UrlParseError),
 }
 
-/// `InternalServerError` for `UrlGeneratorError`
 impl ResponseError for UrlGenerationError {}
 
 /// A set of errors that can occur during parsing urlencoded payloads
@@ -70,7 +74,6 @@ pub enum UrlencodedError {
     Payload(PayloadError),
 }
 
-/// Return `BadRequest` for `UrlencodedError`
 impl ResponseError for UrlencodedError {
     fn status_code(&self) -> StatusCode {
         match self {
@@ -149,7 +152,6 @@ pub enum QueryPayloadError {
     Deserialize(serde::de::value::Error),
 }
 
-/// Return `BadRequest` for `QueryPayloadError`
 impl ResponseError for QueryPayloadError {
     fn status_code(&self) -> StatusCode {
         StatusCode::BAD_REQUEST
@@ -177,7 +179,6 @@ pub enum ReadlinesError {
     ContentTypeError(ContentTypeError),
 }
 
-/// Return `BadRequest` for `ReadlinesError`
 impl ResponseError for ReadlinesError {
     fn status_code(&self) -> StatusCode {
         match *self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,7 @@ pub(crate) mod types;
 pub mod web;
 
 pub use actix_http::Response as BaseHttpResponse;
-pub use actix_http::{body, Error, HttpMessage, ResponseError, Result};
+pub use actix_http::{body, Error, HttpMessage, ResponseError};
 #[doc(inline)]
 pub use actix_rt as rt;
 pub use actix_web_codegen::*;
@@ -105,6 +105,7 @@ pub use actix_web_codegen::*;
 pub use cookie;
 
 pub use crate::app::App;
+pub use crate::error::Result;
 pub use crate::extract::FromRequest;
 pub use crate::request::HttpRequest;
 pub use crate::resource::Resource;

--- a/src/middleware/compat.rs
+++ b/src/middleware/compat.rs
@@ -1,12 +1,13 @@
 //! For middleware documentation, see [`Compat`].
 
 use std::{
+    error::Error as StdError,
     future::Future,
     pin::Pin,
     task::{Context, Poll},
 };
 
-use actix_http::body::{Body, MessageBody, ResponseBody};
+use actix_http::body::{Body, MessageBody};
 use actix_service::{Service, Transform};
 use futures_core::{future::LocalBoxFuture, ready};
 
@@ -116,10 +117,10 @@ pub trait MapServiceResponseBody {
 impl<B> MapServiceResponseBody for ServiceResponse<B>
 where
     B: MessageBody + Unpin + 'static,
-    B::Error: Into<Error>,
+    B::Error: Into<Box<dyn StdError + 'static>>,
 {
     fn map_body(self) -> ServiceResponse {
-        self.map_body(|_, body| ResponseBody::Other(Body::from_message(body)))
+        self.map_body(|_, body| Body::from_message(body))
     }
 }
 

--- a/src/responder.rs
+++ b/src/responder.rs
@@ -264,7 +264,7 @@ pub(crate) mod tests {
         let resp = srv.call(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
         match resp.response().body() {
-            ResponseBody::Body(Body::Bytes(ref b)) => {
+            Body::Bytes(ref b) => {
                 let bytes = b.clone();
                 assert_eq!(bytes, Bytes::from_static(b"some"));
             }
@@ -277,16 +277,28 @@ pub(crate) mod tests {
         fn body(&self) -> &Body;
     }
 
+    impl BodyTest for Body {
+        fn bin_ref(&self) -> &[u8] {
+            match self {
+                Body::Bytes(ref bin) => &bin,
+                _ => unreachable!("bug in test impl"),
+            }
+        }
+        fn body(&self) -> &Body {
+            self
+        }
+    }
+
     impl BodyTest for ResponseBody<Body> {
         fn bin_ref(&self) -> &[u8] {
             match self {
                 ResponseBody::Body(ref b) => match b {
                     Body::Bytes(ref bin) => &bin,
-                    _ => panic!(),
+                    _ => unreachable!("bug in test impl"),
                 },
                 ResponseBody::Other(ref b) => match b {
                     Body::Bytes(ref bin) => &bin,
-                    _ => panic!(),
+                    _ => unreachable!("bug in test impl"),
                 },
             }
         }

--- a/src/response/builder.rs
+++ b/src/response/builder.rs
@@ -318,9 +318,9 @@ impl HttpResponseBuilder {
     ///
     /// `HttpResponseBuilder` can not be used after this call.
     pub fn message_body<B>(&mut self, body: B) -> HttpResponse<B> {
-        if let Some(err) = self.err.take() {
-            return HttpResponse::from_error(Error::from(err)).into_body();
-        }
+        // if let Some(err) = self.err.take() {
+        //     return HttpResponse::from_error(Error::from(err)).into_body();
+        // }
 
         let res = self
             .res
@@ -336,7 +336,8 @@ impl HttpResponseBuilder {
             for cookie in jar.delta() {
                 match HeaderValue::from_str(&cookie.to_string()) {
                     Ok(val) => res.headers_mut().append(header::SET_COOKIE, val),
-                    Err(err) => return HttpResponse::from_error(Error::from(err)).into_body(),
+                    Err(err) => res.error = Some(err.into()),
+                    // Err(err) => return HttpResponse::from_error(Error::from(err)).into_body(),
                 };
             }
         }

--- a/src/response/builder.rs
+++ b/src/response/builder.rs
@@ -479,42 +479,42 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_json() {
-        let mut resp = HttpResponse::Ok().json(vec!["v1", "v2", "v3"]);
+        let resp = HttpResponse::Ok().json(vec!["v1", "v2", "v3"]);
         let ct = resp.headers().get(CONTENT_TYPE).unwrap();
         assert_eq!(ct, HeaderValue::from_static("application/json"));
         assert_eq!(
-            body::to_bytes(resp.take_body()).await.unwrap().as_ref(),
+            body::to_bytes(resp.into_body()).await.unwrap().as_ref(),
             br#"["v1","v2","v3"]"#
         );
 
-        let mut resp = HttpResponse::Ok().json(&["v1", "v2", "v3"]);
+        let resp = HttpResponse::Ok().json(&["v1", "v2", "v3"]);
         let ct = resp.headers().get(CONTENT_TYPE).unwrap();
         assert_eq!(ct, HeaderValue::from_static("application/json"));
         assert_eq!(
-            body::to_bytes(resp.take_body()).await.unwrap().as_ref(),
+            body::to_bytes(resp.into_body()).await.unwrap().as_ref(),
             br#"["v1","v2","v3"]"#
         );
 
         // content type override
-        let mut resp = HttpResponse::Ok()
+        let resp = HttpResponse::Ok()
             .insert_header((CONTENT_TYPE, "text/json"))
             .json(&vec!["v1", "v2", "v3"]);
         let ct = resp.headers().get(CONTENT_TYPE).unwrap();
         assert_eq!(ct, HeaderValue::from_static("text/json"));
         assert_eq!(
-            body::to_bytes(resp.take_body()).await.unwrap().as_ref(),
+            body::to_bytes(resp.into_body()).await.unwrap().as_ref(),
             br#"["v1","v2","v3"]"#
         );
     }
 
     #[actix_rt::test]
     async fn test_serde_json_in_body() {
-        let mut resp = HttpResponse::Ok().body(
+        let resp = HttpResponse::Ok().body(
             serde_json::to_vec(&serde_json::json!({ "test-key": "test-value" })).unwrap(),
         );
 
         assert_eq!(
-            body::to_bytes(resp.take_body()).await.unwrap().as_ref(),
+            body::to_bytes(resp.into_body()).await.unwrap().as_ref(),
             br#"{"test-key":"test-value"}"#
         );
     }

--- a/src/response/response.rs
+++ b/src/response/response.rs
@@ -229,11 +229,6 @@ impl<B> HttpResponse<B> {
         }
     }
 
-    // /// Extract response body
-    // pub fn take_body(&mut self) -> ResponseBody<B> {
-    //     self.res.take_body()
-    // }
-
     /// Extract response body
     pub fn into_body(self) -> B {
         self.res.into_body()

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -578,7 +578,7 @@ mod tests {
     use actix_utils::future::ok;
     use bytes::Bytes;
 
-    use crate::dev::{Body, ResponseBody};
+    use crate::dev::{Body};
     use crate::http::{header, HeaderValue, Method, StatusCode};
     use crate::middleware::DefaultHeaders;
     use crate::service::ServiceRequest;
@@ -748,7 +748,7 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::OK);
 
         match resp.response().body() {
-            ResponseBody::Body(Body::Bytes(ref b)) => {
+            Body::Bytes(ref b) => {
                 let bytes = b.clone();
                 assert_eq!(bytes, Bytes::from_static(b"project: project1"));
             }
@@ -849,7 +849,7 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::CREATED);
 
         match resp.response().body() {
-            ResponseBody::Body(Body::Bytes(ref b)) => {
+            Body::Bytes(ref b) => {
                 let bytes = b.clone();
                 assert_eq!(bytes, Bytes::from_static(b"project: project_1"));
             }
@@ -877,7 +877,7 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::CREATED);
 
         match resp.response().body() {
-            ResponseBody::Body(Body::Bytes(ref b)) => {
+            Body::Bytes(ref b) => {
                 let bytes = b.clone();
                 assert_eq!(bytes, Bytes::from_static(b"project: test - 1"));
             }

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -578,7 +578,7 @@ mod tests {
     use actix_utils::future::ok;
     use bytes::Bytes;
 
-    use crate::dev::{Body};
+    use crate::dev::Body;
     use crate::http::{header, HeaderValue, Method, StatusCode};
     use crate::middleware::DefaultHeaders;
     use crate::service::ServiceRequest;

--- a/src/service.rs
+++ b/src/service.rs
@@ -413,11 +413,6 @@ impl<B> ServiceResponse<B> {
         }
     }
 
-    // /// Extract response body
-    // pub fn take_body(&mut self) -> ResponseBody<B> {
-    //     self.response.take_body()
-    // }
-
     /// Extract response body
     pub fn into_body(self) -> B {
         self.response.into_body()

--- a/src/service.rs
+++ b/src/service.rs
@@ -403,14 +403,8 @@ impl<B> ServiceResponse<B> {
         F: FnOnce(&mut Self) -> Result<(), E>,
         E: Into<Error>,
     {
-        match f(&mut self) {
-            Ok(_) => Ok(self),
-            Err(err) => {
-                Err(err.into())
-                // let res = HttpResponse::from_error(err.into());
-                // ServiceResponse::new(self.request, res.into_body())
-            }
-        }
+        f(&mut self).map_err(Into::into)?;
+        Ok(self)
     }
 
     /// Extract response body

--- a/src/service.rs
+++ b/src/service.rs
@@ -2,7 +2,7 @@ use std::cell::{Ref, RefMut};
 use std::rc::Rc;
 use std::{fmt, net};
 
-use actix_http::body::{Body, MessageBody, ResponseBody};
+use actix_http::body::{Body, MessageBody};
 use actix_http::http::{HeaderMap, Method, StatusCode, Uri, Version};
 use actix_http::{
     Error, Extensions, HttpMessage, Payload, PayloadStream, RequestHead, Response, ResponseHead,
@@ -110,9 +110,9 @@ impl ServiceRequest {
 
     /// Create service response for error
     #[inline]
-    pub fn error_response<B, E: Into<Error>>(self, err: E) -> ServiceResponse<B> {
+    pub fn error_response<E: Into<Error>>(self, err: E) -> ServiceResponse {
         let res = HttpResponse::from_error(err.into());
-        ServiceResponse::new(self.req, res.into_body())
+        ServiceResponse::new(self.req, res)
     }
 
     /// This method returns reference to the request head
@@ -335,22 +335,24 @@ pub struct ServiceResponse<B = Body> {
     response: HttpResponse<B>,
 }
 
+impl ServiceResponse<Body> {
+    /// Create service response from the error
+    pub fn from_err<E: Into<Error>>(err: E, request: HttpRequest) -> Self {
+        let response = HttpResponse::from_error(err.into());
+        ServiceResponse { request, response }
+    }
+}
+
 impl<B> ServiceResponse<B> {
     /// Create service response instance
     pub fn new(request: HttpRequest, response: HttpResponse<B>) -> Self {
         ServiceResponse { request, response }
     }
 
-    /// Create service response from the error
-    pub fn from_err<E: Into<Error>>(err: E, request: HttpRequest) -> Self {
-        let response = HttpResponse::from_error(err.into()).into_body();
-        ServiceResponse { request, response }
-    }
-
     /// Create service response for error
     #[inline]
-    pub fn error_response<E: Into<Error>>(self, err: E) -> Self {
-        Self::from_err(err, self.request)
+    pub fn error_response<E: Into<Error>>(self, err: E) -> ServiceResponse {
+        ServiceResponse::from_err(err, self.request)
     }
 
     /// Create service response
@@ -396,23 +398,29 @@ impl<B> ServiceResponse<B> {
     }
 
     /// Execute closure and in case of error convert it to response.
-    pub fn checked_expr<F, E>(mut self, f: F) -> Self
+    pub fn checked_expr<F, E>(mut self, f: F) -> Result<Self, Error>
     where
         F: FnOnce(&mut Self) -> Result<(), E>,
         E: Into<Error>,
     {
         match f(&mut self) {
-            Ok(_) => self,
+            Ok(_) => Ok(self),
             Err(err) => {
-                let res = HttpResponse::from_error(err.into());
-                ServiceResponse::new(self.request, res.into_body())
+                Err(err.into())
+                // let res = HttpResponse::from_error(err.into());
+                // ServiceResponse::new(self.request, res.into_body())
             }
         }
     }
 
+    // /// Extract response body
+    // pub fn take_body(&mut self) -> ResponseBody<B> {
+    //     self.response.take_body()
+    // }
+
     /// Extract response body
-    pub fn take_body(&mut self) -> ResponseBody<B> {
-        self.response.take_body()
+    pub fn into_body(self) -> B {
+        self.response.into_body()
     }
 }
 
@@ -420,7 +428,7 @@ impl<B> ServiceResponse<B> {
     /// Set a new body
     pub fn map_body<F, B2>(self, f: F) -> ServiceResponse<B2>
     where
-        F: FnOnce(&mut ResponseHead, ResponseBody<B>) -> ResponseBody<B2>,
+        F: FnOnce(&mut ResponseHead, B) -> B2,
     {
         let response = self.response.map_body(f);
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -6,7 +6,7 @@ pub use actix_http::test::TestBuffer;
 use actix_http::{
     http::{header::IntoHeaderPair, Method, StatusCode, Uri, Version},
     test::TestRequest as HttpTestRequest,
-    Extensions, Request,
+    Extensions, Request, body
 };
 use actix_router::{Path, ResourceDef, Url};
 use actix_service::{IntoService, IntoServiceFactory, Service, ServiceFactory};
@@ -273,6 +273,14 @@ where
         data.extend_from_slice(&item?);
     }
     Ok(data.freeze())
+}
+
+pub async fn load_body<B>(body: B) -> Result<Bytes, Error>
+where
+    B: MessageBody + Unpin,
+    B::Error: Into<Error>,
+{
+    body::to_bytes(body).await.map_err(Into::into)
 }
 
 /// Helper function that returns a deserialized response body of a TestRequest

--- a/src/test.rs
+++ b/src/test.rs
@@ -4,9 +4,10 @@ use std::{net::SocketAddr, rc::Rc};
 
 pub use actix_http::test::TestBuffer;
 use actix_http::{
+    body,
     http::{header::IntoHeaderPair, Method, StatusCode, Uri, Version},
     test::TestRequest as HttpTestRequest,
-    Extensions, Request, body
+    Extensions, Request,
 };
 use actix_router::{Path, ResourceDef, Url};
 use actix_service::{IntoService, IntoServiceFactory, Service, ServiceFactory};

--- a/src/types/json.rs
+++ b/src/types/json.rs
@@ -435,7 +435,7 @@ mod tests {
             header::{self, CONTENT_LENGTH, CONTENT_TYPE},
             StatusCode,
         },
-        test::{load_stream, TestRequest},
+        test::{load_body, TestRequest},
     };
 
     #[derive(Serialize, Deserialize, PartialEq, Debug)]
@@ -492,10 +492,10 @@ mod tests {
             .to_http_parts();
 
         let s = Json::<MyObject>::from_request(&req, &mut pl).await;
-        let mut resp = HttpResponse::from_error(s.err().unwrap());
+        let resp = HttpResponse::from_error(s.err().unwrap());
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
 
-        let body = load_stream(resp.take_body()).await.unwrap();
+        let body = load_body(resp.into_body()).await.unwrap();
         let msg: MyObject = serde_json::from_slice(&body).unwrap();
         assert_eq!(msg.name, "invalid request");
     }

--- a/tests/test_server.rs
+++ b/tests/test_server.rs
@@ -901,7 +901,7 @@ async fn test_normalize() {
     let srv = actix_test::start_with(actix_test::config().h1(), || {
         App::new()
             .wrap(NormalizePath::new(TrailingSlash::Trim))
-            .service(web::resource("/one").route(web::to(|| HttpResponse::Ok().finish())))
+            .service(web::resource("/one").route(web::to(|| HttpResponse::Ok())))
     });
 
     let response = srv.get("/one/").send().await.unwrap();

--- a/tests/test_server.rs
+++ b/tests/test_server.rs
@@ -32,7 +32,7 @@ use rand::{distributions::Alphanumeric, Rng};
 
 use actix_web::dev::BodyEncoding;
 use actix_web::middleware::{Compress, NormalizePath, TrailingSlash};
-use actix_web::{dev, web, App, Error, HttpResponse};
+use actix_web::{web, App, Error, HttpResponse};
 
 const STR: &str = "Hello World Hello World Hello World Hello World Hello World \
                    Hello World Hello World Hello World Hello World Hello World \
@@ -160,9 +160,7 @@ async fn test_body_gzip2() {
     let srv = actix_test::start_with(actix_test::config().h1(), || {
         App::new()
             .wrap(Compress::new(ContentEncoding::Gzip))
-            .service(web::resource("/").route(web::to(|| {
-                HttpResponse::Ok().body(STR).into_body::<dev::Body>()
-            })))
+            .service(web::resource("/").route(web::to(|| HttpResponse::Ok().body(STR))))
     });
 
     let mut response = srv


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Refactor


## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
The `ResponseBody` abstraction is a kind of annoying way to get around the problem of `B` vs `Body` in dispatcher-land as well as in fallible functions. This PR attempts to remove this indirection by providing different paths for error responses and hopefully provides a more ergonomic interface especially in the area of `map_body`.

## Further Work
- Remove ResponseBody from encoding mod.
- I suspect some issues would surface in user code due to removing the old `into_body` method(s) but I have an idea for it. (We might see it occur in -extras.)
