### PR TITLE
web: implement `into_inner` for `Data<T: ?Sized>`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 ### Changed
 * Associated type `FromRequest::Config` was removed. [#2233]
 * Inner field made private on `web::Payload`. [#2384]
+* `Data::into_inner` and `Data::get_ref` no longer require T: Sized. [#2403]
 
 ### Removed
 * `ServiceResponse::checked_expr` was a legacy and just removed. [#2401]

--- a/src/data.rs
+++ b/src/data.rs
@@ -306,4 +306,38 @@ mod tests {
         let data_arc = Data::from(dyn_arc);
         assert_eq!(data_arc_box.get_num(), data_arc.get_num())
     }
+
+    #[actix_rt::test]
+    async fn test_dyn_data_into_arc() {
+        trait TestTrait {
+            fn get_num(&self) -> i32;
+        }
+        struct A {}
+        impl TestTrait for A {
+            fn get_num(&self) -> i32 {
+                42
+            }
+        }
+        let dyn_arc: Arc<dyn TestTrait> = Arc::new(A {});
+        let data_arc = Data::from(dyn_arc);
+        let arc_from_data = data_arc.clone().into_inner();
+        assert_eq!(data_arc.get_num(), arc_from_data.get_num())
+    }
+
+    #[actix_rt::test]
+    async fn test_get_ref_from_dyn_data() {
+        trait TestTrait {
+            fn get_num(&self) -> i32;
+        }
+        struct A {}
+        impl TestTrait for A {
+            fn get_num(&self) -> i32 {
+                42
+            }
+        }
+        let dyn_arc: Arc<dyn TestTrait> = Arc::new(A {});
+        let data_arc = Data::from(dyn_arc);
+        let ref_data = data_arc.get_ref();
+        assert_eq!(data_arc.get_num(), ref_data.get_num())
+    }
 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -75,7 +75,9 @@ impl<T> Data<T> {
     pub fn new(state: T) -> Data<T> {
         Data(Arc::new(state))
     }
+}
 
+impl<T: ?Sized> Data<T> {
     /// Get reference to inner app data.
     pub fn get_ref(&self) -> &T {
         self.0.as_ref()


### PR DESCRIPTION
## PR Type
Feature


## PR Checklist
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
Closes #2403 
