### PR TITLE
add ability for condition middleware to consume an option and future

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@
 ### Changed
 * Associated type `FromRequest::Config` was removed. [#2233]
 * Inner field made private on `web::Payload`. [#2384]
-* `middleware::Condition::new` was removed in favour of `middleware::conditionally` 
+* `middleware::Condition::new` was deprecated in favour of `middleware::conditionally` 
 
 [#2233]: https://github.com/actix/actix-web/pull/2233
 [#2362]: https://github.com/actix/actix-web/pull/2362

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,10 +3,12 @@
 ## Unreleased - 2021-xx-xx
 ### Added
 * Option to allow `Json` extractor to work without a `Content-Type` header present. [#2362]
+* New construction possiblity for the `Condition` middleware using `middleware::conditionally`, `middleware::optionally`, `middleware::optionally_fut`, `middleware::futurally`
 
 ### Changed
 * Associated type `FromRequest::Config` was removed. [#2233]
 * Inner field made private on `web::Payload`. [#2384]
+* `middleware::Condition::new` was removed in favour of `middleware::conditionally` 
 
 [#2233]: https://github.com/actix/actix-web/pull/2233
 [#2362]: https://github.com/actix/actix-web/pull/2362

--- a/src/middleware/compat.rs
+++ b/src/middleware/compat.rs
@@ -139,7 +139,7 @@ mod tests {
 
     use crate::dev::ServiceRequest;
     use crate::http::StatusCode;
-    use crate::middleware::{self, Condition, Logger};
+    use crate::middleware::{self, conditionally, Condition, Logger};
     use crate::test::{call_service, init_service, TestRequest};
     use crate::{web, App, HttpResponse};
 
@@ -199,7 +199,7 @@ mod tests {
 
         let logger = Logger::default();
 
-        let mw = Condition::new(true, Compat::new(logger))
+        let mw = conditionally(true, Compat::new(logger))
             .new_transform(srv.into_service())
             .await
             .unwrap();

--- a/src/middleware/condition.rs
+++ b/src/middleware/condition.rs
@@ -31,7 +31,7 @@ use std::sync::Mutex;
 ///     .wrap(conditionally(enable_normalize, NormalizePath::default()))
 ///     .wrap(optionally(config_opt, |mode| NormalizePath::new(mode)))
 ///     .wrap(optionally_fut(config_opt_future, |mode| NormalizePath::new(mode)))
-///     .wrap(Condition::new(future));
+///     .wrap(futurally(future));
 /// ```
 
 pub struct Condition<T, F>(Rc<Mutex<F>>)

--- a/src/middleware/condition.rs
+++ b/src/middleware/condition.rs
@@ -18,7 +18,7 @@ use std::sync::Mutex;
 ///
 /// # Examples
 /// ```
-/// use actix_web::middleware::{Condition, NormalizePath, TrailingSlash, conditionally, optionally, optionally_fut};
+/// use actix_web::middleware::{Condition, NormalizePath, TrailingSlash, conditionally, optionally, optionally_fut, futurally};
 /// use actix_web::App;
 /// use std::future::ready;
 ///
@@ -37,6 +37,13 @@ use std::sync::Mutex;
 pub struct Condition<T, F>(Rc<Mutex<F>>)
 where
     F: Future<Output = Option<T>> + Unpin + 'static;
+
+impl<T> Condition<T, Ready<Option<T>>> {
+    #[deprecated(since = "4.0.0", note = "Use middleware::conditionally instead")]
+    pub fn new(enable: bool, transformer: T) -> Self {
+        conditionally(enable, transformer)
+    }
+}
 
 pub fn futurally<T, F>(transformer: F) -> Condition<T, F>
 where

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -8,6 +8,10 @@ mod logger;
 mod normalize;
 
 pub use self::compat::Compat;
+pub use self::condition::conditionally;
+pub use self::condition::futurally;
+pub use self::condition::optionally;
+pub use self::condition::optionally_fut;
 pub use self::condition::Condition;
 pub use self::default_headers::DefaultHeaders;
 pub use self::err_handlers::{ErrorHandlerResponse, ErrorHandlers};
@@ -25,6 +29,7 @@ mod tests {
     use crate::{http::StatusCode, App};
 
     use super::*;
+    use crate::middleware::conditionally;
 
     #[test]
     fn common_combinations() {
@@ -32,7 +37,7 @@ mod tests {
 
         let _ = App::new()
             .wrap(Compat::new(Logger::default()))
-            .wrap(Condition::new(true, DefaultHeaders::new()))
+            .wrap(conditionally(true, DefaultHeaders::new()))
             .wrap(DefaultHeaders::new().header("X-Test2", "X-Value2"))
             .wrap(ErrorHandlers::new().handler(StatusCode::FORBIDDEN, |res| {
                 Ok(ErrorHandlerResponse::Response(res))
@@ -47,7 +52,7 @@ mod tests {
                 Ok(ErrorHandlerResponse::Response(res))
             }))
             .wrap(DefaultHeaders::new().header("X-Test2", "X-Value2"))
-            .wrap(Condition::new(true, DefaultHeaders::new()))
+            .wrap(conditionally(true, DefaultHeaders::new()))
             .wrap(Compat::new(Logger::default()));
 
         #[cfg(feature = "__compress")]
@@ -55,7 +60,7 @@ mod tests {
             let _ = App::new().wrap(Compress::default()).wrap(Logger::default());
             let _ = App::new().wrap(Logger::default()).wrap(Compress::default());
             let _ = App::new().wrap(Compat::new(Compress::default()));
-            let _ = App::new().wrap(Condition::new(true, Compat::new(Compress::default())));
+            let _ = App::new().wrap(conditionally(true, Compat::new(Compress::default())));
         }
     }
 }


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
FEATURE

## PR Checklist
<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview

Currently `middleware::Condition` only supports receiving a boolean and a middleware to be turned on or off based on the value of the supplied enable flag.

The PR adds more flexibility to construct the middleware to be enabled / disabled based on the value of an `Option`, or even a `Future` value. Thus if the `Option` is `None`, no middleware is added, if the value is `Some(value)`, then that value is supplied to an `FnOnce` to construct the middleware to be added. This is useful when the user wants to turn off the configuration parameters for a middleware if they are not available.


```
/// use actix_web::middleware::{Condition, NormalizePath, TrailingSlash, conditionally, optionally, optionally_fut, futurally};
/// use actix_web::App;
/// use std::future::ready;
///
/// let enable_normalize = std::env::var("NORMALIZE_PATH").is_ok();
/// let config_opt = Some(TrailingSlash::Trim);
/// let config_opt_future = ready(Some(TrailingSlash::Always));
/// let future = ready(Some(NormalizePath::new(TrailingSlash::MergeOnly)));
///
/// let app = App::new()
///     .wrap(conditionally(enable_normalize, NormalizePath::default()))
///     .wrap(optionally(config_opt, |mode| NormalizePath::new(mode)))
///     .wrap(optionally_fut(config_opt_future, |mode| NormalizePath::new(mode)))
///     .wrap(futurally(future));
```

No breaking changes

The type parameter restrictions are probably overly redundant, please feel free to suggest a fix, I'm still trying to wrap (ha!) my head around when they are needed and when and where can they be omitted.