### PR TITLE
Display field in deserialization error

### DIFF
--- a/actix-web/Cargo.toml
+++ b/actix-web/Cargo.toml
@@ -33,6 +33,7 @@ features = [
     "compress-zstd",
     "cookies",
     "secure-cookies",
+    "beautify-errors"
 ]
 
 [package.metadata.cargo_check_external_types]
@@ -88,6 +89,9 @@ cookies = ["dep:cookie"]
 
 # Secure & signed cookies
 secure-cookies = ["cookies", "cookie/secure"]
+
+# Field names in deserialization errors
+beautify-errors = ["dep:serde_path_to_error"]
 
 # HTTP/2 support (including h2c).
 http2 = ["actix-http/http2"]
@@ -160,6 +164,7 @@ regex = { version = "1.5.5", optional = true }
 regex-lite = "0.1"
 serde = "1.0"
 serde_json = "1.0"
+serde_path_to_error = { version = "0.1", optional = true }
 serde_urlencoded = "0.7"
 smallvec = "1.6.1"
 socket2 = "0.5"
@@ -210,6 +215,10 @@ required-features = ["compress-gzip"]
 [[example]]
 name = "on-connect"
 required-features = []
+
+[[example]]
+name = "error"
+required-features = ["beautify-errors"]
 
 [[bench]]
 name = "server"

--- a/actix-web/examples/error.rs
+++ b/actix-web/examples/error.rs
@@ -54,24 +54,24 @@ async fn main() -> std::io::Result<()> {
 
 #[derive(Debug, Deserialize)]
 pub struct OptionalFilters {
-    limit: Option<i32>,
-    active: Option<bool>,
+    pub limit: Option<i32>,
+    pub active: Option<bool>,
 }
 
 #[derive(Debug, Deserialize)]
 pub struct MandatoryFilters {
-    limit: i32,
-    active: bool,
+    pub limit: i32,
+    pub active: bool,
 }
 
 #[derive(Debug, Deserialize)]
 pub struct OptionalPayload {
-    name: Option<String>,
-    age: Option<i32>,
+    pub name: Option<String>,
+    pub age: Option<i32>,
 }
 
 #[derive(Debug, Deserialize)]
 pub struct MandatoryPayload {
-    name: String,
-    age: i32,
+    pub name: String,
+    pub age: i32,
 }

--- a/actix-web/examples/error.rs
+++ b/actix-web/examples/error.rs
@@ -1,0 +1,77 @@
+use actix_web::{
+    get, middleware, post,
+    web::{Json, Query},
+    App, HttpServer,
+};
+use serde::Deserialize;
+
+#[get("/optional")]
+async fn optional_query_params(maybe_qs: Option<Query<OptionalFilters>>) -> String {
+    format!("you asked for the optional query params: {:#?}", maybe_qs)
+}
+
+#[get("/mandatory")]
+async fn mandatory_query_params(qs: Query<MandatoryFilters>) -> String {
+    format!("you asked for the mandatory query params: {:#?}", qs)
+}
+
+#[post("/optional")]
+async fn optional_payload(
+    maybe_qs: Option<Query<OptionalFilters>>,
+    maybe_payload: Option<Json<OptionalPayload>>,
+) -> String {
+    format!(
+        "you asked for the optional query params: {:#?} and optional body: {:#?}",
+        maybe_qs, maybe_payload
+    )
+}
+
+#[post("/mandatory")]
+async fn mandatory_payload(qs: Query<MandatoryFilters>, payload: Json<OptionalPayload>) -> String {
+    format!(
+        "you asked for the mandatory query params: {:#?} and mandatory body: {:#?}",
+        qs, payload
+    )
+}
+
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    env_logger::init_from_env(env_logger::Env::new().default_filter_or("info"));
+
+    HttpServer::new(|| {
+        App::new()
+            .wrap(middleware::Logger::default())
+            .service(optional_query_params)
+            .service(mandatory_query_params)
+            .service(optional_payload)
+            .service(mandatory_payload)
+    })
+    .bind("127.0.0.1:8080")?
+    .workers(1)
+    .run()
+    .await
+}
+
+#[derive(Debug, Deserialize)]
+pub struct OptionalFilters {
+    limit: Option<i32>,
+    active: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct MandatoryFilters {
+    limit: i32,
+    active: bool,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct OptionalPayload {
+    name: Option<String>,
+    age: Option<i32>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct MandatoryPayload {
+    name: String,
+    age: i32,
+}

--- a/actix-web/examples/error.rs
+++ b/actix-web/examples/error.rs
@@ -27,7 +27,7 @@ async fn optional_payload(
 }
 
 #[post("/mandatory")]
-async fn mandatory_payload(qs: Query<MandatoryFilters>, payload: Json<OptionalPayload>) -> String {
+async fn mandatory_payload(qs: Query<MandatoryFilters>, payload: Json<MandatoryPayload>) -> String {
     format!(
         "you asked for the mandatory query params: {:#?} and mandatory body: {:#?}",
         qs, payload

--- a/actix-web/examples/error_postman.json
+++ b/actix-web/examples/error_postman.json
@@ -1,0 +1,848 @@
+{
+	"info": {
+		"_postman_id": "1147f102-8d16-40e4-8642-5f0679879e59",
+		"name": "actix-web",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "field in deserialize errors",
+			"item": [
+				{
+					"name": "optional filters",
+					"item": [
+						{
+							"name": "without filters",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "127.0.0.1:8080/optional",
+									"host": [
+										"127",
+										"0",
+										"0",
+										"1"
+									],
+									"port": "8080",
+									"path": [
+										"optional"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "with a single filter",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "127.0.0.1:8080/optional?limit=1",
+									"host": [
+										"127",
+										"0",
+										"0",
+										"1"
+									],
+									"port": "8080",
+									"path": [
+										"optional"
+									],
+									"query": [
+										{
+											"key": "limit",
+											"value": "1"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "with both filters",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "127.0.0.1:8080/optional?limit=1&active=true",
+									"host": [
+										"127",
+										"0",
+										"0",
+										"1"
+									],
+									"port": "8080",
+									"path": [
+										"optional"
+									],
+									"query": [
+										{
+											"key": "limit",
+											"value": "1"
+										},
+										{
+											"key": "active",
+											"value": "true"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "with a single invalid filter",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "127.0.0.1:8080/optional?limit=wrong&active=true",
+									"host": [
+										"127",
+										"0",
+										"0",
+										"1"
+									],
+									"port": "8080",
+									"path": [
+										"optional"
+									],
+									"query": [
+										{
+											"key": "limit",
+											"value": "wrong"
+										},
+										{
+											"key": "active",
+											"value": "true"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "with both invalid filters",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "127.0.0.1:8080/optional?limit=wrong&active=wrong",
+									"host": [
+										"127",
+										"0",
+										"0",
+										"1"
+									],
+									"port": "8080",
+									"path": [
+										"optional"
+									],
+									"query": [
+										{
+											"key": "limit",
+											"value": "wrong"
+										},
+										{
+											"key": "active",
+											"value": "wrong"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "mandatory filters",
+					"item": [
+						{
+							"name": "without filters",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "127.0.0.1:8080/mandatory",
+									"host": [
+										"127",
+										"0",
+										"0",
+										"1"
+									],
+									"port": "8080",
+									"path": [
+										"mandatory"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "with a single filter",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "127.0.0.1:8080/mandatory?limit=1",
+									"host": [
+										"127",
+										"0",
+										"0",
+										"1"
+									],
+									"port": "8080",
+									"path": [
+										"mandatory"
+									],
+									"query": [
+										{
+											"key": "limit",
+											"value": "1"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "with both filters",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "127.0.0.1:8080/mandatory?limit=1&active=true",
+									"host": [
+										"127",
+										"0",
+										"0",
+										"1"
+									],
+									"port": "8080",
+									"path": [
+										"mandatory"
+									],
+									"query": [
+										{
+											"key": "limit",
+											"value": "1"
+										},
+										{
+											"key": "active",
+											"value": "true"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "with a single invalid filter",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "127.0.0.1:8080/mandatory?limit=wrong&active=true",
+									"host": [
+										"127",
+										"0",
+										"0",
+										"1"
+									],
+									"port": "8080",
+									"path": [
+										"mandatory"
+									],
+									"query": [
+										{
+											"key": "limit",
+											"value": "wrong"
+										},
+										{
+											"key": "active",
+											"value": "true"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "with both invalid filters",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "127.0.0.1:8080/mandatory?limit=wrong&active=wrong",
+									"host": [
+										"127",
+										"0",
+										"0",
+										"1"
+									],
+									"port": "8080",
+									"path": [
+										"mandatory"
+									],
+									"query": [
+										{
+											"key": "limit",
+											"value": "wrong"
+										},
+										{
+											"key": "active",
+											"value": "wrong"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "optional filters and payload",
+					"item": [
+						{
+							"name": "without filters",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"name\": \"John\",\n    \"age\": 13\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "127.0.0.1:8080/optional",
+									"host": [
+										"127",
+										"0",
+										"0",
+										"1"
+									],
+									"port": "8080",
+									"path": [
+										"optional"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "with a single filter",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"name\": \"John\",\n    \"age\": 13\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "127.0.0.1:8080/optional?limit=1",
+									"host": [
+										"127",
+										"0",
+										"0",
+										"1"
+									],
+									"port": "8080",
+									"path": [
+										"optional"
+									],
+									"query": [
+										{
+											"key": "limit",
+											"value": "1"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "with both filters",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"name\": \"John\",\n    \"age\": 13\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "127.0.0.1:8080/optional?limit=1&active=true",
+									"host": [
+										"127",
+										"0",
+										"0",
+										"1"
+									],
+									"port": "8080",
+									"path": [
+										"optional"
+									],
+									"query": [
+										{
+											"key": "limit",
+											"value": "1"
+										},
+										{
+											"key": "active",
+											"value": "true"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "with a single invalid filter",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"name\": \"John\",\n    \"age\": 13\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "127.0.0.1:8080/optional?limit=wrong&active=true",
+									"host": [
+										"127",
+										"0",
+										"0",
+										"1"
+									],
+									"port": "8080",
+									"path": [
+										"optional"
+									],
+									"query": [
+										{
+											"key": "limit",
+											"value": "wrong"
+										},
+										{
+											"key": "active",
+											"value": "true"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "with both invalid filters",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"name\": \"John\",\n    \"age\": 13\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "127.0.0.1:8080/optional?limit=wrong&active=wrong",
+									"host": [
+										"127",
+										"0",
+										"0",
+										"1"
+									],
+									"port": "8080",
+									"path": [
+										"optional"
+									],
+									"query": [
+										{
+											"key": "limit",
+											"value": "wrong"
+										},
+										{
+											"key": "active",
+											"value": "wrong"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "with both filters and invalid payload",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"name\": \"John\",\n    \"age\": \"wrong\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "127.0.0.1:8080/optional?limit=1&active=true",
+									"host": [
+										"127",
+										"0",
+										"0",
+										"1"
+									],
+									"port": "8080",
+									"path": [
+										"optional"
+									],
+									"query": [
+										{
+											"key": "limit",
+											"value": "1"
+										},
+										{
+											"key": "active",
+											"value": "true"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "with both invalid filters and invalid payload",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"name\": \"John\",\n    \"age\": \"wrong\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "127.0.0.1:8080/optional?limit=wrong&active=wrong",
+									"host": [
+										"127",
+										"0",
+										"0",
+										"1"
+									],
+									"port": "8080",
+									"path": [
+										"optional"
+									],
+									"query": [
+										{
+											"key": "limit",
+											"value": "wrong"
+										},
+										{
+											"key": "active",
+											"value": "wrong"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "mandatory filters and payload",
+					"item": [
+						{
+							"name": "without filters",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"name\": \"John\",\n    \"age\": 13\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "127.0.0.1:8080/mandatory",
+									"host": [
+										"127",
+										"0",
+										"0",
+										"1"
+									],
+									"port": "8080",
+									"path": [
+										"mandatory"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "with a single filter",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"name\": \"John\",\n    \"age\": 13\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "127.0.0.1:8080/mandatory?limit=1",
+									"host": [
+										"127",
+										"0",
+										"0",
+										"1"
+									],
+									"port": "8080",
+									"path": [
+										"mandatory"
+									],
+									"query": [
+										{
+											"key": "limit",
+											"value": "1"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "with both filters",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"name\": \"John\",\n    \"age\": 13\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "127.0.0.1:8080/mandatory?limit=1&active=true",
+									"host": [
+										"127",
+										"0",
+										"0",
+										"1"
+									],
+									"port": "8080",
+									"path": [
+										"mandatory"
+									],
+									"query": [
+										{
+											"key": "limit",
+											"value": "1"
+										},
+										{
+											"key": "active",
+											"value": "true"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "with a single invalid filter",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"name\": \"John\",\n    \"age\": 13\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "127.0.0.1:8080/mandatory?limit=wrong&active=true",
+									"host": [
+										"127",
+										"0",
+										"0",
+										"1"
+									],
+									"port": "8080",
+									"path": [
+										"mandatory"
+									],
+									"query": [
+										{
+											"key": "limit",
+											"value": "wrong"
+										},
+										{
+											"key": "active",
+											"value": "true"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "with both invalid filters",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"name\": \"John\",\n    \"age\": 13\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "127.0.0.1:8080/mandatory?limit=wrong&active=wrong",
+									"host": [
+										"127",
+										"0",
+										"0",
+										"1"
+									],
+									"port": "8080",
+									"path": [
+										"mandatory"
+									],
+									"query": [
+										{
+											"key": "limit",
+											"value": "wrong"
+										},
+										{
+											"key": "active",
+											"value": "wrong"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "with both filters and invalid payload",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"name\": \"John\",\n    \"age\": \"wrong\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "127.0.0.1:8080/mandatory?limit=1&active=true",
+									"host": [
+										"127",
+										"0",
+										"0",
+										"1"
+									],
+									"port": "8080",
+									"path": [
+										"mandatory"
+									],
+									"query": [
+										{
+											"key": "limit",
+											"value": "1"
+										},
+										{
+											"key": "active",
+											"value": "true"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "with both invalid filters and invalid payload",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"name\": \"John\",\n    \"age\": \"wrong\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "127.0.0.1:8080/mandatory?limit=wrong&active=wrong",
+									"host": [
+										"127",
+										"0",
+										"0",
+										"1"
+									],
+									"port": "8080",
+									"path": [
+										"mandatory"
+									],
+									"query": [
+										{
+											"key": "limit",
+											"value": "wrong"
+										},
+										{
+											"key": "active",
+											"value": "wrong"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				}
+			]
+		}
+	]
+}

--- a/actix-web/src/types/mod.rs
+++ b/actix-web/src/types/mod.rs
@@ -21,3 +21,11 @@ pub use self::{
     query::{Query, QueryConfig},
     readlines::Readlines,
 };
+
+#[cfg(feature = "beautify-errors")]
+pub fn map_deserialize_error(field: &str, original: &str) -> String {
+    if field == "." {
+        return original.to_string();
+    }
+    format!("'{}': {}", field, original)
+}

--- a/actix-web/src/types/query.rs
+++ b/actix-web/src/types/query.rs
@@ -88,10 +88,7 @@ impl<T: DeserializeOwned> Query<T> {
             .map_err(QueryPayloadError::Deserialize)
     }
     #[cfg(feature = "beautify-errors")]
-    pub fn from_query(query_str: &str) -> Result<Self, QueryPayloadError>
-    where
-        T: de::DeserializeOwned,
-    {
+    pub fn from_query(query_str: &str) -> Result<Self, QueryPayloadError> {
         let deserializer = serde_urlencoded::Deserializer::new(parse(query_str.as_bytes()));
         let qs = serde_path_to_error::deserialize(deserializer)
             .map(Self)


### PR DESCRIPTION
## PR Type
Feature (minor)

## PR Checklist
This PR is so far, a proof-of-concept, I'd rather wait for some guidance regarding tests especially.
I'll gladly add the missing parts as requested.

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
Currently, when deserialization error happens in either [Json](https://docs.rs/actix-web/4.0.0-beta.8/actix_web/web/struct.Json.html) or [Query](https://docs.rs/actix-web/4.0.0-beta.8/actix_web/web/struct.Query.html), there's no hint at the field which caused it.

As of now, given an expected **limit** `i32` field in query string parameters, and provided with an incorrect `String` :
e.g. *Query deserialize error: invalid digit found in string*

This PR add a new feature `beautify-errors` (actix contributors please suggest a better name, and if a feature is the right solution), which will turn the same error out to :
e.g. *Query deserialize error: 'limit': invalid digit found in string*

Not sure if this closes issue(s) or not.
