### PR TITLE
Bump `actix-codec` version, Reexport ConnectionIo

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@
 ## Unreleased - 2021-xx-xx
 ### Changed
 * `ContentType::html` now returns `Content-Type: text/html; charset=utf-8` instead of `Content-Type: text/html`.
-
+* Updated `actix-codec` to v0.4.1 [#2436]
 
 ## 4.0.0-beta.10 - 2021-10-20
 ### Added

--- a/actix-test/CHANGES.md
+++ b/actix-test/CHANGES.md
@@ -1,7 +1,8 @@
 # Changes
 
 ## Unreleased - 2021-xx-xx
-
+* Updated `actix-codec` to v0.4.1 
+[#2436]: https://github.com/actix/actix-web/pull/2436
 
 ## 0.1.0-beta.5 - 2021-10-20
 * Updated rustls to v0.20. [#2414]

--- a/actix-test/Cargo.toml
+++ b/actix-test/Cargo.toml
@@ -28,7 +28,7 @@ rustls = ["tls-rustls", "actix-http/rustls", "awc/rustls"]
 openssl = ["tls-openssl", "actix-http/openssl", "awc/openssl"]
 
 [dependencies]
-actix-codec = "0.4.0"
+actix-codec = "0.4.1"
 actix-http = "3.0.0-beta.11"
 actix-http-test = "3.0.0-beta.5"
 actix-service = "2.0.0"

--- a/actix-web-actors/CHANGES.md
+++ b/actix-web-actors/CHANGES.md
@@ -2,7 +2,8 @@
 
 ## Unreleased - 2021-xx-xx
 * Minimum supported Rust version (MSRV) is now 1.52.
-
+* Updated `actix-codec` to v0.4.1 
+[#2436]: https://github.com/actix/actix-web/pull/2436
 
 ## 4.0.0-beta.7 - 2021-09-09
 * Minimum supported Rust version (MSRV) is now 1.51.

--- a/actix-web-actors/Cargo.toml
+++ b/actix-web-actors/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/lib.rs"
 
 [dependencies]
 actix = { version = "0.12.0", default-features = false }
-actix-codec = "0.4.0"
+actix-codec = "0.4.1"
 actix-http = "3.0.0-beta.11"
 actix-web = { version = "4.0.0-beta.10", default-features = false }
 

--- a/awc/CHANGES.md
+++ b/awc/CHANGES.md
@@ -1,7 +1,9 @@
 # Changes
 
 ## Unreleased - 2021-xx-xx
-
+* Reexport ConnectionIo
+* Bump `actix-codec` version to 0.4.1
+[#2436]: https://github.com/actix/actix-web/pull/2436
 
 ## 3.0.0-beta.9 - 2021-10-20
 * Updated rustls to v0.20. [#2414]

--- a/awc/Cargo.toml
+++ b/awc/Cargo.toml
@@ -53,7 +53,7 @@ trust-dns = ["trust-dns-resolver"]
 __compress = []
 
 [dependencies]
-actix-codec = "0.4.0"
+actix-codec = "0.4.1"
 actix-service = "2.0.0"
 actix-http = "3.0.0-beta.11"
 actix-rt = { version = "2.1", default-features = false }

--- a/awc/src/lib.rs
+++ b/awc/src/lib.rs
@@ -121,7 +121,7 @@ pub use actix_http::http;
 pub use cookie;
 
 pub use self::builder::ClientBuilder;
-pub use self::client::Connector;
+pub use self::client::{ConnectionIo, Connector};
 pub use self::connect::{BoxConnectorService, BoxedSocket, ConnectRequest, ConnectResponse};
 pub use self::frozen::{FrozenClientRequest, FrozenSendBuilder};
 pub use self::request::ClientRequest;


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Other


## PR Checklist
<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [ ] (Team) Label with affected crates and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
During the refactor of moving `actix_http::client` over to `awc`, `ConnectionIo` was not reexported. Users need this trait for websocket usage. Additionally, updates the `actix-codec` version so websocket clients don't silently drop/not send continuation frames when the data is large (see actix/actix#431 and actix/actix-net#409)  
