### PR TITLE
compile time validation of path

### DIFF
--- a/actix-router/src/resource.rs
+++ b/actix-router/src/resource.rs
@@ -967,7 +967,10 @@ impl ResourceDef {
                 _ => false,
             })
             .unwrap_or_else(|| {
-                panic!(r#"pattern "{}" contains malformed dynamic segment"#, pattern)
+                panic!(
+                    r#"pattern "{}" contains malformed dynamic segment"#,
+                    pattern
+                )
             });
 
         let (mut param, mut unprocessed) = pattern.split_at(close_idx + 1);

--- a/actix-router/src/resource.rs
+++ b/actix-router/src/resource.rs
@@ -967,7 +967,7 @@ impl ResourceDef {
                 _ => false,
             })
             .unwrap_or_else(|| {
-                panic!(r#"path "{}" contains malformed dynamic segment"#, pattern)
+                panic!(r#"pattern "{}" contains malformed dynamic segment"#, pattern)
             });
 
         let (mut param, mut unprocessed) = pattern.split_at(close_idx + 1);

--- a/actix-web-codegen/CHANGES.md
+++ b/actix-web-codegen/CHANGES.md
@@ -1,6 +1,9 @@
 # Changes
 
 ## Unreleased - 2021-xx-xx
+* In routing macros, paths are now validated at compile time. [#2350]
+
+[#2350]: https://github.com/actix/actix-web/pull/2350
 
 
 ## 0.5.0-beta.3 - 2021-06-17

--- a/actix-web-codegen/Cargo.toml
+++ b/actix-web-codegen/Cargo.toml
@@ -17,6 +17,7 @@ proc-macro = true
 quote = "1"
 syn = { version = "1", features = ["full", "parsing"] }
 proc-macro2 = "1"
+actix-router = "0.2.7"
 
 [dev-dependencies]
 actix-rt = "2.2"

--- a/actix-web-codegen/Cargo.toml
+++ b/actix-web-codegen/Cargo.toml
@@ -17,7 +17,7 @@ proc-macro = true
 quote = "1"
 syn = { version = "1", features = ["full", "parsing"] }
 proc-macro2 = "1"
-actix-router = "0.2.7"
+actix-router = "0.5.0-beta.1"
 
 [dev-dependencies]
 actix-rt = "2.2"

--- a/actix-web-codegen/src/route.rs
+++ b/actix-web-codegen/src/route.rs
@@ -102,6 +102,7 @@ impl Args {
             match arg {
                 NestedMeta::Lit(syn::Lit::Str(lit)) => match path {
                     None => {
+                        let _ = ResourceDef::new(lit.value());
                         path = Some(lit);
                     }
                     _ => {
@@ -114,7 +115,6 @@ impl Args {
                 NestedMeta::Meta(syn::Meta::NameValue(nv)) => {
                     if nv.path.is_ident("name") {
                         if let syn::Lit::Str(lit) = nv.lit {
-                            let _ = ResourceDef::new(lit.value());
                             resource_name = Some(lit);
                         } else {
                             return Err(syn::Error::new_spanned(

--- a/actix-web-codegen/src/route.rs
+++ b/actix-web-codegen/src/route.rs
@@ -3,6 +3,7 @@ extern crate proc_macro;
 use std::collections::HashSet;
 use std::convert::TryFrom;
 
+use actix_router::ResourceDef;
 use proc_macro::TokenStream;
 use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::{format_ident, quote, ToTokens, TokenStreamExt};
@@ -113,6 +114,7 @@ impl Args {
                 NestedMeta::Meta(syn::Meta::NameValue(nv)) => {
                     if nv.path.is_ident("name") {
                         if let syn::Lit::Str(lit) = nv.lit {
+                            let _ = ResourceDef::new(lit.value());
                             resource_name = Some(lit);
                         } else {
                             return Err(syn::Error::new_spanned(

--- a/actix-web-codegen/tests/trybuild.rs
+++ b/actix-web-codegen/tests/trybuild.rs
@@ -10,6 +10,7 @@ fn compile_macros() {
     t.compile_fail("tests/trybuild/route-missing-method-fail.rs");
     t.compile_fail("tests/trybuild/route-duplicate-method-fail.rs");
     t.compile_fail("tests/trybuild/route-unexpected-method-fail.rs");
+    t.compile_fail("tests/trybuild/route-malformed-path-fail.rs");
 
     t.pass("tests/trybuild/docstring-ok.rs");
 }

--- a/actix-web-codegen/tests/trybuild/route-malformed-path-fail.rs
+++ b/actix-web-codegen/tests/trybuild/route-malformed-path-fail.rs
@@ -1,7 +1,33 @@
-use actix_web_codegen::*;
+use actix_web_codegen::get;
 
-#[get("/one/{", other)]
-async fn one() -> String {
-    "Hello World!".to_owned()
+#[get("/{")]
+async fn zero() -> &'static str {
+    "malformed resource def"
 }
+
+#[get("/{foo")]
+async fn one() -> &'static str {
+    "malformed resource def"
+}
+
+#[get("/{}")]
+async fn two() -> &'static str {
+    "malformed resource def"
+}
+
+#[get("/*")]
+async fn three() -> &'static str {
+    "malformed resource def"
+}
+
+#[get("/{tail:\\d+}*")]
+async fn four() -> &'static str {
+    "malformed resource def"
+}
+
+#[get("/{a}/{b}/{c}/{d}/{e}/{f}/{g}/{h}/{i}/{j}/{k}/{l}/{m}/{n}/{o}/{p}/{q}")]
+async fn five() -> &'static str {
+    "malformed resource def"
+}
+
 fn main() {}

--- a/actix-web-codegen/tests/trybuild/route-malformed-path-fail.rs
+++ b/actix-web-codegen/tests/trybuild/route-malformed-path-fail.rs
@@ -1,0 +1,7 @@
+use actix_web_codegen::*;
+
+#[get("/one/{", other)]
+async fn one() -> String {
+    "Hello World!".to_owned()
+}
+fn main() {}

--- a/actix-web-codegen/tests/trybuild/route-malformed-path-fail.stderr
+++ b/actix-web-codegen/tests/trybuild/route-malformed-path-fail.stderr
@@ -1,5 +1,42 @@
-error: Unknown attribute.
- --> $DIR/route-malformed-path-fail.rs:3:17
+error: custom attribute panicked
+ --> $DIR/route-malformed-path-fail.rs:3:1
   |
-3 | #[get("/one/{", other)]
-  |                 ^^^^^
+3 | #[get("/{")]
+  | ^^^^^^^^^^^^
+  |
+  = help: message: pattern "{" contains malformed dynamic segment
+
+error: custom attribute panicked
+ --> $DIR/route-malformed-path-fail.rs:8:1
+  |
+8 | #[get("/{foo")]
+  | ^^^^^^^^^^^^^^^
+  |
+  = help: message: pattern "{foo" contains malformed dynamic segment
+
+error: custom attribute panicked
+  --> $DIR/route-malformed-path-fail.rs:13:1
+   |
+13 | #[get("/{}")]
+   | ^^^^^^^^^^^^^
+   |
+   = help: message: Wrong path pattern: "/{}" regex parse error:
+               ((?s-m)^/(?P<>[^/]+))$
+                            ^
+           error: empty capture group name
+
+error: custom attribute panicked
+  --> $DIR/route-malformed-path-fail.rs:23:1
+   |
+23 | #[get("/{tail:\\d+}*")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: message: custom regex is not supported for tail match
+
+error: custom attribute panicked
+  --> $DIR/route-malformed-path-fail.rs:28:1
+   |
+28 | #[get("/{a}/{b}/{c}/{d}/{e}/{f}/{g}/{h}/{i}/{j}/{k}/{l}/{m}/{n}/{o}/{p}/{q}")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: message: Only 16 dynamic segments are allowed, provided: 17

--- a/actix-web-codegen/tests/trybuild/route-malformed-path-fail.stderr
+++ b/actix-web-codegen/tests/trybuild/route-malformed-path-fail.stderr
@@ -1,0 +1,5 @@
+error: Unknown attribute.
+ --> $DIR/route-malformed-path-fail.rs:3:17
+  |
+3 | #[get("/one/{", other)]
+  |                 ^^^^^


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Feature


## PR Checklist
<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
<!-- Describe the current and new behavior. -->
Currently, the following code will panic during runtime
```rust
#[get("/foo/{bar")] // Missing `}`
async fn handle_foo(...) {
  ...
}
```
This PR will validate path and produce the following error at compile time
```bash
error: Unknown attribute.
 --> $DIR/route-malformed-path-fail.rs:3:17
  |
3 | #[get("/one/{", other)]
  |                 ^^^^^
  ```

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
Closes #2239
Related PR: [actix-net/#384](https://github.com/actix/actix-net/pull/384)