### PR TITLE
Add `start_with_addr_and_codec` to websocket actor creation

### DIFF
--- a/actix-web-actors/CHANGES.md
+++ b/actix-web-actors/CHANGES.md
@@ -1,7 +1,7 @@
 # Changes
 
 ## Unreleased - 2021-xx-xx
-
+* Add ability to create a websocket actor with a specified `Codec` while returning the `Addr<A>` 
 
 ## 4.0.0-beta.6 - 2021-06-26
 * Update `actix` to `0.12`. [#2277]


### PR DESCRIPTION
## PR Type
Feature


## PR Checklist
- [ ] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [ ] Format code with the latest stable rustfmt.
- [ ] (Team) Label with affected crates and semver status.


## Overview
It currently isn't possible to start a websocket actor and return the address while also specifying the codec. This is a non-breaking (purely additive) change to do so. There were no tests for `with_codec` anyway, so no extra tests were made.
