### PR TITLE
move actix_http::client module to awc

### DIFF
--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -1,6 +1,11 @@
 # Changes
 
 ## Unreleased - 2021-xx-xx
+### Removed
+* `client` module. [#2425]
+* `trust-dns` feature. [#2425]
+
+[#2425]: https://github.com/actix/actix-web/pull/2425
 
 
 ## 3.0.0-beta.11 - 2021-10-20

--- a/actix-http/Cargo.toml
+++ b/actix-http/Cargo.toml
@@ -37,9 +37,6 @@ compress-brotli = ["brotli2", "__compress"]
 compress-gzip = ["flate2", "__compress"]
 compress-zstd = ["zstd", "__compress"]
 
-# trust-dns as client dns resolver
-trust-dns = ["trust-dns-resolver"]
-
 # Internal (PRIVATE!) features used to aid testing and cheking feature status.
 # Don't rely on these whatsoever. They may disappear at anytime.
 __compress = []
@@ -49,7 +46,7 @@ actix-service = "2.0.0"
 actix-codec = "0.4.0"
 actix-utils = "3.0.0"
 actix-rt = "2.2"
-actix-tls = { version = "3.0.0-beta.7", features = ["accept", "connect"] }
+actix-tls = { version = "3.0.0-beta.7", features = ["accept"] }
 
 ahash = "0.7"
 base64 = "0.13"
@@ -81,8 +78,6 @@ tokio = { version = "1.2", features = ["sync"] }
 brotli2 = { version="0.3.2", optional = true }
 flate2 = { version = "1.0.13", optional = true }
 zstd = { version = "0.7", optional = true }
-
-trust-dns-resolver = { version = "0.20.0", optional = true }
 
 [dev-dependencies]
 actix-server = "2.0.0-beta.3"

--- a/actix-http/src/lib.rs
+++ b/actix-http/src/lib.rs
@@ -29,7 +29,6 @@ extern crate log;
 
 pub mod body;
 mod builder;
-pub mod client;
 mod config;
 
 #[cfg(feature = "__compress")]

--- a/actix-test/Cargo.toml
+++ b/actix-test/Cargo.toml
@@ -22,10 +22,10 @@ edition = "2018"
 default = []
 
 # rustls
-rustls = ["tls-rustls", "actix-http/rustls"]
+rustls = ["tls-rustls", "actix-http/rustls", "awc/rustls"]
 
 # openssl
-openssl = ["tls-openssl", "actix-http/openssl"]
+openssl = ["tls-openssl", "actix-http/openssl", "awc/openssl"]
 
 [dependencies]
 actix-codec = "0.4.0"

--- a/awc/Cargo.toml
+++ b/awc/Cargo.toml
@@ -30,10 +30,10 @@ features = ["openssl", "rustls", "compress-brotli", "compress-gzip", "compress-z
 default = ["compress-brotli", "compress-gzip", "compress-zstd", "cookies"]
 
 # openssl
-openssl = ["tls-openssl", "actix-http/openssl"]
+openssl = ["tls-openssl", "actix-tls/openssl"]
 
 # rustls
-rustls = ["tls-rustls", "actix-http/rustls"]
+rustls = ["tls-rustls", "actix-tls/rustls"]
 
 # Brotli algorithm content-encoding support
 compress-brotli = ["actix-http/compress-brotli", "__compress"]
@@ -46,7 +46,7 @@ compress-zstd = ["actix-http/compress-zstd", "__compress"]
 cookies = ["cookie"]
 
 # trust-dns as dns resolver
-trust-dns = ["actix-http/trust-dns"]
+trust-dns = ["trust-dns-resolver"]
 
 # Internal (PRIVATE!) features used to aid testing and cheking feature status.
 # Don't rely on these whatsoever. They may disappear at anytime.
@@ -57,13 +57,18 @@ actix-codec = "0.4.0"
 actix-service = "2.0.0"
 actix-http = "3.0.0-beta.11"
 actix-rt = { version = "2.1", default-features = false }
+actix-tls = { version = "3.0.0-beta.7", features = ["connect"] }
+actix-utils = "3.0.0"
 
+ahash = "0.7"
 base64 = "0.13"
 bytes = "1"
 cfg-if = "1"
-cookie = { version = "0.15", features = ["percent-encode"], optional = true }
 derive_more = "0.99.5"
 futures-core = { version = "0.3.7", default-features = false }
+futures-util = { version = "0.3.7", default-features = false }
+h2 = "0.3"
+http = "0.2"
 itoa = "0.4"
 log =" 0.4"
 mime = "0.3"
@@ -73,8 +78,14 @@ rand = "0.8"
 serde = "1.0"
 serde_json = "1.0"
 serde_urlencoded = "0.7"
+tokio = { version = "1", features = ["sync"] }
+
+cookie = { version = "0.15", features = ["percent-encode"], optional = true }
+
 tls-openssl = { package = "openssl", version = "0.10.9", optional = true }
 tls-rustls = { package = "rustls", version = "0.20.0", optional = true, features = ["dangerous_configuration"] }
+
+trust-dns-resolver = { version = "0.20.0", optional = true }
 
 [dev-dependencies]
 actix-web = { version = "4.0.0-beta.10", features = ["openssl"] }

--- a/awc/src/builder.rs
+++ b/awc/src/builder.rs
@@ -4,13 +4,11 @@ use std::net::IpAddr;
 use std::rc::Rc;
 use std::time::Duration;
 
-use actix_http::{
-    client::{Connector, ConnectorService, TcpConnect, TcpConnectError, TcpConnection},
-    http::{self, header, Error as HttpError, HeaderMap, HeaderName, Uri},
-};
+use actix_http::http::{self, header, Error as HttpError, HeaderMap, HeaderName, Uri};
 use actix_rt::net::{ActixStream, TcpStream};
 use actix_service::{boxed, Service};
 
+use crate::client::{Connector, ConnectorService, TcpConnect, TcpConnectError, TcpConnection};
 use crate::connect::DefaultConnector;
 use crate::error::SendRequestError;
 use crate::middleware::{NestTransform, Redirect, Transform};

--- a/awc/src/client/config.rs
+++ b/awc/src/client/config.rs
@@ -1,5 +1,4 @@
-use std::net::IpAddr;
-use std::time::Duration;
+use std::{net::IpAddr, time::Duration};
 
 const DEFAULT_H2_CONN_WINDOW: u32 = 1024 * 1024 * 2; // 2MB
 const DEFAULT_H2_STREAM_WINDOW: u32 = 1024 * 1024; // 1MB

--- a/awc/src/client/error.rs
+++ b/awc/src/client/error.rs
@@ -2,11 +2,12 @@ use std::{error::Error as StdError, fmt, io};
 
 use derive_more::{Display, From};
 
+use actix_http::{
+    error::{Error, ParseError},
+    http::Error as HttpError,
+};
 #[cfg(feature = "openssl")]
 use actix_tls::accept::openssl::SslError;
-
-use crate::error::{Error, ParseError};
-use crate::http::Error as HttpError;
 
 /// A set of errors that can occur while connecting to an HTTP host
 #[derive(Debug, Display, From)]

--- a/awc/src/client/h2proto.rs
+++ b/awc/src/client/h2proto.rs
@@ -8,13 +8,12 @@ use h2::{
 };
 use http::header::{HeaderValue, CONNECTION, CONTENT_LENGTH, TRANSFER_ENCODING};
 use http::{request::Request, Method, Version};
+use log::trace;
 
-use crate::{
+use actix_http::{
     body::{BodySize, MessageBody},
     header::HeaderMap,
-    message::{RequestHeadType, ResponseHead},
-    payload::Payload,
-    Error,
+    Error, Payload, RequestHeadType, ResponseHead,
 };
 
 use super::{
@@ -131,10 +130,7 @@ where
     Ok((head, payload))
 }
 
-async fn send_body<B>(
-    body: B,
-    mut send: SendStream<Bytes>,
-) -> Result<(), SendRequestError>
+async fn send_body<B>(body: B, mut send: SendStream<Bytes>) -> Result<(), SendRequestError>
 where
     B: MessageBody,
     B::Error: Into<Error>,
@@ -184,8 +180,7 @@ where
 pub(crate) fn handshake<Io: ConnectionIo>(
     io: Io,
     config: &ConnectorConfig,
-) -> impl Future<Output = Result<(SendRequest<Bytes>, Connection<Io, Bytes>), h2::Error>>
-{
+) -> impl Future<Output = Result<(SendRequest<Bytes>, Connection<Io, Bytes>), h2::Error>> {
     let mut builder = Builder::new();
     builder
         .initial_window_size(config.stream_window_size)

--- a/awc/src/client/mod.rs
+++ b/awc/src/client/mod.rs
@@ -17,7 +17,6 @@ pub use actix_tls::connect::{
 pub use self::connection::{Connection, ConnectionIo};
 pub use self::connector::{Connector, ConnectorService};
 pub use self::error::{ConnectError, FreezeRequestError, InvalidUrl, SendRequestError};
-pub use crate::Protocol;
 
 #[derive(Clone)]
 pub struct Connect {

--- a/awc/src/client/pool.rs
+++ b/awc/src/client/pool.rs
@@ -14,22 +14,20 @@ use std::{
 };
 
 use actix_codec::{AsyncRead, AsyncWrite, ReadBuf};
+use actix_http::Protocol;
 use actix_rt::time::{sleep, Sleep};
 use actix_service::Service;
 use ahash::AHashMap;
 use futures_core::future::LocalBoxFuture;
 use http::uri::Authority;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 
 use super::config::ConnectorConfig;
-use super::connection::{
-    ConnectionInnerType, ConnectionIo, ConnectionType, H2ConnectionInner,
-};
+use super::connection::{ConnectionInnerType, ConnectionIo, ConnectionType, H2ConnectionInner};
 use super::error::ConnectError;
 use super::h2proto::handshake;
 use super::Connect;
-use super::Protocol;
 
 #[derive(Hash, Eq, PartialEq, Clone, Debug)]
 pub struct Key {
@@ -152,9 +150,7 @@ where
 
 impl<S, Io> Service<Connect> for ConnectionPool<S, Io>
 where
-    S: Service<Connect, Response = (Io, Protocol), Error = ConnectError>
-        + Clone
-        + 'static,
+    S: Service<Connect, Response = (Io, Protocol), Error = ConnectError> + Clone + 'static,
     Io: ConnectionIo,
 {
     type Response = ConnectionType<Io>;
@@ -195,8 +191,8 @@ where
                         let config = &inner.config;
                         let idle_dur = now - c.used;
                         let age = now - c.created;
-                        let conn_ineligible = idle_dur > config.conn_keep_alive
-                            || age > config.conn_lifetime;
+                        let conn_ineligible =
+                            idle_dur > config.conn_keep_alive || age > config.conn_lifetime;
 
                         if conn_ineligible {
                             // drop connections that are too old
@@ -231,9 +227,7 @@ where
 
             // match the connection and spawn new one if did not get anything.
             match conn {
-                Some(conn) => {
-                    Ok(ConnectionType::from_pool(conn.conn, conn.created, acquired))
-                }
+                Some(conn) => Ok(ConnectionType::from_pool(conn.conn, conn.created, acquired)),
                 None => {
                     let (io, proto) = connector.call(req).await?;
 
@@ -284,9 +278,7 @@ where
         let mut read_buf = ReadBuf::new(&mut buf);
 
         let state = match Pin::new(&mut this.io).poll_read(cx, &mut read_buf) {
-            Poll::Ready(Ok(())) if !read_buf.filled().is_empty() => {
-                ConnectionState::Tainted
-            }
+            Poll::Ready(Ok(())) if !read_buf.filled().is_empty() => ConnectionState::Tainted,
 
             Poll::Pending => ConnectionState::Live,
             _ => ConnectionState::Skip,
@@ -302,11 +294,13 @@ struct PooledConnection<Io> {
     created: Instant,
 }
 
-#[pin_project]
-struct CloseConnection<Io> {
-    io: Io,
-    #[pin]
-    timeout: Sleep,
+pin_project! {
+    #[project = CloseConnectionProj]
+    struct CloseConnection<Io> {
+        io: Io,
+        #[pin]
+        timeout: Sleep,
+    }
 }
 
 impl<Io> CloseConnection<Io>
@@ -413,17 +407,11 @@ mod test {
             unimplemented!()
         }
 
-        fn poll_flush(
-            self: Pin<&mut Self>,
-            _: &mut Context<'_>,
-        ) -> Poll<io::Result<()>> {
+        fn poll_flush(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {
             unimplemented!()
         }
 
-        fn poll_shutdown(
-            self: Pin<&mut Self>,
-            _: &mut Context<'_>,
-        ) -> Poll<io::Result<()>> {
+        fn poll_shutdown(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {
             Poll::Ready(Ok(()))
         }
     }

--- a/awc/src/connect.rs
+++ b/awc/src/connect.rs
@@ -8,16 +8,14 @@ use std::{
 
 use actix_codec::Framed;
 use actix_http::{
-    body::Body,
-    client::{
-        Connect as ClientConnect, ConnectError, Connection, ConnectionIo, SendRequestError,
-    },
-    h1::ClientCodec,
-    Payload, RequestHead, RequestHeadType, ResponseHead,
+    body::Body, h1::ClientCodec, Payload, RequestHead, RequestHeadType, ResponseHead,
 };
 use actix_service::Service;
 use futures_core::{future::LocalBoxFuture, ready};
 
+use crate::client::{
+    Connect as ClientConnect, ConnectError, Connection, ConnectionIo, SendRequestError,
+};
 use crate::response::ClientResponse;
 
 pub type BoxConnectorService = Rc<

--- a/awc/src/error.rs
+++ b/awc/src/error.rs
@@ -1,15 +1,15 @@
 //! HTTP client errors
 
-pub use actix_http::client::{ConnectError, FreezeRequestError, InvalidUrl, SendRequestError};
-pub use actix_http::error::PayloadError;
-pub use actix_http::http::Error as HttpError;
-pub use actix_http::ws::HandshakeError as WsHandshakeError;
-pub use actix_http::ws::ProtocolError as WsProtocolError;
+pub use actix_http::{
+    error::PayloadError,
+    http::{header::HeaderValue, Error as HttpError, StatusCode},
+    ws::{HandshakeError as WsHandshakeError, ProtocolError as WsProtocolError},
+};
 
+use derive_more::{Display, From};
 use serde_json::error::Error as JsonError;
 
-use actix_http::http::{header::HeaderValue, StatusCode};
-use derive_more::{Display, From};
+pub use crate::client::{ConnectError, FreezeRequestError, InvalidUrl, SendRequestError};
 
 /// Websocket client error
 #[derive(Debug, Display, From)]

--- a/awc/src/lib.rs
+++ b/awc/src/lib.rs
@@ -104,22 +104,8 @@
 #![doc(html_logo_url = "https://actix.rs/img/logo.png")]
 #![doc(html_favicon_url = "https://actix.rs/favicon.ico")]
 
-use std::{convert::TryFrom, rc::Rc, time::Duration};
-
-#[cfg(feature = "cookies")]
-pub use cookie;
-
-pub use actix_http::{client::Connector, http};
-
-use actix_http::{
-    client::{TcpConnect, TcpConnectError, TcpConnection},
-    http::{Error as HttpError, HeaderMap, Method, Uri},
-    RequestHead,
-};
-use actix_rt::net::TcpStream;
-use actix_service::Service;
-
 mod builder;
+mod client;
 mod connect;
 pub mod error;
 mod frozen;
@@ -130,12 +116,28 @@ mod sender;
 pub mod test;
 pub mod ws;
 
+pub use actix_http::http;
+#[cfg(feature = "cookies")]
+pub use cookie;
+
 pub use self::builder::ClientBuilder;
+pub use self::client::Connector;
 pub use self::connect::{BoxConnectorService, BoxedSocket, ConnectRequest, ConnectResponse};
 pub use self::frozen::{FrozenClientRequest, FrozenSendBuilder};
 pub use self::request::ClientRequest;
 pub use self::response::{ClientResponse, JsonBody, MessageBody};
 pub use self::sender::SendClientRequest;
+
+use std::{convert::TryFrom, rc::Rc, time::Duration};
+
+use actix_http::{
+    http::{Error as HttpError, HeaderMap, Method, Uri},
+    RequestHead,
+};
+use actix_rt::net::TcpStream;
+use actix_service::Service;
+
+use self::client::{TcpConnect, TcpConnectError, TcpConnection};
 
 /// An asynchronous HTTP and WebSocket client.
 ///

--- a/awc/src/middleware/redirect.rs
+++ b/awc/src/middleware/redirect.rs
@@ -9,7 +9,6 @@ use std::{
 
 use actix_http::{
     body::Body,
-    client::{InvalidUrl, SendRequestError},
     http::{header, Method, StatusCode, Uri},
     RequestHead, RequestHeadType,
 };
@@ -19,6 +18,7 @@ use futures_core::ready;
 
 use super::Transform;
 
+use crate::client::{InvalidUrl, SendRequestError};
 use crate::connect::{ConnectRequest, ConnectResponse};
 use crate::ClientResponse;
 


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Refactor


## PR Checklist
<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Benefit is actix-http does not build with `trust-dns-resolver` crate and `actix-tls/connect` feature anymore.
awc does not build with `actix-http/openssl` and `actix-http/rustl`s features anymore (They both carry `actix-tls/accept` feature which is not used by awc in anyway)

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
