### PR TITLE
fix actix_http::Error conversion.

### DIFF
--- a/actix-http/src/body/body.rs
+++ b/actix-http/src/body/body.rs
@@ -139,56 +139,56 @@ impl<S: fmt::Debug> fmt::Debug for AnyBody<S> {
     }
 }
 
-impl From<&'static str> for AnyBody {
-    fn from(string: &'static str) -> AnyBody {
-        AnyBody::Bytes(Bytes::from_static(string.as_ref()))
+impl<B> From<&'static str> for AnyBody<B> {
+    fn from(string: &'static str) -> Self {
+        Self::Bytes(Bytes::from_static(string.as_ref()))
     }
 }
 
-impl From<&'static [u8]> for AnyBody {
-    fn from(bytes: &'static [u8]) -> AnyBody {
-        AnyBody::Bytes(Bytes::from_static(bytes))
+impl<B> From<&'static [u8]> for AnyBody<B> {
+    fn from(bytes: &'static [u8]) -> Self {
+        Self::Bytes(Bytes::from_static(bytes))
     }
 }
 
-impl From<Vec<u8>> for AnyBody {
-    fn from(vec: Vec<u8>) -> AnyBody {
-        AnyBody::Bytes(Bytes::from(vec))
+impl<B> From<Vec<u8>> for AnyBody<B> {
+    fn from(vec: Vec<u8>) -> Self {
+        Self::Bytes(Bytes::from(vec))
     }
 }
 
-impl From<String> for AnyBody {
-    fn from(string: String) -> AnyBody {
-        string.into_bytes().into()
+impl<B> From<String> for AnyBody<B> {
+    fn from(string: String) -> Self {
+        Self::Bytes(Bytes::from(string))
     }
 }
 
-impl From<&'_ String> for AnyBody {
-    fn from(string: &String) -> AnyBody {
-        AnyBody::Bytes(Bytes::copy_from_slice(AsRef::<[u8]>::as_ref(&string)))
+impl<B> From<&'_ String> for AnyBody<B> {
+    fn from(string: &String) -> Self {
+        Self::Bytes(Bytes::copy_from_slice(AsRef::<[u8]>::as_ref(&string)))
     }
 }
 
-impl From<Cow<'_, str>> for AnyBody {
-    fn from(string: Cow<'_, str>) -> AnyBody {
+impl<B> From<Cow<'_, str>> for AnyBody<B> {
+    fn from(string: Cow<'_, str>) -> Self {
         match string {
-            Cow::Owned(s) => AnyBody::from(s),
+            Cow::Owned(s) => Self::from(s),
             Cow::Borrowed(s) => {
-                AnyBody::Bytes(Bytes::copy_from_slice(AsRef::<[u8]>::as_ref(s)))
+                Self::Bytes(Bytes::copy_from_slice(AsRef::<[u8]>::as_ref(s)))
             }
         }
     }
 }
 
-impl From<Bytes> for AnyBody {
+impl<B> From<Bytes> for AnyBody<B> {
     fn from(bytes: Bytes) -> Self {
-        AnyBody::Bytes(bytes)
+        Self::Bytes(bytes)
     }
 }
 
-impl From<BytesMut> for AnyBody {
+impl<B> From<BytesMut> for AnyBody<B> {
     fn from(bytes: BytesMut) -> Self {
-        AnyBody::Bytes(bytes.freeze())
+        Self::Bytes(bytes.freeze())
     }
 }
 

--- a/actix-http/src/body/mod.rs
+++ b/actix-http/src/body/mod.rs
@@ -86,6 +86,7 @@ mod tests {
         }
     }
 
+    /// AnyBody alias because rustc does not (can not?) infer the default type parameter.
     type TestBody = AnyBody;
 
     #[actix_rt::test]

--- a/actix-http/src/body/mod.rs
+++ b/actix-http/src/body/mod.rs
@@ -86,11 +86,13 @@ mod tests {
         }
     }
 
+    type TestBody = AnyBody;
+
     #[actix_rt::test]
     async fn test_static_str() {
-        assert_eq!(AnyBody::from("").size(), BodySize::Sized(0));
-        assert_eq!(AnyBody::from("test").size(), BodySize::Sized(4));
-        assert_eq!(AnyBody::from("test").get_ref(), b"test");
+        assert_eq!(TestBody::from("").size(), BodySize::Sized(0));
+        assert_eq!(TestBody::from("test").size(), BodySize::Sized(4));
+        assert_eq!(TestBody::from("test").get_ref(), b"test");
 
         assert_eq!("test".size(), BodySize::Sized(4));
         assert_eq!(
@@ -104,14 +106,14 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_static_bytes() {
-        assert_eq!(AnyBody::from(b"test".as_ref()).size(), BodySize::Sized(4));
-        assert_eq!(AnyBody::from(b"test".as_ref()).get_ref(), b"test");
+        assert_eq!(TestBody::from(b"test".as_ref()).size(), BodySize::Sized(4));
+        assert_eq!(TestBody::from(b"test".as_ref()).get_ref(), b"test");
         assert_eq!(
-            AnyBody::copy_from_slice(b"test".as_ref()).size(),
+            TestBody::copy_from_slice(b"test".as_ref()).size(),
             BodySize::Sized(4)
         );
         assert_eq!(
-            AnyBody::copy_from_slice(b"test".as_ref()).get_ref(),
+            TestBody::copy_from_slice(b"test".as_ref()).get_ref(),
             b"test"
         );
         let sb = Bytes::from(&b"test"[..]);
@@ -126,8 +128,8 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_vec() {
-        assert_eq!(AnyBody::from(Vec::from("test")).size(), BodySize::Sized(4));
-        assert_eq!(AnyBody::from(Vec::from("test")).get_ref(), b"test");
+        assert_eq!(TestBody::from(Vec::from("test")).size(), BodySize::Sized(4));
+        assert_eq!(TestBody::from(Vec::from("test")).get_ref(), b"test");
         let test_vec = Vec::from("test");
         pin!(test_vec);
 
@@ -144,8 +146,8 @@ mod tests {
     #[actix_rt::test]
     async fn test_bytes() {
         let b = Bytes::from("test");
-        assert_eq!(AnyBody::from(b.clone()).size(), BodySize::Sized(4));
-        assert_eq!(AnyBody::from(b.clone()).get_ref(), b"test");
+        assert_eq!(TestBody::from(b.clone()).size(), BodySize::Sized(4));
+        assert_eq!(TestBody::from(b.clone()).get_ref(), b"test");
         pin!(b);
 
         assert_eq!(b.size(), BodySize::Sized(4));
@@ -158,8 +160,8 @@ mod tests {
     #[actix_rt::test]
     async fn test_bytes_mut() {
         let b = BytesMut::from("test");
-        assert_eq!(AnyBody::from(b.clone()).size(), BodySize::Sized(4));
-        assert_eq!(AnyBody::from(b.clone()).get_ref(), b"test");
+        assert_eq!(TestBody::from(b.clone()).size(), BodySize::Sized(4));
+        assert_eq!(TestBody::from(b.clone()).get_ref(), b"test");
         pin!(b);
 
         assert_eq!(b.size(), BodySize::Sized(4));
@@ -172,10 +174,10 @@ mod tests {
     #[actix_rt::test]
     async fn test_string() {
         let b = "test".to_owned();
-        assert_eq!(AnyBody::from(b.clone()).size(), BodySize::Sized(4));
-        assert_eq!(AnyBody::from(b.clone()).get_ref(), b"test");
-        assert_eq!(AnyBody::from(&b).size(), BodySize::Sized(4));
-        assert_eq!(AnyBody::from(&b).get_ref(), b"test");
+        assert_eq!(TestBody::from(b.clone()).size(), BodySize::Sized(4));
+        assert_eq!(TestBody::from(b.clone()).get_ref(), b"test");
+        assert_eq!(TestBody::from(&b).size(), BodySize::Sized(4));
+        assert_eq!(TestBody::from(&b).get_ref(), b"test");
         pin!(b);
 
         assert_eq!(b.size(), BodySize::Sized(4));
@@ -216,22 +218,22 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_body_debug() {
-        assert!(format!("{:?}", AnyBody::<BoxBody>::None).contains("Body::None"));
-        assert!(format!("{:?}", AnyBody::from(Bytes::from_static(b"1"))).contains('1'));
+        assert!(format!("{:?}", TestBody::None).contains("Body::None"));
+        assert!(format!("{:?}", TestBody::from(Bytes::from_static(b"1"))).contains('1'));
     }
 
     #[actix_rt::test]
     async fn test_serde_json() {
         use serde_json::{json, Value};
         assert_eq!(
-            AnyBody::from(
+            TestBody::from(
                 serde_json::to_vec(&Value::String("test".to_owned())).unwrap()
             )
             .size(),
             BodySize::Sized(6)
         );
         assert_eq!(
-            AnyBody::from(
+            TestBody::from(
                 serde_json::to_vec(&json!({"test-key":"test-value"})).unwrap()
             )
             .size(),

--- a/actix-http/src/error.rs
+++ b/actix-http/src/error.rs
@@ -66,7 +66,7 @@ impl Error {
     }
 }
 
-impl From<Error> for Response<AnyBody> {
+impl<B> From<Error> for Response<AnyBody<B>> {
     fn from(err: Error) -> Self {
         let status_code = match err.inner.kind {
             Kind::Parse => StatusCode::BAD_REQUEST,


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Bug Fix


## PR Checklist
<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
This restore the conversion from `Error` to `AnyBody<B>`. As error type always converted to a in memory response body that is stored in Bytes variant. So whay B type actually is does not matter.

`body/mod.rs` has some issue to infer the default type so a type alias is introduced.

With this PR it would be possible to clean up all the messy code that is specialized for handling `Into<Response<AnyBody>>` in `actix-http`. As the `Into<Response<B>>` on service type is always `AnyBody<B>` from actix-web stand point. Of course for explicity they can all be unifed to `Response<AnyBody<B: MessageBody>>`
