### PR TITLE
simplify `AnyBody` and `BodySize`

### DIFF
--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -1,8 +1,14 @@
 # Changes
 
 ## Unreleased - 2021-xx-xx
+### Added
+* `AnyBody::empty` for quickly creating an empty body. [???]
+
 ### Changed
 * Rename `AnyBody::{Message => Stream}`. [#????]
+
+### Removed
+* `AnyBody::Empty`; an empty body can now only be represented as a zero-length `Bytes` variant. [#????]
 
 [#????]: https://github.com/actix/actix-web/pull/????
 

--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -1,6 +1,10 @@
 # Changes
 
 ## Unreleased - 2021-xx-xx
+### Changed
+* Rename `AnyBody::{Message => Stream}`. [#????]
+
+[#????]: https://github.com/actix/actix-web/pull/????
 
 
 ## 3.0.0-beta.12 - 2021-11-15

--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -9,6 +9,7 @@
 
 ### Removed
 * `AnyBody::Empty`; an empty body can now only be represented as a zero-length `Bytes` variant. [#????]
+* `BodySize::Empty`; an empty body can now only be represented as a `Sized(0)` variant. [#????]
 
 [#????]: https://github.com/actix/actix-web/pull/????
 

--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -2,16 +2,16 @@
 
 ## Unreleased - 2021-xx-xx
 ### Added
-* `AnyBody::empty` for quickly creating an empty body. [???]
+* `AnyBody::empty` for quickly creating an empty body. [#2446]
 
 ### Changed
-* Rename `AnyBody::{Message => Stream}`. [#????]
+* Rename `AnyBody::{Message => Stream}`. [#2446]
 
 ### Removed
-* `AnyBody::Empty`; an empty body can now only be represented as a zero-length `Bytes` variant. [#????]
-* `BodySize::Empty`; an empty body can now only be represented as a `Sized(0)` variant. [#????]
+* `AnyBody::Empty`; an empty body can now only be represented as a zero-length `Bytes` variant. [#2446]
+* `BodySize::Empty`; an empty body can now only be represented as a `Sized(0)` variant. [#2446]
 
-[#????]: https://github.com/actix/actix-web/pull/????
+[#2446]: https://github.com/actix/actix-web/pull/2446
 
 
 ## 3.0.0-beta.12 - 2021-11-15

--- a/actix-http/src/body/body.rs
+++ b/actix-http/src/body/body.rs
@@ -54,7 +54,6 @@ impl MessageBody for AnyBody {
     fn size(&self) -> BodySize {
         match self {
             AnyBody::None => BodySize::None,
-            AnyBody::Bytes(ref bin) if bin.is_empty() => BodySize::Empty,
             AnyBody::Bytes(ref bin) => BodySize::Sized(bin.len() as u64),
             AnyBody::Stream(ref body) => body.size(),
         }

--- a/actix-http/src/body/body.rs
+++ b/actix-http/src/body/body.rs
@@ -27,7 +27,7 @@ pub enum AnyBody {
     Bytes(Bytes),
 
     /// Generic message body.
-    Message(BoxAnyBody),
+    Stream(BoxAnyBody),
 }
 
 impl AnyBody {
@@ -42,7 +42,7 @@ impl AnyBody {
         B: MessageBody + 'static,
         B::Error: Into<Box<dyn StdError + 'static>>,
     {
-        Self::Message(BoxAnyBody::from_body(body))
+        Self::Stream(BoxAnyBody::from_body(body))
     }
 }
 
@@ -54,7 +54,7 @@ impl MessageBody for AnyBody {
             AnyBody::None => BodySize::None,
             AnyBody::Empty => BodySize::Empty,
             AnyBody::Bytes(ref bin) => BodySize::Sized(bin.len() as u64),
-            AnyBody::Message(ref body) => body.size(),
+            AnyBody::Stream(ref body) => body.size(),
         }
     }
 
@@ -74,7 +74,7 @@ impl MessageBody for AnyBody {
                 }
             }
 
-            AnyBody::Message(body) => body
+            AnyBody::Stream(body) => body
                 .as_pin_mut()
                 .poll_next(cx)
                 .map_err(|err| Error::new_body().with_cause(err)),
@@ -91,7 +91,7 @@ impl PartialEq for AnyBody {
                 AnyBody::Bytes(ref b2) => b == b2,
                 _ => false,
             },
-            AnyBody::Message(_) => false,
+            AnyBody::Stream(_) => false,
         }
     }
 }
@@ -102,7 +102,7 @@ impl fmt::Debug for AnyBody {
             AnyBody::None => write!(f, "AnyBody::None"),
             AnyBody::Empty => write!(f, "AnyBody::Empty"),
             AnyBody::Bytes(ref b) => write!(f, "AnyBody::Bytes({:?})", b),
-            AnyBody::Message(_) => write!(f, "AnyBody::Message(_)"),
+            AnyBody::Stream(_) => write!(f, "AnyBody::Message(_)"),
         }
     }
 }

--- a/actix-http/src/body/message_body.rs
+++ b/actix-http/src/body/message_body.rs
@@ -31,7 +31,7 @@ impl MessageBody for () {
     type Error = Infallible;
 
     fn size(&self) -> BodySize {
-        BodySize::Empty
+        BodySize::Sized(0)
     }
 
     fn poll_next(

--- a/actix-http/src/body/mod.rs
+++ b/actix-http/src/body/mod.rs
@@ -44,8 +44,9 @@ pub use self::sized_stream::SizedStream;
 /// ```
 pub async fn to_bytes<B: MessageBody>(body: B) -> Result<Bytes, B::Error> {
     let cap = match body.size() {
-        BodySize::None | BodySize::Empty | BodySize::Sized(0) => return Ok(Bytes::new()),
+        BodySize::None | BodySize::Sized(0) => return Ok(Bytes::new()),
         BodySize::Sized(size) => size as usize,
+        // good enough first guess for chunk size
         BodySize::Stream => 32_768,
     };
 
@@ -184,7 +185,7 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_unit() {
-        assert_eq!(().size(), BodySize::Empty);
+        assert_eq!(().size(), BodySize::Sized(0));
         assert!(poll_fn(|cx| Pin::new(&mut ()).poll_next(cx))
             .await
             .is_none());
@@ -194,11 +195,11 @@ mod tests {
     async fn test_box_and_pin() {
         let val = Box::new(());
         pin!(val);
-        assert_eq!(val.size(), BodySize::Empty);
+        assert_eq!(val.size(), BodySize::Sized(0));
         assert!(poll_fn(|cx| val.as_mut().poll_next(cx)).await.is_none());
 
         let mut val = Box::pin(());
-        assert_eq!(val.size(), BodySize::Empty);
+        assert_eq!(val.size(), BodySize::Sized(0));
         assert!(poll_fn(|cx| val.as_mut().poll_next(cx)).await.is_none());
     }
 

--- a/actix-http/src/body/mod.rs
+++ b/actix-http/src/body/mod.rs
@@ -33,7 +33,7 @@ pub use self::sized_stream::SizedStream;
 /// use bytes::Bytes;
 ///
 /// # async fn test_to_bytes() {
-/// let body = Body::Empty;
+/// let body = Body::None;
 /// let bytes = to_bytes(body).await.unwrap();
 /// assert!(bytes.is_empty());
 ///

--- a/actix-http/src/body/mod.rs
+++ b/actix-http/src/body/mod.rs
@@ -214,7 +214,6 @@ mod tests {
     #[actix_rt::test]
     async fn test_body_debug() {
         assert!(format!("{:?}", Body::None).contains("Body::None"));
-        assert!(format!("{:?}", Body::Empty).contains("Body::Empty"));
         assert!(format!("{:?}", Body::Bytes(Bytes::from_static(b"1"))).contains('1'));
     }
 
@@ -252,7 +251,7 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_to_bytes() {
-        let body = Body::Empty;
+        let body = Body::empty();
         let bytes = to_bytes(body).await.unwrap();
         assert!(bytes.is_empty());
 

--- a/actix-http/src/body/size.rs
+++ b/actix-http/src/body/size.rs
@@ -6,14 +6,9 @@ pub enum BodySize {
     /// Will skip writing Content-Length header.
     None,
 
-    /// Zero size body.
-    ///
-    /// Will write `Content-Length: 0` header.
-    Empty,
-
     /// Known size body.
     ///
-    /// Will write `Content-Length: N` header. `Sized(0)` is treated the same as `Empty`.
+    /// Will write `Content-Length: N` header.
     Sized(u64),
 
     /// Unknown size body.
@@ -25,6 +20,8 @@ pub enum BodySize {
 impl BodySize {
     /// Returns true if size hint indicates no or empty body.
     ///
+    /// Streams will return false because it cannot be known without reading the stream.
+    ///
     /// ```
     /// # use actix_http::body::BodySize;
     /// assert!(BodySize::None.is_eof());
@@ -35,6 +32,6 @@ impl BodySize {
     /// assert!(!BodySize::Stream.is_eof());
     /// ```
     pub fn is_eof(&self) -> bool {
-        matches!(self, BodySize::None | BodySize::Empty | BodySize::Sized(0))
+        matches!(self, BodySize::None | BodySize::Sized(0))
     }
 }

--- a/actix-http/src/body/size.rs
+++ b/actix-http/src/body/size.rs
@@ -25,7 +25,6 @@ impl BodySize {
     /// ```
     /// # use actix_http::body::BodySize;
     /// assert!(BodySize::None.is_eof());
-    /// assert!(BodySize::Empty.is_eof());
     /// assert!(BodySize::Sized(0).is_eof());
     ///
     /// assert!(!BodySize::Sized(64).is_eof());

--- a/actix-http/src/encoding/encoder.rs
+++ b/actix-http/src/encoding/encoder.rs
@@ -69,7 +69,7 @@ impl<B: MessageBody> Encoder<B> {
                         return ResponseBody::Other(Body::Bytes(buf));
                     }
                 }
-                Body::Message(stream) => EncoderBody::BoxedStream(stream),
+                Body::Stream(stream) => EncoderBody::BoxedStream(stream),
             },
             ResponseBody::Body(stream) => EncoderBody::Stream(stream),
         };

--- a/actix-http/src/encoding/encoder.rs
+++ b/actix-http/src/encoding/encoder.rs
@@ -61,7 +61,6 @@ impl<B: MessageBody> Encoder<B> {
         let body = match body {
             ResponseBody::Other(b) => match b {
                 Body::None => return ResponseBody::Other(Body::None),
-                Body::Empty => return ResponseBody::Other(Body::Empty),
                 Body::Bytes(buf) => {
                     if can_encode {
                         EncoderBody::Bytes(buf)

--- a/actix-http/src/h1/dispatcher.rs
+++ b/actix-http/src/h1/dispatcher.rs
@@ -380,7 +380,7 @@ where
                         // send_response would update InnerDispatcher state to SendPayload or
                         // None(If response body is empty).
                         // continue loop to poll it.
-                        self.as_mut().send_error_response(res, AnyBody::Empty)?;
+                        self.as_mut().send_error_response(res, AnyBody::empty())?;
                     }
 
                     // return with upgrade request and poll it exclusively.
@@ -772,7 +772,7 @@ where
                                 trace!("Slow request timeout");
                                 let _ = self.as_mut().send_error_response(
                                     Response::with_body(StatusCode::REQUEST_TIMEOUT, ()),
-                                    AnyBody::Empty,
+                                    AnyBody::empty(),
                                 );
                                 this = self.project();
                                 this.flags.insert(Flags::STARTED | Flags::SHUTDOWN);

--- a/actix-http/src/h1/dispatcher.rs
+++ b/actix-http/src/h1/dispatcher.rs
@@ -325,7 +325,7 @@ where
     ) -> Result<(), DispatchError> {
         let size = self.as_mut().send_response_inner(message, &body)?;
         let state = match size {
-            BodySize::None | BodySize::Empty => State::None,
+            BodySize::None | BodySize::Sized(0) => State::None,
             _ => State::SendPayload(body),
         };
         self.project().state.set(state);
@@ -339,7 +339,7 @@ where
     ) -> Result<(), DispatchError> {
         let size = self.as_mut().send_response_inner(message, &body)?;
         let state = match size {
-            BodySize::None | BodySize::Empty => State::None,
+            BodySize::None | BodySize::Sized(0) => State::None,
             _ => State::SendErrorPayload(body),
         };
         self.project().state.set(state);

--- a/actix-http/src/h2/dispatcher.rs
+++ b/actix-http/src/h2/dispatcher.rs
@@ -285,9 +285,11 @@ fn prepare_response(
 
     let _ = match size {
         BodySize::None | BodySize::Stream => None,
-        BodySize::Empty => res
+
+        BodySize::Sized(0) => res
             .headers_mut()
             .insert(CONTENT_LENGTH, HeaderValue::from_static("0")),
+
         BodySize::Sized(len) => {
             let mut buf = itoa::Buffer::new();
 

--- a/actix-http/src/response.rs
+++ b/actix-http/src/response.rs
@@ -28,7 +28,7 @@ impl Response<AnyBody> {
     pub fn new(status: StatusCode) -> Self {
         Response {
             head: BoxedResponseHead::new(status),
-            body: AnyBody::Empty,
+            body: AnyBody::empty(),
         }
     }
 

--- a/actix-http/src/response_builder.rs
+++ b/actix-http/src/response_builder.rs
@@ -270,7 +270,7 @@ impl ResponseBuilder {
     /// This `ResponseBuilder` will be left in a useless state.
     #[inline]
     pub fn finish(&mut self) -> Response<AnyBody> {
-        self.body(AnyBody::Empty)
+        self.body(AnyBody::empty())
     }
 
     /// Create an owned `ResponseBuilder`, leaving the original in a useless state.
@@ -390,7 +390,7 @@ mod tests {
     fn test_content_type() {
         let resp = Response::build(StatusCode::OK)
             .content_type("text/plain")
-            .body(Body::Empty);
+            .body(Body::empty());
         assert_eq!(resp.headers().get(CONTENT_TYPE).unwrap(), "text/plain")
     }
 

--- a/awc/src/client/h1proto.rs
+++ b/awc/src/client/h1proto.rs
@@ -70,7 +70,7 @@ where
     // RFC: https://tools.ietf.org/html/rfc7231#section-5.1.1
     let is_expect = if head.as_ref().headers.contains_key(EXPECT) {
         match body.size() {
-            BodySize::None | BodySize::Empty | BodySize::Sized(0) => {
+            BodySize::None | BodySize::Sized(0) => {
                 let keep_alive = framed.codec_ref().keepalive();
                 framed.io_mut().on_release(keep_alive);
 
@@ -104,7 +104,7 @@ where
     if do_send {
         // send request body
         match body.size() {
-            BodySize::None | BodySize::Empty | BodySize::Sized(0) => {}
+            BodySize::None | BodySize::Sized(0) => {}
             _ => send_body(body, pin_framed.as_mut()).await?,
         };
 

--- a/awc/src/middleware/redirect.rs
+++ b/awc/src/middleware/redirect.rs
@@ -194,7 +194,7 @@ where
                             match body {
                                 Some(ref bytes) => Body::Bytes(bytes.clone()),
                                 // TODO: should this be Body::Empty or Body::None.
-                                _ => Body::Empty,
+                                _ => Body::empty(),
                             }
                         } else {
                             body = None;

--- a/awc/src/sender.rs
+++ b/awc/src/sender.rs
@@ -297,7 +297,7 @@ impl RequestSender {
         timeout: Option<Duration>,
         config: &ClientConfig,
     ) -> SendClientRequest {
-        self.send_body(addr, response_decompress, timeout, config, Body::Empty)
+        self.send_body(addr, response_decompress, timeout, config, Body::empty())
     }
 
     fn set_header_if_none<V>(&mut self, key: HeaderName, value: V) -> Result<(), HttpError>

--- a/src/response/builder.rs
+++ b/src/response/builder.rs
@@ -387,7 +387,7 @@ impl HttpResponseBuilder {
     /// `HttpResponseBuilder` can not be used after this call.
     #[inline]
     pub fn finish(&mut self) -> HttpResponse {
-        self.body(AnyBody::Empty)
+        self.body(AnyBody::empty())
     }
 
     /// This method construct new `HttpResponseBuilder`
@@ -475,7 +475,7 @@ mod tests {
     fn test_content_type() {
         let resp = HttpResponseBuilder::new(StatusCode::OK)
             .content_type("text/plain")
-            .body(Body::Empty);
+            .body(Body::empty());
         assert_eq!(resp.headers().get(CONTENT_TYPE).unwrap(), "text/plain")
     }
 

--- a/src/response/http_codes.rs
+++ b/src/response/http_codes.rs
@@ -87,13 +87,12 @@ impl HttpResponse {
 
 #[cfg(test)]
 mod tests {
-    use crate::dev::Body;
     use crate::http::StatusCode;
     use crate::HttpResponse;
 
     #[test]
     fn test_build() {
-        let resp = HttpResponse::Ok().body(Body::Empty);
+        let resp = HttpResponse::Ok().finish();
         assert_eq!(resp.status(), StatusCode::OK);
     }
 }


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Refactor


## PR Checklist
<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
- Remove `Empty` variants of `AnyBody` and `BodySize`.
- Rename `AnyBody::{Message => Stream}`.