### PR TITLE
Avoid possibility of dispatcher getting stuck while backpressuring io

### DIFF
--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -9,12 +9,13 @@
 * Remove slice creation pointing to potential uninitialized data on h1 encoder. [#2364]
 * Remove `Into<Error>` bound on `Encoder` body types. [#2375]
 * Fix quality parse error in Accept-Encoding header. [#2344]
+* Avoid possibility of dispatcher getting stuck while backpressuring io. [#2369]
 
 [#2364]: https://github.com/actix/actix-web/pull/2364
 [#2375]: https://github.com/actix/actix-web/pull/2375
 [#2344]: https://github.com/actix/actix-web/pull/2344
 [#2377]: https://github.com/actix/actix-web/pull/2377
-
+[#2369]: https://github.com/actix/actix-web/pull/2369
 
 ## 3.0.0-beta.8 - 2021-08-09
 ### Fixed


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Bug Fix


## PR Checklist
<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Avoid losing dispatcher's waker in the case we're backpressuring io and have a payload ready to read data.
For more information see: https://github.com/actix/actix-web/issues/1679#issuecomment-901507166


<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
If my understanding is correct, this closes #1679
