### PR TITLE
Fix quality parse error in Accept-Encoding HTTP header

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,13 +5,11 @@
 * Re-export actix-service `ServiceFactory` in `dev` module. [#2325]
 
 ### Changes
+* Fix quality parse error in Accept-Encoding HTTP header. [#2344]
 * Minimum supported Rust version (MSRV) is now 1.51.
 
 [#2325]: https://github.com/actix/actix-web/pull/2325
-
-### Changed
-* Fix quality parse error in Accept-Encoding HTTP header. [#2344]
-
+[#2344]: https://github.com/actix/actix-web/pull/2344
 
 ## 4.0.0-beta.8 - 2021-06-26
 ### Added

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,12 +4,16 @@
 ### Added
 * Re-export actix-service `ServiceFactory` in `dev` module. [#2325]
 
-### Changes
-* Fix quality parse error in Accept-Encoding HTTP header. [#2344]
+### Changed
 * Minimum supported Rust version (MSRV) is now 1.51.
+* Compress middleware will return 406 Not Acceptable when no content encoding is acceptable to the client. [#2344]
+
+### Fixed
+* Fix quality parse error in Accept-Encoding header. [#2344]
 
 [#2325]: https://github.com/actix/actix-web/pull/2325
 [#2344]: https://github.com/actix/actix-web/pull/2344
+
 
 ## 4.0.0-beta.8 - 2021-06-26
 ### Added

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,9 @@
 
 [#2325]: https://github.com/actix/actix-web/pull/2325
 
+### Changed
+* Fix quality parse error in Accept-Encoding HTTP header. [#2344]
+
 
 ## 4.0.0-beta.8 - 2021-06-26
 ### Added

--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -16,6 +16,8 @@
 ### Fixed
 * Potential HTTP request smuggling vulnerabilities. [RUSTSEC-2021-0081](https://github.com/rustsec/advisory-db/pull/977)
 
+### Changed
+* Fix quality parse error in Accept-Encoding HTTP header. [#2344]
 
 ## 3.0.0-beta.8 - 2021-06-26
 ### Changed

--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -1,13 +1,13 @@
 # Changes
 
 ## Unreleased - 2021-xx-xx
-### Changes
+### Changed
 * Minimum supported Rust version (MSRV) is now 1.51.
 
 ### Fixed
 * Remove slice creation pointing to potential uninitialized data on h1 encoder. [#2364]
 * Remove `Into<Error>` bound on `Encoder` body types. [#2375]
-* Fix quality parse error in Accept-Encoding HTTP header. [#2344]
+* Fix quality parse error in Accept-Encoding header. [#2344]
 
 [#2364]: https://github.com/actix/actix-web/pull/2364
 [#2375]: https://github.com/actix/actix-web/pull/2375

--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -7,17 +7,16 @@
 ### Fixed
 * Remove slice creation pointing to potential uninitialized data on h1 encoder. [#2364]
 * Remove `Into<Error>` bound on `Encoder` body types. [#2375]
+* Fix quality parse error in Accept-Encoding HTTP header. [#2344]
 
 [#2364]: https://github.com/actix/actix-web/pull/2364
 [#2375]: https://github.com/actix/actix-web/pull/2375
+[#2344]: https://github.com/actix/actix-web/pull/2344
 
 
 ## 3.0.0-beta.8 - 2021-08-09
 ### Fixed
 * Potential HTTP request smuggling vulnerabilities. [RUSTSEC-2021-0081](https://github.com/rustsec/advisory-db/pull/977)
-
-### Changed
-* Fix quality parse error in Accept-Encoding HTTP header. [#2344]
 
 ## 3.0.0-beta.8 - 2021-06-26
 ### Changed

--- a/actix-http/src/encoding/decoder.rs
+++ b/actix-http/src/encoding/decoder.rs
@@ -1,6 +1,7 @@
 //! Stream decoders.
 
 use std::{
+    convert::TryFrom,
     future::Future,
     io::{self, Write as _},
     pin::Pin,
@@ -80,7 +81,7 @@ where
         let encoding = headers
             .get(&CONTENT_ENCODING)
             .and_then(|val| val.to_str().ok())
-            .map(ContentEncoding::from)
+            .and_then(|x| ContentEncoding::try_from(x).ok())
             .unwrap_or(ContentEncoding::Identity);
 
         Self::new(stream, encoding)

--- a/actix-http/src/header/shared/content_encoding.rs
+++ b/actix-http/src/header/shared/content_encoding.rs
@@ -1,4 +1,4 @@
-use std::{convert::Infallible, str::FromStr};
+use std::{convert::TryFrom, error, fmt, str::FromStr};
 
 use http::header::InvalidHeaderValue;
 
@@ -7,6 +7,20 @@ use crate::{
     header::{self, from_one_raw_str, Header, HeaderName, HeaderValue, IntoHeaderValue},
     HttpMessage,
 };
+
+/// Error return when a content encoding is unknown.
+///
+/// Example: 'compress'
+#[derive(Debug)]
+pub struct ContentEncodingParseError;
+
+impl fmt::Display for ContentEncodingParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Unsupported content encoding")
+    }
+}
+
+impl error::Error for ContentEncodingParseError {}
 
 /// Represents a supported content encoding.
 #[derive(Copy, Clone, PartialEq, Debug)]
@@ -48,18 +62,6 @@ impl ContentEncoding {
             ContentEncoding::Identity | ContentEncoding::Auto => "identity",
         }
     }
-
-    /// Default Q-factor (quality) value.
-    #[inline]
-    pub fn quality(self) -> f64 {
-        match self {
-            ContentEncoding::Br => 1.1,
-            ContentEncoding::Gzip => 1.0,
-            ContentEncoding::Deflate => 0.9,
-            ContentEncoding::Identity | ContentEncoding::Auto => 0.1,
-            ContentEncoding::Zstd => 0.0,
-        }
-    }
 }
 
 impl Default for ContentEncoding {
@@ -69,27 +71,29 @@ impl Default for ContentEncoding {
 }
 
 impl FromStr for ContentEncoding {
-    type Err = Infallible;
+    type Err = ContentEncodingParseError;
 
     fn from_str(val: &str) -> Result<Self, Self::Err> {
-        Ok(Self::from(val))
+        Self::try_from(val)
     }
 }
 
-impl From<&str> for ContentEncoding {
-    fn from(val: &str) -> ContentEncoding {
+impl TryFrom<&str> for ContentEncoding {
+    type Error = ContentEncodingParseError;
+
+    fn try_from(val: &str) -> Result<Self, Self::Error> {
         let val = val.trim();
 
         if val.eq_ignore_ascii_case("br") {
-            ContentEncoding::Br
+            Ok(ContentEncoding::Br)
         } else if val.eq_ignore_ascii_case("gzip") {
-            ContentEncoding::Gzip
+            Ok(ContentEncoding::Gzip)
         } else if val.eq_ignore_ascii_case("deflate") {
-            ContentEncoding::Deflate
+            Ok(ContentEncoding::Deflate)
         } else if val.eq_ignore_ascii_case("zstd") {
-            ContentEncoding::Zstd
+            Ok(ContentEncoding::Zstd)
         } else {
-            ContentEncoding::default()
+            Err(ContentEncodingParseError)
         }
     }
 }

--- a/actix-http/src/header/shared/content_encoding.rs
+++ b/actix-http/src/header/shared/content_encoding.rs
@@ -51,7 +51,7 @@ impl ContentEncoding {
         matches!(self, ContentEncoding::Identity | ContentEncoding::Auto)
     }
 
-    /// Convert content encoding to string
+    /// Convert content encoding to string.
     #[inline]
     pub fn as_str(self) -> &'static str {
         match self {
@@ -74,14 +74,6 @@ impl FromStr for ContentEncoding {
     type Err = ContentEncodingParseError;
 
     fn from_str(val: &str) -> Result<Self, Self::Err> {
-        Self::try_from(val)
-    }
-}
-
-impl TryFrom<&str> for ContentEncoding {
-    type Error = ContentEncodingParseError;
-
-    fn try_from(val: &str) -> Result<Self, Self::Error> {
         let val = val.trim();
 
         if val.eq_ignore_ascii_case("br") {
@@ -95,6 +87,14 @@ impl TryFrom<&str> for ContentEncoding {
         } else {
             Err(ContentEncodingParseError)
         }
+    }
+}
+
+impl TryFrom<&str> for ContentEncoding {
+    type Error = ContentEncodingParseError;
+
+    fn try_from(val: &str) -> Result<Self, Self::Error> {
+        val.parse()
     }
 }
 

--- a/actix-http/src/header/shared/quality_item.rs
+++ b/actix-http/src/header/shared/quality_item.rs
@@ -1,10 +1,13 @@
 use std::{
     cmp,
     convert::{TryFrom, TryInto},
-    fmt, str,
+    fmt,
+    str::{self, FromStr},
 };
 
 use derive_more::{Display, Error};
+
+use crate::error::ParseError;
 
 const MAX_QUALITY: u16 = 1000;
 const MAX_FLOAT_QUALITY: f32 = 1.0;
@@ -113,12 +116,12 @@ impl<T: fmt::Display> fmt::Display for QualityItem<T> {
     }
 }
 
-impl<T: str::FromStr> str::FromStr for QualityItem<T> {
-    type Err = crate::error::ParseError;
+impl<T: FromStr> FromStr for QualityItem<T> {
+    type Err = ParseError;
 
-    fn from_str(qitem_str: &str) -> Result<QualityItem<T>, crate::error::ParseError> {
+    fn from_str(qitem_str: &str) -> Result<Self, Self::Err> {
         if !qitem_str.is_ascii() {
-            return Err(crate::error::ParseError::Header);
+            return Err(ParseError::Header);
         }
 
         // Set defaults used if parsing fails.
@@ -139,7 +142,7 @@ impl<T: str::FromStr> str::FromStr for QualityItem<T> {
             if parts[0].len() < 2 {
                 // Can't possibly be an attribute since an attribute needs at least a name followed
                 // by an equals sign. And bare identifiers are forbidden.
-                return Err(crate::error::ParseError::Header);
+                return Err(ParseError::Header);
             }
 
             let start = &parts[0][0..2];
@@ -148,25 +151,21 @@ impl<T: str::FromStr> str::FromStr for QualityItem<T> {
                 let q_val = &parts[0][2..];
                 if q_val.len() > 5 {
                     // longer than 5 indicates an over-precise q-factor
-                    return Err(crate::error::ParseError::Header);
+                    return Err(ParseError::Header);
                 }
 
-                let q_value = q_val
-                    .parse::<f32>()
-                    .map_err(|_| crate::error::ParseError::Header)?;
+                let q_value = q_val.parse::<f32>().map_err(|_| ParseError::Header)?;
 
                 if (0f32..=1f32).contains(&q_value) {
                     quality = q_value;
                     raw_item = parts[1];
                 } else {
-                    return Err(crate::error::ParseError::Header);
+                    return Err(ParseError::Header);
                 }
             }
         }
 
-        let item = raw_item
-            .parse::<T>()
-            .map_err(|_| crate::error::ParseError::Header)?;
+        let item = raw_item.parse::<T>().map_err(|_| ParseError::Header)?;
 
         // we already checked above that the quality is within range
         Ok(QualityItem::new(item, Quality::from_f32(quality)))
@@ -224,7 +223,7 @@ mod tests {
         }
     }
 
-    impl str::FromStr for Encoding {
+    impl FromStr for Encoding {
         type Err = crate::error::ParseError;
         fn from_str(s: &str) -> Result<Encoding, crate::error::ParseError> {
             use Encoding::*;

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -53,7 +53,7 @@ mod tests {
         #[cfg(feature = "__compress")]
         {
             let _ = App::new().wrap(Compress::default()).wrap(Logger::default());
-            // let _ = App::new().wrap(Logger::default()).wrap(Compress::default());
+            let _ = App::new().wrap(Logger::default()).wrap(Compress::default());
             let _ = App::new().wrap(Compat::new(Compress::default()));
             let _ = App::new().wrap(Condition::new(true, Compat::new(Compress::default())));
         }

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -53,7 +53,7 @@ mod tests {
         #[cfg(feature = "__compress")]
         {
             let _ = App::new().wrap(Compress::default()).wrap(Logger::default());
-            let _ = App::new().wrap(Logger::default()).wrap(Compress::default());
+            // let _ = App::new().wrap(Logger::default()).wrap(Compress::default());
             let _ = App::new().wrap(Compat::new(Compress::default()));
             let _ = App::new().wrap(Condition::new(true, Compat::new(Compress::default())));
         }


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Bug Fix


## PR Checklist
<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

HTTP header `Accept-Encoding` was not correctly parsed.

Other changes:

- Better respect of client algorithms choices.
- Follow MDN spec about default qfactor value.
- It client need compressed response, now server send 406 HTTP error if there is no available algorithms.
- Make `ContentEncoding::parse` fail instead of returning default value.

### Issue open to discussion

I have change `CompressMiddleware` trait requirements.
```diff
- B: MessageBody
+ B: MessageBody + From<String>
```

Indeed, I have not been able to use the `Either` trait correctly to answer available compress algorithm when we have to answer NotAcceptable status code.

So the only way I have been able to work with is adding `From<String>` requirement to  `B`.

This make `test common_combinations` fail (see: https://github.com/actix/actix-web/commit/dade818ebaab441e8cc5d359068209daa002b488). So I have disable it ...
If anyone has a good idea to fix this, I will be happy to edit my PR.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->

Closes #2322