### PR TITLE
Select compression algorithm using features flags

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ## Unreleased - 2021-xx-xx
 
+### Changed
+
+* Change compression algorithm features flags. [#2250]
+
+[#2250]: https://github.com/actix/actix-web/pull/2250
 
 ## 4.0.0-beta.7 - 2021-06-17
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2018"
 
 [package.metadata.docs.rs]
 # features that docs.rs will build with
-features = ["openssl", "rustls", "compress", "cookies", "secure-cookies"]
+features = ["openssl", "rustls", "compress-brotli", "compress-gzip", "compress-zstd", "cookies", "secure-cookies"]
 
 [lib]
 name = "actix_web"
@@ -39,10 +39,14 @@ members = [
 # resolver = "2"
 
 [features]
-default = ["compress", "cookies"]
+default = ["compress-brotli", "compress-gzip", "compress-zstd", "cookies"]
 
-# content-encoding support
-compress = ["actix-http/compress"]
+# Brotli algorithm content-encoding support
+compress-brotli = ["actix-http/compress-brotli", "__compress"]
+# Gzip and deflate algorithms content-encoding support
+compress-gzip = ["actix-http/compress-gzip", "__compress"]
+# Zstd algorithm content-encoding support
+compress-zstd = ["actix-http/compress-zstd", "__compress"]
 
 # support for cookies
 cookies = ["cookie"]
@@ -55,6 +59,10 @@ openssl = ["actix-http/openssl", "actix-tls/accept", "actix-tls/openssl"]
 
 # rustls
 rustls = ["actix-http/rustls", "actix-tls/accept", "actix-tls/rustls"]
+
+# Internal (PRIVATE!) features used to aid testing and cheking feature status.
+# Don't rely on these whatsoever. They may disappear at anytime.
+__compress = []
 
 [dependencies]
 actix-codec = "0.4.0"
@@ -71,6 +79,7 @@ actix-http = "3.0.0-beta.7"
 
 ahash = "0.7"
 bytes = "1"
+cfg-if = "1"
 cookie = { version = "0.15", features = ["percent-encode"], optional = true }
 derive_more = "0.99.5"
 either = "1.5.3"
@@ -126,15 +135,15 @@ awc = { path = "awc" }
 
 [[test]]
 name = "test_server"
-required-features = ["compress", "cookies"]
+required-features = ["compress-brotli", "compress-gzip", "compress-zstd", "cookies"]
 
 [[example]]
 name = "basic"
-required-features = ["compress"]
+required-features = ["compress-gzip"]
 
 [[example]]
 name = "uds"
-required-features = ["compress"]
+required-features = ["compress-gzip"]
 
 [[example]]
 name = "on_connect"

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -10,6 +10,18 @@
 
   Alternatively, explicitly require trailing slashes: `NormalizePath::new(TrailingSlash::Always)`.
 
+* Feature flag `compress` has been split into its supported algorithm (brotli, gzip, zstd).
+  By default all compression algorithms are enabled.
+  To select algorithm you want to include with `middleware::Compress` use following flags:
+  - `compress-brotli`
+  - `compress-gzip`
+  - `compress-zstd`
+  If you have set in your `Cargo.toml` dedicated `actix-web` features and you still want
+  to have compression enabled. Please change features selection like bellow:
+
+  Before: `"compress"`
+  After: `"compress-brotli", "compress-gzip", "compress-zstd"`
+
 
 ## 3.0.0
 

--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -2,6 +2,11 @@
 
 ## Unreleased - 2021-xx-xx
 
+### Changed
+
+* Change compression algorithm features flags. [#2250]
+
+[#2250]: https://github.com/actix/actix-web/pull/2250
 
 ## 3.0.0-beta.7 - 2021-06-17
 ### Added

--- a/actix-http/Cargo.toml
+++ b/actix-http/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 
 [package.metadata.docs.rs]
 # features that docs.rs will build with
-features = ["openssl", "rustls", "compress"]
+features = ["openssl", "rustls", "compress-brotli", "compress-gzip", "compress-zstd"]
 
 [lib]
 name = "actix_http"
@@ -32,10 +32,16 @@ openssl = ["actix-tls/openssl"]
 rustls = ["actix-tls/rustls"]
 
 # enable compression support
-compress = ["flate2", "brotli2", "zstd"]
+compress-brotli = ["brotli2", "__compress"]
+compress-gzip = ["flate2", "__compress"]
+compress-zstd = ["zstd", "__compress"]
 
 # trust-dns as client dns resolver
 trust-dns = ["trust-dns-resolver"]
+
+# Internal (PRIVATE!) features used to aid testing and cheking feature status.
+# Don't rely on these whatsoever. They may disappear at anytime.
+__compress = []
 
 [dependencies]
 actix-service = "2.0.0"

--- a/actix-http/src/lib.rs
+++ b/actix-http/src/lib.rs
@@ -1,12 +1,14 @@
 //! HTTP primitives for the Actix ecosystem.
 //!
 //! ## Crate Features
-//! | Feature          | Functionality                                         |
-//! | ---------------- | ----------------------------------------------------- |
-//! | `openssl`        | TLS support via [OpenSSL].                            |
-//! | `rustls`         | TLS support via [rustls].                             |
-//! | `compress`       | Payload compression support. (Deflate, Gzip & Brotli) |
-//! | `trust-dns`      | Use [trust-dns] as the client DNS resolver.           |
+//! | Feature             | Functionality                               |
+//! | ------------------- | ------------------------------------------- |
+//! | `openssl`           | TLS support via [OpenSSL].                  |
+//! | `rustls`            | TLS support via [rustls].                   |
+//! | `compress-brotli`   | Payload compression support: Brotli.        |
+//! | `compress-gzip`     | Payload compression support: Deflate, Gzip. |
+//! | `compress-zstd`     | Payload compression support: Zstd.          |
+//! | `trust-dns`         | Use [trust-dns] as the client DNS resolver. |
 //!
 //! [OpenSSL]: https://crates.io/crates/openssl
 //! [rustls]: https://crates.io/crates/rustls
@@ -32,7 +34,8 @@ pub mod body;
 mod builder;
 pub mod client;
 mod config;
-#[cfg(feature = "compress")]
+
+#[cfg(feature = "__compress")]
 pub mod encoding;
 mod extensions;
 pub mod header;

--- a/awc/CHANGES.md
+++ b/awc/CHANGES.md
@@ -2,10 +2,14 @@
 
 ## Unreleased - 2021-xx-xx
 
+### Changed
+
+* Change compression algorithm features flags. [#2250]
+
+[#2250]: https://github.com/actix/actix-web/pull/2250
 
 ## 3.0.0-beta.6 - 2021-06-17
 * No significant changes since 3.0.0-beta.5.
-
 
 ## 3.0.0-beta.5 - 2021-04-17
 ### Removed

--- a/awc/Cargo.toml
+++ b/awc/Cargo.toml
@@ -24,10 +24,10 @@ path = "src/lib.rs"
 
 [package.metadata.docs.rs]
 # features that docs.rs will build with
-features = ["openssl", "rustls", "compress", "cookies"]
+features = ["openssl", "rustls", "compress-brotli", "compress-gzip", "compress-zstd", "cookies"]
 
 [features]
-default = ["compress", "cookies"]
+default = ["compress-brotli", "compress-gzip", "compress-zstd", "cookies"]
 
 # openssl
 openssl = ["tls-openssl", "actix-http/openssl"]
@@ -35,14 +35,22 @@ openssl = ["tls-openssl", "actix-http/openssl"]
 # rustls
 rustls = ["tls-rustls", "actix-http/rustls"]
 
-# content-encoding support
-compress = ["actix-http/compress"]
+# Brotli algorithm content-encoding support
+compress-brotli = ["actix-http/compress-brotli", "__compress"]
+# Gzip and deflate algorithms content-encoding support
+compress-gzip = ["actix-http/compress-gzip", "__compress"]
+# Zstd algorithm content-encoding support
+compress-zstd = ["actix-http/compress-zstd", "__compress"]
 
 # cookie parsing and cookie jar
 cookies = ["cookie"]
 
 # trust-dns as dns resolver
 trust-dns = ["actix-http/trust-dns"]
+
+# Internal (PRIVATE!) features used to aid testing and cheking feature status.
+# Don't rely on these whatsoever. They may disappear at anytime.
+__compress = []
 
 [dependencies]
 actix-codec = "0.4.0"
@@ -52,6 +60,7 @@ actix-rt = { version = "2.1", default-features = false }
 
 base64 = "0.13"
 bytes = "1"
+cfg-if = "1"
 cookie = { version = "0.15", features = ["percent-encode"], optional = true }
 derive_more = "0.99.5"
 futures-core = { version = "0.3.7", default-features = false }

--- a/awc/src/sender.rs
+++ b/awc/src/sender.rs
@@ -22,7 +22,7 @@ use derive_more::From;
 use futures_core::Stream;
 use serde::Serialize;
 
-#[cfg(feature = "compress")]
+#[cfg(feature = "__compress")]
 use actix_http::{encoding::Decoder, http::header::ContentEncoding, Payload, PayloadStream};
 
 use crate::{
@@ -91,7 +91,7 @@ impl SendClientRequest {
     }
 }
 
-#[cfg(feature = "compress")]
+#[cfg(feature = "__compress")]
 impl Future for SendClientRequest {
     type Output = Result<ClientResponse<Decoder<Payload<PayloadStream>>>, SendRequestError>;
 
@@ -131,7 +131,7 @@ impl Future for SendClientRequest {
     }
 }
 
-#[cfg(not(feature = "compress"))]
+#[cfg(not(feature = "__compress"))]
 impl Future for SendClientRequest {
     type Output = Result<ClientResponse, SendRequestError>;
 

--- a/src/http/header/encoding.rs
+++ b/src/http/header/encoding.rs
@@ -1,7 +1,7 @@
 use std::{fmt, str};
 
 pub use self::Encoding::{
-    Brotli, Chunked, Compress, Deflate, EncodingExt, Gzip, Identity, Trailers,
+    Brotli, Chunked, Compress, Deflate, EncodingExt, Gzip, Identity, Trailers, Zstd,
 };
 
 /// A value to represent an encoding used in `Transfer-Encoding`
@@ -22,6 +22,8 @@ pub enum Encoding {
     Identity,
     /// The `trailers` encoding.
     Trailers,
+    /// The `zstd` encoding.
+    Zstd,
     /// Some other encoding that is less common, can be any String.
     EncodingExt(String),
 }
@@ -36,6 +38,7 @@ impl fmt::Display for Encoding {
             Compress => "compress",
             Identity => "identity",
             Trailers => "trailers",
+            Zstd => "zstd",
             EncodingExt(ref s) => s.as_ref(),
         })
     }
@@ -52,6 +55,7 @@ impl str::FromStr for Encoding {
             "compress" => Ok(Compress),
             "identity" => Ok(Identity),
             "trailers" => Ok(Trailers),
+            "zstd" => Ok(Zstd),
             _ => Ok(EncodingExt(s.to_owned())),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@
 //! * Streaming and pipelining
 //! * Keep-alive and slow requests handling
 //! * Client/server [WebSockets](https://actix.rs/docs/websockets/) support
-//! * Transparent content compression/decompression (br, gzip, deflate)
+//! * Transparent content compression/decompression (br, gzip, deflate, zstd)
 //! * Powerful [request routing](https://actix.rs/docs/url-dispatch/)
 //! * Multipart streams
 //! * Static assets
@@ -140,7 +140,8 @@ pub mod dev {
     pub use actix_http::body::{
         AnyBody, Body, BodySize, MessageBody, ResponseBody, SizedStream,
     };
-    #[cfg(feature = "compress")]
+
+    #[cfg(feature = "__compress")]
     pub use actix_http::encoding::Decoder as Decompress;
     pub use actix_http::ResponseBuilder as BaseHttpResponseBuilder;
     pub use actix_http::{Extensions, Payload, PayloadStream, RequestHead, ResponseHead};

--- a/src/middleware/compat.rs
+++ b/src/middleware/compat.rs
@@ -144,7 +144,7 @@ mod tests {
     use crate::{web, App, HttpResponse};
 
     #[actix_rt::test]
-    #[cfg(all(feature = "cookies", feature = "compress"))]
+    #[cfg(all(feature = "cookies", feature = "__compress"))]
     async fn test_scope_middleware() {
         use crate::middleware::Compress;
 
@@ -167,7 +167,7 @@ mod tests {
     }
 
     #[actix_rt::test]
-    #[cfg(all(feature = "cookies", feature = "compress"))]
+    #[cfg(all(feature = "cookies", feature = "__compress"))]
     async fn test_resource_scope_middleware() {
         use crate::middleware::Compress;
 

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -14,7 +14,8 @@ pub use self::err_handlers::{ErrorHandlerResponse, ErrorHandlers};
 pub use self::logger::Logger;
 pub use self::normalize::{NormalizePath, TrailingSlash};
 
-#[cfg(feature = "compress")]
+#[cfg(feature = "__compress")]
 mod compress;
-#[cfg(feature = "compress")]
+
+#[cfg(feature = "__compress")]
 pub use self::compress::Compress;

--- a/src/types/form.rs
+++ b/src/types/form.rs
@@ -16,7 +16,7 @@ use futures_core::{future::LocalBoxFuture, ready};
 use futures_util::{FutureExt as _, StreamExt as _};
 use serde::{de::DeserializeOwned, Serialize};
 
-#[cfg(feature = "compress")]
+#[cfg(feature = "__compress")]
 use crate::dev::Decompress;
 use crate::{
     error::UrlencodedError, extract::FromRequest, http::header::CONTENT_LENGTH, web, Error,
@@ -255,9 +255,9 @@ impl Default for FormConfig {
 /// - content type is not `application/x-www-form-urlencoded`
 /// - content length is greater than [limit](UrlEncoded::limit())
 pub struct UrlEncoded<T> {
-    #[cfg(feature = "compress")]
+    #[cfg(feature = "__compress")]
     stream: Option<Decompress<Payload>>,
-    #[cfg(not(feature = "compress"))]
+    #[cfg(not(feature = "__compress"))]
     stream: Option<Payload>,
 
     limit: usize,
@@ -293,10 +293,15 @@ impl<T> UrlEncoded<T> {
             }
         };
 
-        #[cfg(feature = "compress")]
-        let payload = Decompress::from_headers(payload.take(), req.headers());
-        #[cfg(not(feature = "compress"))]
-        let payload = payload.take();
+        let payload = {
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "__compress")] {
+                    Decompress::from_headers(payload.take(), req.headers())
+                } else {
+                    payload.take()
+                }
+            }
+        };
 
         UrlEncoded {
             encoding,


### PR DESCRIPTION
## PR Type

Refactor

## PR Checklist

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.

## Overview

Update `compress` feature flag to allow selection of enabled algorithms with `compress-brotli`, `compress-gzip` and `compress-zstd` flags.

### Breaking change

I totaly remove `compress` flag and replace it by `compress-<alg>` flags.

Having both `compress` flag and `compress-<alg>` flags may lead to invalid selection:
- Example 1: compress enabled but not algorithm selected
- Example 2: algorithm selected but compress disabled

### Change for developpers

For developers, checking if compression is supported or not is done through new internal flag: `__compress`.
This flag is enabled by selecting any of `compress-brotli`, `compress-gzip` or `compress-zstd` flags.

Before it was:
```rust
#[cfg(feature = "compress")]
```

Now it is:
```rust
#[cfg(feature = "__compress")]
```

### Other changes

Completely refact `awc` selection of `Accept-Encoding` HTTP header

This PR follow works that has been started in PR [#2244].