### PR TITLE
Note that Form cannot require data ordering

### DIFF
--- a/src/types/form.rs
+++ b/src/types/form.rs
@@ -80,6 +80,10 @@ use crate::{
 ///     })
 /// }
 /// ```
+///
+/// # Panics
+/// URL encoded forms consist of unordered `key=value` pairs, therefore they cannot be decoded into
+/// any type which depends upon data ordering (eg. tuples). Trying to do so will result in a panic.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub struct Form<T>(pub T);
 


### PR DESCRIPTION

<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Docs


## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Documentation comments have been added / updated.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.

Note: I was unsure whether this should go into the changelog.

## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

URL encoded forms are always unordered `key=value` pairs.  Similarly to `Query`, note that trying to decode it into something like a tuple will fail at runtime.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
