### PR TITLE
files: allow `show_files_listing()` with `index_file()`

### DIFF
--- a/actix-files/CHANGES.md
+++ b/actix-files/CHANGES.md
@@ -4,10 +4,12 @@
 * `NamedFile` now implements `ServiceFactory` and `HttpServiceFactory` making it much more useful in routing. For example, it can be used directly as a default service. [#2135]
 * For symbolic links, `Content-Disposition` header no longer shows the filename of the original file. [#2156]
 * `Files::redirect_to_slash_directory()` now works as expected when used with `Files::show_files_listing()`. [#2225]
+* `Files::show_files_listing()` can now be used with `Files::index_file()` to show files listing as a fallback when the index file is not found. [#2228]
 
 [#2135]: https://github.com/actix/actix-web/pull/2135
 [#2156]: https://github.com/actix/actix-web/pull/2156
 [#2225]: https://github.com/actix/actix-web/pull/2225
+[#2228]: https://github.com/actix/actix-web/pull/2228
 
 
 ## 0.6.0-beta.4 - 2021-04-02

--- a/actix-files/src/files.rs
+++ b/actix-files/src/files.rs
@@ -114,6 +114,9 @@ impl Files {
     /// Show files listing for directories.
     ///
     /// By default show files listing is disabled.
+    ///
+    /// When used with [`Files::index_file()`], files listing is shown as a fallback
+    /// when the index file is not found.
     pub fn show_files_listing(mut self) -> Self {
         self.show_index = true;
         self
@@ -148,8 +151,11 @@ impl Files {
 
     /// Set index file
     ///
-    /// Shows specific index file for directory "/" instead of
+    /// Shows specific index file for directories instead of
     /// showing files listing.
+    ///
+    /// If the index file is not found, files listing is shown as a fallback if
+    /// [`Files::show_files_listing()`] is set.
     pub fn index_file<T: Into<String>>(mut self, index: T) -> Self {
         self.index = Some(index.into());
         self

--- a/actix-files/src/service.rs
+++ b/actix-files/src/service.rs
@@ -129,6 +129,7 @@ impl Service<ServiceRequest> for FilesService {
             match self.index {
                 Some(ref index) => match NamedFile::open(path.join(index)) {
                     Ok(named_file) => serve_named_file(req, named_file),
+                    Err(_) if self.show_index => show_index(req),
                     Err(err) => self.handle_err(err, req),
                 },
                 None if self.show_index => show_index(req),

--- a/actix-files/src/service.rs
+++ b/actix-files/src/service.rs
@@ -102,26 +102,20 @@ impl Service<ServiceRequest> for FilesService {
                 )));
             }
 
-            if let Some(ref redir_index) = self.index {
-                let path = path.join(redir_index);
-
-                match NamedFile::open(path) {
-                    Ok(mut named_file) => {
-                        if let Some(ref mime_override) = self.mime_override {
-                            let new_disposition =
-                                mime_override(&named_file.content_type.type_());
-                            named_file.content_disposition.disposition = new_disposition;
-                        }
-                        named_file.flags = self.file_flags;
-
-                        let (req, _) = req.into_parts();
-                        let res = named_file.into_response(&req);
-                        Box::pin(ok(ServiceResponse::new(req, res)))
-                    }
-                    Err(err) => self.handle_err(err, req),
+            let serve_named_file = |req: ServiceRequest, mut named_file: NamedFile| {
+                if let Some(ref mime_override) = self.mime_override {
+                    let new_disposition = mime_override(&named_file.content_type.type_());
+                    named_file.content_disposition.disposition = new_disposition;
                 }
-            } else if self.show_index {
-                let dir = Directory::new(self.directory.clone(), path);
+                named_file.flags = self.file_flags;
+
+                let (req, _) = req.into_parts();
+                let res = named_file.into_response(&req);
+                Box::pin(ok(ServiceResponse::new(req, res)))
+            };
+
+            let show_index = |req: ServiceRequest| {
+                let dir = Directory::new(self.directory.clone(), path.clone());
 
                 let (req, _) = req.into_parts();
                 let x = (self.renderer)(&dir, &req);
@@ -130,11 +124,18 @@ impl Service<ServiceRequest> for FilesService {
                     Ok(resp) => ok(resp),
                     Err(err) => ok(ServiceResponse::from_err(err, req)),
                 })
-            } else {
-                Box::pin(ok(ServiceResponse::from_err(
+            };
+
+            match self.index {
+                Some(ref index) => match NamedFile::open(path.join(index)) {
+                    Ok(named_file) => serve_named_file(req, named_file),
+                    Err(err) => self.handle_err(err, req),
+                },
+                None if self.show_index => show_index(req),
+                _ => Box::pin(ok(ServiceResponse::from_err(
                     FilesError::IsDirectory,
                     req.into_parts().0,
-                )))
+                ))),
             }
         } else {
             match NamedFile::open(path) {


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Feature


## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Currently, `Files::show_files_listing()` has no effect when `index_file(_)` is set - if the index file is not found, an error response is always returned regardless. 

This PR changes this behavior to allow showing file listing when an index file is not found

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
