### PR TITLE
files: Fix `redirect_to_slash_directory()` when used with `show_files_listing()`

### DIFF
--- a/actix-files/CHANGES.md
+++ b/actix-files/CHANGES.md
@@ -3,9 +3,11 @@
 ## Unreleased - 2021-xx-xx
 * `NamedFile` now implements `ServiceFactory` and `HttpServiceFactory` making it much more useful in routing. For example, it can be used directly as a default service. [#2135]
 * For symbolic links, `Content-Disposition` header no longer shows the filename of the original file. [#2156]
+* `Files::redirect_to_slash_directory()` now works as expected when used with `Files::show_files_listing()`. [#2225]
 
 [#2135]: https://github.com/actix/actix-web/pull/2135
 [#2156]: https://github.com/actix/actix-web/pull/2156
+[#2225]: https://github.com/actix/actix-web/pull/2225
 
 
 ## 0.6.0-beta.4 - 2021-04-02

--- a/actix-files/src/lib.rs
+++ b/actix-files/src/lib.rs
@@ -632,7 +632,7 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_redirect_to_slash_directory() {
-        // should not redirect if no index
+        // should not redirect if no index and files listing is disabled
         let srv = test::init_service(
             App::new().service(Files::new("/", ".").redirect_to_slash_directory()),
         )
@@ -646,6 +646,19 @@ mod tests {
             App::new().service(
                 Files::new("/", ".")
                     .index_file("test.png")
+                    .redirect_to_slash_directory(),
+            ),
+        )
+        .await;
+        let req = TestRequest::with_uri("/tests").to_request();
+        let resp = test::call_service(&srv, req).await;
+        assert_eq!(resp.status(), StatusCode::FOUND);
+
+        // should redirect if files listing is enabled
+        let srv = test::init_service(
+            App::new().service(
+                Files::new("/", ".")
+                    .show_files_listing()
                     .redirect_to_slash_directory(),
             ),
         )

--- a/actix-files/src/service.rs
+++ b/actix-files/src/service.rs
@@ -89,17 +89,20 @@ impl Service<ServiceRequest> for FilesService {
         }
 
         if path.is_dir() {
+            if self.redirect_to_slash
+                && !req.path().ends_with('/')
+                && (self.index.is_some() || self.show_index)
+            {
+                let redirect_to = format!("{}/", req.path());
+
+                return Box::pin(ok(req.into_response(
+                    HttpResponse::Found()
+                        .insert_header((header::LOCATION, redirect_to))
+                        .finish(),
+                )));
+            }
+
             if let Some(ref redir_index) = self.index {
-                if self.redirect_to_slash && !req.path().ends_with('/') {
-                    let redirect_to = format!("{}/", req.path());
-
-                    return Box::pin(ok(req.into_response(
-                        HttpResponse::Found()
-                            .insert_header((header::LOCATION, redirect_to))
-                            .finish(),
-                    )));
-                }
-
                 let path = path.join(redir_index);
 
                 match NamedFile::open(path) {


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Bug fix


## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated (There is none for such change).
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
`Files::redirect_to_slash_directory()` currently redirects only when an index file is set with `.index_file(_)`. However, the rationale behind this feature (see #1134) is also valid when showing directory listings instead of index files. 

I considered this a bug because the current behavior is totally not expected according to the documents.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
