### PR TITLE
Replace askama_escape in favor of v_htmlescape

### DIFF
--- a/actix-files/CHANGES.md
+++ b/actix-files/CHANGES.md
@@ -1,7 +1,7 @@
 # Changes
 
 ## Unreleased - 2021-xx-xx
-
+* Replace `askama_escape` with `v_htmlescape`
 
 ## 0.6.0-beta.7 - 2021-09-09
 * Minimum supported Rust version (MSRV) is now 1.51.

--- a/actix-files/Cargo.toml
+++ b/actix-files/Cargo.toml
@@ -20,7 +20,6 @@ actix-http = "3.0.0-beta.10"
 actix-service = "2.0.0"
 actix-utils = "3.0.0"
 
-askama_escape = "0.10"
 bitflags = "1"
 bytes = "1"
 futures-core = { version = "0.3.7", default-features = false, features = ["alloc"] }
@@ -30,6 +29,7 @@ log = "0.4"
 mime = "0.3"
 mime_guess = "2.0.1"
 percent-encoding = "2.1"
+v_htmlescape = "0.14"
 
 [dev-dependencies]
 actix-rt = "2.2"

--- a/actix-files/src/directory.rs
+++ b/actix-files/src/directory.rs
@@ -1,8 +1,8 @@
 use std::{fmt::Write, fs::DirEntry, io, path::Path, path::PathBuf};
 
 use actix_web::{dev::ServiceResponse, HttpRequest, HttpResponse};
-use askama_escape::{escape as escape_html_entity, Html};
 use percent_encoding::{utf8_percent_encode, CONTROLS};
+use v_htmlescape::escape as escape_html_entity;
 
 /// A directory; responds with the generated directory listing.
 #[derive(Debug)]
@@ -50,7 +50,7 @@ macro_rules! encode_file_url {
 // " -- &quot;  & -- &amp;  ' -- &#x27;  < -- &lt;  > -- &gt;  / -- &#x2f;
 macro_rules! encode_file_name {
     ($entry:ident) => {
-        escape_html_entity(&$entry.file_name().to_string_lossy(), Html)
+        escape_html_entity(&$entry.file_name().to_string_lossy())
     };
 }
 


### PR DESCRIPTION
## PR Type
Refactor/Other

## PR Checklist
* [x]  A changelog entry has been made for the appropriate packages.
* [x]  Format code with the latest stable rustfmt.
* [x]  (Team) Label with affected crates and semver status.
  
## Overview
I have already uncoupled the crates `bytes` from `v_escape`. This version is several times faster as it is optimized with SIMD instructions.
