### PR TITLE
copy original route macro input with compile errors

### DIFF
--- a/actix-web-codegen/CHANGES.md
+++ b/actix-web-codegen/CHANGES.md
@@ -1,6 +1,9 @@
 # Changes
 
 ## Unreleased - 2021-xx-xx
+* Improve error recovery potential when macro input is invalid. [#2410]
+
+[#2410]: https://github.com/actix/actix-web/pull/2410
 
 
 ## 0.5.0-beta.4 - 2021-09-09

--- a/actix-web-codegen/Cargo.toml
+++ b/actix-web-codegen/Cargo.toml
@@ -21,6 +21,7 @@ actix-router = "0.5.0-beta.2"
 
 [dev-dependencies]
 actix-rt = "2.2"
+actix-macros = "0.2.2"
 actix-test = "0.1.0-beta.3"
 actix-utils = "3.0.0"
 actix-web = "4.0.0-beta.9"

--- a/actix-web-codegen/src/route.rs
+++ b/actix-web-codegen/src/route.rs
@@ -349,8 +349,21 @@ pub(crate) fn with_method(
     input: TokenStream,
 ) -> TokenStream {
     let args = parse_macro_input!(args as syn::AttributeArgs);
-    match Route::new(args, input, method) {
+    match Route::new(args, input.clone(), method) {
         Ok(route) => route.into_token_stream().into(),
-        Err(err) => err.to_compile_error().into(),
+        // on parse err, make IDEs happy; see fn docs
+        Err(err) => input_and_compile_error(input, err),
     }
+}
+
+/// Converts the error to a token stream and appends it to the original input.
+///
+/// Returning the original input in addition to the error is good for IDEs which can gracefully
+/// recover and show more precise errors within the macro body.
+///
+/// See <https://github.com/rust-analyzer/rust-analyzer/issues/10468> for more info.
+fn input_and_compile_error(mut item: TokenStream, err: syn::Error) -> TokenStream {
+    let compile_err = TokenStream::from(err.to_compile_error());
+    item.extend(compile_err);
+    return item;
 }

--- a/actix-web-codegen/tests/trybuild/route-duplicate-method-fail.stderr
+++ b/actix-web-codegen/tests/trybuild/route-duplicate-method-fail.stderr
@@ -4,8 +4,8 @@ error: HTTP method defined more than once: `GET`
 3 | #[route("/", method="GET", method="GET")]
   |                                   ^^^^^
 
-error[E0425]: cannot find value `index` in this scope
+error[E0277]: the trait bound `fn() -> impl std::future::Future {index}: HttpServiceFactory` is not satisfied
   --> $DIR/route-duplicate-method-fail.rs:12:55
    |
 12 |     let srv = actix_test::start(|| App::new().service(index));
-   |                                                       ^^^^^ not found in this scope
+   |                                                       ^^^^^ the trait `HttpServiceFactory` is not implemented for `fn() -> impl std::future::Future {index}`

--- a/actix-web-codegen/tests/trybuild/route-missing-method-fail.stderr
+++ b/actix-web-codegen/tests/trybuild/route-missing-method-fail.stderr
@@ -6,8 +6,8 @@ error: The #[route(..)] macro requires at least one `method` attribute
   |
   = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0425]: cannot find value `index` in this scope
+error[E0277]: the trait bound `fn() -> impl std::future::Future {index}: HttpServiceFactory` is not satisfied
   --> $DIR/route-missing-method-fail.rs:12:55
    |
 12 |     let srv = actix_test::start(|| App::new().service(index));
-   |                                                       ^^^^^ not found in this scope
+   |                                                       ^^^^^ the trait `HttpServiceFactory` is not implemented for `fn() -> impl std::future::Future {index}`

--- a/actix-web-codegen/tests/trybuild/route-unexpected-method-fail.stderr
+++ b/actix-web-codegen/tests/trybuild/route-unexpected-method-fail.stderr
@@ -4,8 +4,8 @@ error: Unexpected HTTP method: `UNEXPECTED`
 3 | #[route("/", method="UNEXPECTED")]
   |                     ^^^^^^^^^^^^
 
-error[E0425]: cannot find value `index` in this scope
+error[E0277]: the trait bound `fn() -> impl std::future::Future {index}: HttpServiceFactory` is not satisfied
   --> $DIR/route-unexpected-method-fail.rs:12:55
    |
 12 |     let srv = actix_test::start(|| App::new().service(index));
-   |                                                       ^^^^^ not found in this scope
+   |                                                       ^^^^^ the trait `HttpServiceFactory` is not implemented for `fn() -> impl std::future::Future {index}`


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Fix


## PR Checklist
<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
Same purpose as https://github.com/actix/actix-net/pull/391.

Compile error output has changed now that the original code is actually output and, therefore, the emitted handlers do not impl `HttpServiceFactory`.

Closes #2394
