### PR TITLE
Expose common types for App<T, _>

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,8 +96,10 @@ pub mod test;
 pub(crate) mod types;
 pub mod web;
 
+pub use actix_service::ServiceFactory;
+
 pub use actix_http::Response as BaseHttpResponse;
-pub use actix_http::{body, HttpMessage};
+pub use actix_http::{body, HttpMessage, Request};
 #[doc(inline)]
 pub use actix_rt as rt;
 pub use actix_web_codegen::*;
@@ -105,6 +107,7 @@ pub use actix_web_codegen::*;
 pub use cookie;
 
 pub use crate::app::App;
+pub use crate::app_service::AppEntry;
 pub use crate::error::{Error, ResponseError, Result};
 pub use crate::extract::FromRequest;
 pub use crate::request::HttpRequest;

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -11,7 +11,7 @@ pub use self::compat::Compat;
 pub use self::condition::Condition;
 pub use self::default_headers::DefaultHeaders;
 pub use self::err_handlers::{ErrorHandlerResponse, ErrorHandlers};
-pub use self::logger::Logger;
+pub use self::logger::{Logger, StreamLog};
 pub use self::normalize::{NormalizePath, TrailingSlash};
 
 #[cfg(feature = "__compress")]


### PR DESCRIPTION
Before this commit, many of the common monomorphizations of `App<T, B>`
where impossible to return from a function.

For example:

```rust
/// Create the actix-web application that can be used to start an HttpServer.
pub fn create_app() -> App<
    impl ServiceFactory<
        ServiceRequest,
        Config = (),
        Response = ServiceResponse<StreamLog<Body>>,
        Error = actix_web::error::Error,
        InitError = (),
    >,
    StreamLog<Body>,
> {
    unimplemented!()
}
```

Would fail to compile since the `ServiceFactory` a a couple of other types were not publicly exported from actix-web.

---

In this commit, a few types that are commonly used when constructing an App are now exported.

This allows you to have a `fn create_app () -> App<T, B>` that can be re-used across your test suite.
