### PR TITLE
awc: support http2 over plain tcp with feature flag

### DIFF
--- a/actix-http-test/src/lib.rs
+++ b/actix-http-test/src/lib.rs
@@ -21,16 +21,15 @@ use http::Method;
 use socket2::{Domain, Protocol, Socket, Type};
 use tokio::sync::mpsc;
 
-/// Start test server
+/// Start test server.
 ///
-/// `TestServer` is very simple test server that simplify process of writing
-/// integration tests cases for actix web applications.
+/// `TestServer` is very simple test server that simplify process of writing integration tests cases
+/// for HTTP applications.
 ///
 /// # Examples
-///
-/// ```
+/// ```no_run
 /// use actix_http::HttpService;
-/// use actix_http_test::TestServer;
+/// use actix_http_test::test_server;
 /// use actix_web::{web, App, HttpResponse, Error};
 ///
 /// async fn my_handler() -> Result<HttpResponse, Error> {
@@ -39,10 +38,9 @@ use tokio::sync::mpsc;
 ///
 /// #[actix_web::test]
 /// async fn test_example() {
-///     let mut srv = TestServer::start(
-///         || HttpService::new(
-///             App::new().service(
-///                 web::resource("/").to(my_handler))
+///     let mut srv = TestServer::start(||
+///         HttpService::new(
+///             App::new().service(web::resource("/").to(my_handler))
 ///         )
 ///     );
 ///

--- a/awc/Cargo.toml
+++ b/awc/Cargo.toml
@@ -55,7 +55,7 @@ __compress = []
 # Enable dangerous feature for testing and local network usage:
 # - HTTP/2 over TCP(No Tls).
 # DO NOT enable this over any internet use case.
-dangerous = []
+dangerous-h2c = []
 
 [dependencies]
 actix-codec = "0.4.1"

--- a/awc/Cargo.toml
+++ b/awc/Cargo.toml
@@ -52,6 +52,11 @@ trust-dns = ["trust-dns-resolver"]
 # Don't rely on these whatsoever. They may disappear at anytime.
 __compress = []
 
+# Enable dangerous feature for testing and local network usage:
+# - HTTP/2 over TCP(No Tls).
+# DO NOT enable this over any internet use case.
+dangerous = []
+
 [dependencies]
 actix-codec = "0.4.1"
 actix-service = "2.0.0"

--- a/awc/src/request.rs
+++ b/awc/src/request.rs
@@ -115,10 +115,10 @@ impl ClientRequest {
         &self.head.method
     }
 
-    #[doc(hidden)]
     /// Set HTTP version of this request.
     ///
     /// By default requests's HTTP version depends on network stream
+    #[doc(hidden)]
     #[inline]
     pub fn version(mut self, version: Version) -> Self {
         self.head.version = version;

--- a/awc/tests/test_connector.rs
+++ b/awc/tests/test_connector.rs
@@ -39,7 +39,7 @@ fn tls_config() -> SslAcceptor {
 
 #[actix_rt::test]
 async fn test_connection_window_size() {
-    let srv = test_server(move || {
+    let srv = test_server(|| {
         HttpService::build()
             .h2(map_config(
                 App::new().service(web::resource("/").route(web::to(HttpResponse::Ok))),


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Feature


## PR Checklist
<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Make awc can connect to http2 server with plain tcp connection. This feature is hidden behind a new feature flag and this feature has lower priority than openssl/rustls feature. (Only when an awc client built with no tls connector can this feature be used)

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
