### PR TITLE
add Seal argument to sealed AsHeaderName methods

### DIFF
--- a/actix-http/src/header/as_name.rs
+++ b/actix-http/src/header/as_name.rs
@@ -8,40 +8,42 @@ use http::header::{HeaderName, InvalidHeaderName};
 
 pub trait AsHeaderName: Sealed {}
 
+pub struct Seal;
+
 pub trait Sealed {
-    fn try_as_name(&self) -> Result<Cow<'_, HeaderName>, InvalidHeaderName>;
+    fn try_as_name(&self, seal: Seal) -> Result<Cow<'_, HeaderName>, InvalidHeaderName>;
 }
 
 impl Sealed for HeaderName {
-    fn try_as_name(&self) -> Result<Cow<'_, HeaderName>, InvalidHeaderName> {
+    fn try_as_name(&self, _: Seal) -> Result<Cow<'_, HeaderName>, InvalidHeaderName> {
         Ok(Cow::Borrowed(self))
     }
 }
 impl AsHeaderName for HeaderName {}
 
 impl Sealed for &HeaderName {
-    fn try_as_name(&self) -> Result<Cow<'_, HeaderName>, InvalidHeaderName> {
+    fn try_as_name(&self, _: Seal) -> Result<Cow<'_, HeaderName>, InvalidHeaderName> {
         Ok(Cow::Borrowed(*self))
     }
 }
 impl AsHeaderName for &HeaderName {}
 
 impl Sealed for &str {
-    fn try_as_name(&self) -> Result<Cow<'_, HeaderName>, InvalidHeaderName> {
+    fn try_as_name(&self, _: Seal) -> Result<Cow<'_, HeaderName>, InvalidHeaderName> {
         HeaderName::from_str(self).map(Cow::Owned)
     }
 }
 impl AsHeaderName for &str {}
 
 impl Sealed for String {
-    fn try_as_name(&self) -> Result<Cow<'_, HeaderName>, InvalidHeaderName> {
+    fn try_as_name(&self, _: Seal) -> Result<Cow<'_, HeaderName>, InvalidHeaderName> {
         HeaderName::from_str(self).map(Cow::Owned)
     }
 }
 impl AsHeaderName for String {}
 
 impl Sealed for &String {
-    fn try_as_name(&self) -> Result<Cow<'_, HeaderName>, InvalidHeaderName> {
+    fn try_as_name(&self, _: Seal) -> Result<Cow<'_, HeaderName>, InvalidHeaderName> {
         HeaderName::from_str(self).map(Cow::Owned)
     }
 }

--- a/actix-http/src/header/map.rs
+++ b/actix-http/src/header/map.rs
@@ -213,7 +213,7 @@ impl HeaderMap {
     }
 
     fn get_value(&self, key: impl AsHeaderName) -> Option<&Value> {
-        match key.try_as_name().ok()? {
+        match key.try_as_name(super::as_name::Seal).ok()? {
             Cow::Borrowed(name) => self.inner.get(name),
             Cow::Owned(name) => self.inner.get(&name),
         }
@@ -279,7 +279,7 @@ impl HeaderMap {
     /// assert!(map.get("INVALID HEADER NAME").is_none());
     /// ```
     pub fn get_mut(&mut self, key: impl AsHeaderName) -> Option<&mut HeaderValue> {
-        match key.try_as_name().ok()? {
+        match key.try_as_name(super::as_name::Seal).ok()? {
             Cow::Borrowed(name) => self.inner.get_mut(name).map(|v| v.first_mut()),
             Cow::Owned(name) => self.inner.get_mut(&name).map(|v| v.first_mut()),
         }
@@ -327,7 +327,7 @@ impl HeaderMap {
     /// assert!(map.contains_key(header::ACCEPT));
     /// ```
     pub fn contains_key(&self, key: impl AsHeaderName) -> bool {
-        match key.try_as_name() {
+        match key.try_as_name(super::as_name::Seal) {
             Ok(Cow::Borrowed(name)) => self.inner.contains_key(name),
             Ok(Cow::Owned(name)) => self.inner.contains_key(&name),
             Err(_) => false,
@@ -410,7 +410,7 @@ impl HeaderMap {
     ///
     /// assert!(map.is_empty());
     pub fn remove(&mut self, key: impl AsHeaderName) -> Removed {
-        let value = match key.try_as_name() {
+        let value = match key.try_as_name(super::as_name::Seal) {
             Ok(Cow::Borrowed(name)) => self.inner.remove(name),
             Ok(Cow::Owned(name)) => self.inner.remove(&name),
             Err(_) => None,


### PR DESCRIPTION
## PR Type
Refactor

## PR Checklist
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.

## Overview

It's technically possible to call methods on sealed traits, even if they aren't in scope. Adding a `Seal` argument gets around this. I'm not sure if this really matters in this case, but if it's supposed to be sealed, might as well fully seal it.