### PR TITLE
`actix-files` Do not send a message body in the NOT_MODIFIED case

### DIFF
--- a/actix-files/src/named.rs
+++ b/actix-files/src/named.rs
@@ -8,7 +8,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use std::os::unix::fs::MetadataExt;
 
 use actix_web::{
-    dev::{BodyEncoding, SizedStream},
+    dev::{Body, BodyEncoding, SizedStream},
     http::{
         header::{
             self, Charset, ContentDisposition, DispositionParam, DispositionType,
@@ -421,7 +421,7 @@ impl NamedFile {
         if precondition_failed {
             return Ok(resp.status(StatusCode::PRECONDITION_FAILED).finish());
         } else if not_modified {
-            return Ok(resp.status(StatusCode::NOT_MODIFIED).finish());
+            return Ok(resp.status(StatusCode::NOT_MODIFIED).body(Body::None));
         }
 
         let reader = ChunkedReadFile {


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Bug Fix


## PR Checklist
<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [ ] (Team) Label with affected crates and semver status.

I did not touch the changelog file because I was unsure whether this PR should have been made against the master branch.
This issue probably affects the current beta version as well.

## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

As per RFC7230 section 3.3.2 <https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.2>:

> A server MAY send a Content-Length header field in a 304 (Not
> Modified) response to a conditional GET request (Section 4.1 of
> [RFC7232]);
> a server MUST NOT send Content-Length in such a response
> unless its field-value equals the decimal number of octets that would
> have been sent in the payload body of a 200 (OK) response to the same
> request.

And per RFC7232 section 4.1 <https://datatracker.ietf.org/doc/html/rfc7232#section-4.1>:

> A 304 response cannot contain a message-body; it is always terminated
> by the first empty line after the header fields.

Previously a `Content-Length: 0` header was sent because `.finish()`
sets the body to `Body::Empty`, which indicates a zero-sized response.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
