### PR TITLE
clippy fixes

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,6 @@
 [alias]
 chk = "check --workspace --all-features --tests --examples --bins"
-lint = "clippy --workspace --tests --examples"
+lint = "clippy --workspace --all-features --tests --examples --bins"
 ci-min = "hack check --workspace --no-default-features"
 ci-min-test = "hack check --workspace --no-default-features --tests --examples"
 ci-default = "check --workspace --bins --tests --examples"

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@ PR_TYPE
 
 
 ## PR Checklist
-<!-- Check your PR fulfills the following items. ->>
+<!-- Check your PR fulfills the following items. -->
 <!-- For draft PRs check the boxes as you complete them. -->
 
 - [ ] Tests for the changes have been added / updated.

--- a/actix-http/src/config.rs
+++ b/actix-http/src/config.rs
@@ -104,6 +104,8 @@ impl ServiceConfig {
     }
 
     /// Returns the local address that this server is bound to.
+    ///
+    /// Returns `None` for connections via UDS (Unix Domain Socket).
     #[inline]
     pub fn local_addr(&self) -> Option<net::SocketAddr> {
         self.0.local_addr

--- a/actix-http/src/error.rs
+++ b/actix-http/src/error.rs
@@ -55,6 +55,8 @@ impl Error {
         Self::new(Kind::Io)
     }
 
+    // used in encoder behind feature flag so ignore unused warning
+    #[allow(unused)]
     pub(crate) fn new_encoder() -> Self {
         Self::new(Kind::Encoder)
     }

--- a/src/info.rs
+++ b/src/info.rs
@@ -135,7 +135,7 @@ impl ConnectionInfo {
             .or_else(|| first_header_value(req, &*X_FORWARDED_HOST))
             .or_else(|| req.headers.get(&header::HOST)?.to_str().ok())
             .or_else(|| req.uri.authority().map(Authority::as_str))
-            .unwrap_or(cfg.host())
+            .unwrap_or_else(|| cfg.host())
             .to_owned();
 
         let realip_remote_addr = realip_remote_addr

--- a/src/info.rs
+++ b/src/info.rs
@@ -65,10 +65,10 @@ fn first_header_value<'a>(req: &'a RequestHead, name: &'_ HeaderName) -> Option<
 /// [rfc7239-63]: https://datatracker.ietf.org/doc/html/rfc7239#section-6.3
 #[derive(Debug, Clone, Default)]
 pub struct ConnectionInfo {
-    scheme: String,
     host: String,
-    realip_remote_addr: Option<String>,
+    scheme: String,
     remote_addr: Option<String>,
+    realip_remote_addr: Option<String>,
 }
 
 impl ConnectionInfo {
@@ -145,9 +145,9 @@ impl ConnectionInfo {
         let remote_addr = req.peer_addr.map(|addr| addr.to_string());
 
         ConnectionInfo {
-            remote_addr,
-            scheme,
             host,
+            scheme,
+            remote_addr,
             realip_remote_addr,
         }
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -525,10 +525,11 @@ where
             addr: socket_addr,
         });
 
-        let addr = format!("actix-web-service-{:?}", lst.local_addr()?);
+        let addr = lst.local_addr()?;
+        let name = format!("actix-web-service-{:?}", addr);
         let on_connect_fn = self.on_connect_fn.clone();
 
-        self.builder = self.builder.listen_uds(addr, lst, move || {
+        self.builder = self.builder.listen_uds(name, lst, move || {
             let c = cfg.lock().unwrap();
             let config = AppConfig::new(
                 false,
@@ -540,8 +541,7 @@ where
                 let mut svc = HttpService::build()
                     .keep_alive(c.keep_alive)
                     .client_timeout(c.client_timeout)
-                    .client_disconnect(c.client_shutdown)
-                    .local_addr(addr);
+                    .client_disconnect(c.client_shutdown);
 
                 if let Some(handler) = on_connect_fn.clone() {
                     svc = svc

--- a/src/server.rs
+++ b/src/server.rs
@@ -295,6 +295,7 @@ where
                     let mut svc = HttpService::build()
                         .keep_alive(c.keep_alive)
                         .client_timeout(c.client_timeout)
+                        .client_disconnect(c.client_shutdown)
                         .local_addr(addr);
 
                     if let Some(handler) = on_connect_fn.clone() {
@@ -352,7 +353,8 @@ where
                     let svc = HttpService::build()
                         .keep_alive(c.keep_alive)
                         .client_timeout(c.client_timeout)
-                        .client_disconnect(c.client_shutdown);
+                        .client_disconnect(c.client_shutdown)
+                        .local_addr(addr);
 
                     let svc = if let Some(handler) = on_connect_fn.clone() {
                         svc.on_connect_ext(move |io: &_, ext: _| {
@@ -537,7 +539,9 @@ where
             fn_service(|io: UnixStream| async { Ok((io, Protocol::Http1, None)) }).and_then({
                 let mut svc = HttpService::build()
                     .keep_alive(c.keep_alive)
-                    .client_timeout(c.client_timeout);
+                    .client_timeout(c.client_timeout)
+                    .client_disconnect(c.client_shutdown)
+                    .local_addr(addr);
 
                 if let Some(handler) = on_connect_fn.clone() {
                     svc = svc
@@ -568,6 +572,7 @@ where
         let factory = self.factory.clone();
         let socket_addr =
             net::SocketAddr::new(net::IpAddr::V4(net::Ipv4Addr::new(127, 0, 0, 1)), 8080);
+
         self.sockets.push(Socket {
             scheme: "http",
             addr: socket_addr,
@@ -592,6 +597,8 @@ where
                     HttpService::build()
                         .keep_alive(c.keep_alive)
                         .client_timeout(c.client_timeout)
+                        .client_disconnect(c.client_shutdown)
+                        .local_addr(socket_addr)
                         .finish(map_config(fac, move |_| config.clone())),
                 )
             },

--- a/src/server.rs
+++ b/src/server.rs
@@ -558,8 +558,8 @@ where
         Ok(self)
     }
 
-    #[cfg(unix)]
     /// Start listening for incoming unix domain connections.
+    #[cfg(unix)]
     pub fn bind_uds<A>(mut self, addr: A) -> io::Result<Self>
     where
         A: AsRef<std::path::Path>,
@@ -598,7 +598,6 @@ where
                         .keep_alive(c.keep_alive)
                         .client_timeout(c.client_timeout)
                         .client_disconnect(c.client_shutdown)
-                        .local_addr(socket_addr)
                         .finish(map_config(fac, move |_| config.clone())),
                 )
             },

--- a/tests/test_error_propagation.rs
+++ b/tests/test_error_propagation.rs
@@ -23,7 +23,7 @@ impl std::fmt::Display for MyError {
 
 #[get("/test")]
 async fn test() -> Result<actix_web::HttpResponse, actix_web::error::Error> {
-    return Err(MyError.into());
+    Err(MyError.into())
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Refactor


## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
Clippy fixes.

Also makes sure that `client_disconnect` is set for all types of server. Havent dug too deep on why they weren't set before but seems like they should be, they only feed into ServiceConfig.