### PR TITLE
deprecate `App::data` and `App::data_factory`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,10 +3,10 @@
 ## Unreleased - 2021-xx-xx
 ### Changed
 * Change compression algorithm features flags. [#2250]
-* Deprecate `App::data` and `App::data_factory`. [#????]
+* Deprecate `App::data` and `App::data_factory`. [#2271]
 
 [#2250]: https://github.com/actix/actix-web/pull/2250
-[#????]: https://github.com/actix/actix-web/pull/????
+[#2271]: https://github.com/actix/actix-web/pull/2271
 
 
 ## 4.0.0-beta.7 - 2021-06-17

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,8 +3,10 @@
 ## Unreleased - 2021-xx-xx
 ### Changed
 * Change compression algorithm features flags. [#2250]
+* Deprecate `App::data` and `App::data_factory`. [#????]
 
 [#2250]: https://github.com/actix/actix-web/pull/2250
+[#????]: https://github.com/actix/actix-web/pull/????
 
 
 ## 4.0.0-beta.7 - 2021-06-17

--- a/src/app.rs
+++ b/src/app.rs
@@ -98,13 +98,18 @@ where
     ///         web::resource("/index.html").route(
     ///             web::get().to(index)));
     /// ```
+    #[deprecated(since = "4.0.0", note = "Use `.app_data(Data::new(val))` instead.")]
     pub fn data<U: 'static>(self, data: U) -> Self {
         self.app_data(Data::new(data))
     }
 
-    /// Set application data factory. This function is
-    /// similar to `.data()` but it accepts data factory. Data object get
-    /// constructed asynchronously during application initialization.
+    /// Add application data factory. This function is similar to `.data()` but it accepts a
+    /// "data factory". Data values are constructed asynchronously during application
+    /// initialization, before the server starts accepting requests.
+    #[deprecated(
+        since = "4.0.0",
+        note = "Construct data value before starting server and use `.app_data(Data::new(val))` instead."
+    )]
     pub fn data_factory<F, Out, D, E>(mut self, data: F) -> Self
     where
         F: Fn() -> Out + 'static,

--- a/src/app.rs
+++ b/src/app.rs
@@ -523,6 +523,8 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::CREATED);
     }
 
+    // allow deprecated App::data
+    #[allow(deprecated)]
     #[actix_rt::test]
     async fn test_data_factory() {
         let srv = init_service(
@@ -546,6 +548,8 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
     }
 
+    // allow deprecated App::data
+    #[allow(deprecated)]
     #[actix_rt::test]
     async fn test_data_factory_errors() {
         let srv = try_init_service(

--- a/src/app_service.rs
+++ b/src/app_service.rs
@@ -349,6 +349,8 @@ mod tests {
         }
     }
 
+    // allow deprecated App::data
+    #[allow(deprecated)]
     #[actix_rt::test]
     async fn test_drop_data() {
         let data = Arc::new(AtomicBool::new(false));

--- a/src/data.rs
+++ b/src/data.rs
@@ -154,6 +154,8 @@ mod tests {
         web, App, HttpResponse,
     };
 
+    // allow deprecated App::data
+    #[allow(deprecated)]
     #[actix_rt::test]
     async fn test_data_extractor() {
         let srv = init_service(App::new().data("TEST".to_string()).service(
@@ -221,6 +223,8 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
     }
 
+    // allow deprecated App::data
+    #[allow(deprecated)]
     #[actix_rt::test]
     async fn test_route_data_extractor() {
         let srv = init_service(
@@ -250,6 +254,8 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
     }
 
+    // allow deprecated App::data
+    #[allow(deprecated)]
     #[actix_rt::test]
     async fn test_override_data() {
         let srv =

--- a/src/request.rs
+++ b/src/request.rs
@@ -711,6 +711,8 @@ mod tests {
         assert_eq!(body, Bytes::from_static(b"1"));
     }
 
+    // allow deprecated App::data
+    #[allow(deprecated)]
     #[actix_rt::test]
     async fn test_extensions_dropped() {
         struct Tracker {

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -695,6 +695,8 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::NO_CONTENT);
     }
 
+    // allow deprecated App::data
+    #[allow(deprecated)]
     #[actix_rt::test]
     async fn test_data() {
         let srv = init_service(
@@ -727,6 +729,8 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::OK);
     }
 
+    // allow deprecated App::data
+    #[allow(deprecated)]
     #[actix_rt::test]
     async fn test_data_default_service() {
         let srv = init_service(

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -196,6 +196,7 @@ where
     ///           ));
     /// }
     /// ```
+    #[deprecated(since = "4.0.0", note = "Use `.app_data(Data::new(val))` instead.")]
     pub fn data<U: 'static>(self, data: U) -> Self {
         self.app_data(Data::new(data))
     }

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -991,6 +991,8 @@ mod tests {
         );
     }
 
+    // allow deprecated App::data
+    #[allow(deprecated)]
     #[actix_rt::test]
     async fn test_override_data() {
         let srv = init_service(App::new().data(1usize).service(
@@ -1009,6 +1011,8 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::OK);
     }
 
+    // allow deprecated App::data
+    #[allow(deprecated)]
     #[actix_rt::test]
     async fn test_override_data_default_service() {
         let srv = init_service(App::new().data(1usize).service(

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -146,6 +146,7 @@ where
     ///     );
     /// }
     /// ```
+    #[deprecated(since = "4.0.0", note = "Use `.app_data(Data::new(val))` instead.")]
     pub fn data<U: 'static>(self, data: U) -> Self {
         self.app_data(Data::new(data))
     }

--- a/src/service.rs
+++ b/src/service.rs
@@ -649,6 +649,8 @@ mod tests {
         assert_eq!(resp.status(), http::StatusCode::NOT_FOUND);
     }
 
+    // allow deprecated App::data
+    #[allow(deprecated)]
     #[actix_rt::test]
     async fn test_service_data() {
         let srv =

--- a/src/test.rs
+++ b/src/test.rs
@@ -839,6 +839,8 @@ mod tests {
         assert!(res.status().is_success());
     }
 
+    // allow deprecated App::data
+    #[allow(deprecated)]
     #[actix_rt::test]
     async fn test_server_data() {
         async fn handler(data: web::Data<usize>) -> impl Responder {

--- a/src/types/payload.rs
+++ b/src/types/payload.rs
@@ -398,6 +398,8 @@ mod tests {
         assert!(cfg.check_mimetype(&req).is_ok());
     }
 
+    // allow deprecated App::data
+    #[allow(deprecated)]
     #[actix_rt::test]
     async fn test_config_recall_locations() {
         async fn bytes_handler(_: Bytes) -> impl Responder {

--- a/tests/test_server.rs
+++ b/tests/test_server.rs
@@ -1028,6 +1028,8 @@ async fn test_normalize() {
     assert!(response.status().is_success());
 }
 
+// allow deprecated App::data
+#[allow(deprecated)]
 #[actix_rt::test]
 async fn test_data_drop() {
     use std::sync::{


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Deprecation


## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
Partially addresses the problem we have with `.app_data(val)` vs `.data(val)` vs `.app_data(Data::new(val))` by deprecating `.data(val)` and encouraging use of `.app_data(Data::new(val))` as a replacement.

Also deprecates `App::data_factory()` because of it's limited use. There is a plan to introduce a similar type `LazyData` post-v4 that would be used in the same way as `Data` and more useful because it  allows the app to start serving requests before it resolves.