### PR TITLE
Bump actix-http dependency to 3.0.0-beta.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ actix-utils = "3.0.0"
 actix-tls = { version = "3.0.0-beta.5", default-features = false, optional = true }
 
 actix-web-codegen = "0.5.0-beta.2"
-actix-http = "3.0.0-beta.8"
+actix-http = "3.0.0-beta.9"
 
 ahash = "0.7"
 bytes = "1"


### PR DESCRIPTION
## PR Type
Bug Fix

## PR Checklist

- [X] Tests for the changes have been added / updated.
- [X] Documentation comments have been added / updated.
- [X] A changelog entry has been made for the appropriate packages.
- [X] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.

## Overview

Mitigates [RUSTSEC-2021-0081](https://rustsec.org/advisories/RUSTSEC-2021-0081)
