### PR TITLE
expose `header::map` module

### DIFF
--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -3,9 +3,11 @@
 ## Unreleased - 2021-xx-xx
 ### Changed
 * Guarantee ordering of `header::GetAll` iterator to be same as insertion order. [#2467]
-* Expose `header::{GetAll, Removed}` iterators. [#2467]
+* Expose `header::map` module. [#2467]
+* Implement `ExactSizeIterator` and `FusedIterator` for all `HeaderMap` iterators. [#2470]
 
 [#2467]: https://github.com/actix/actix-web/pull/2467
+[#2470]: https://github.com/actix/actix-web/pull/2470
 
 
 ## 3.0.0-beta.13 - 2021-11-22

--- a/actix-http/src/header/as_name.rs
+++ b/actix-http/src/header/as_name.rs
@@ -1,11 +1,12 @@
-//! Helper trait for types that can be effectively borrowed as a [HeaderValue].
-//!
-//! [HeaderValue]: crate::http::HeaderValue
+//! Sealed [`AsHeaderName`] trait and implementations.
 
-use std::{borrow::Cow, str::FromStr};
+use std::{borrow::Cow, str::FromStr as _};
 
 use http::header::{HeaderName, InvalidHeaderName};
 
+/// Sealed trait implemented for types that can be effectively borrowed as a [`HeaderValue`].
+///
+/// [`HeaderValue`]: crate::http::HeaderValue
 pub trait AsHeaderName: Sealed {}
 
 pub struct Seal;

--- a/actix-http/src/header/into_pair.rs
+++ b/actix-http/src/header/into_pair.rs
@@ -1,4 +1,6 @@
-use std::convert::TryFrom;
+//! [`IntoHeaderPair`] trait and implementations.
+
+use std::convert::TryFrom as _;
 
 use http::{
     header::{HeaderName, InvalidHeaderName, InvalidHeaderValue},
@@ -7,7 +9,10 @@ use http::{
 
 use super::{Header, IntoHeaderValue};
 
-/// Transforms structures into header K/V pairs for inserting into `HeaderMap`s.
+/// An interface for types that can be converted into a [`HeaderName`]/[`HeaderValue`] pair for
+/// insertion into a [`HeaderMap`].
+///
+/// [`HeaderMap`]: crate::http::HeaderMap
 pub trait IntoHeaderPair: Sized {
     type Error: Into<HttpError>;
 

--- a/actix-http/src/header/into_value.rs
+++ b/actix-http/src/header/into_value.rs
@@ -1,10 +1,12 @@
-use std::convert::TryFrom;
+//! [`IntoHeaderValue`] trait and implementations.
+
+use std::convert::TryFrom as _;
 
 use bytes::Bytes;
 use http::{header::InvalidHeaderValue, Error as HttpError, HeaderValue};
 use mime::Mime;
 
-/// A trait for any object that can be Converted to a `HeaderValue`
+/// An interface for types that can be converted into a [`HeaderValue`].
 pub trait IntoHeaderValue: Sized {
     /// The type returned in the event of a conversion error.
     type Error: Into<HttpError>;

--- a/actix-http/src/header/mod.rs
+++ b/actix-http/src/header/mod.rs
@@ -34,7 +34,7 @@ use crate::{error::ParseError, HttpMessage};
 mod as_name;
 mod into_pair;
 mod into_value;
-pub(crate) mod map;
+pub mod map;
 mod shared;
 mod utils;
 
@@ -44,12 +44,12 @@ pub use self::shared::*;
 pub use self::as_name::AsHeaderName;
 pub use self::into_pair::IntoHeaderPair;
 pub use self::into_value::IntoHeaderValue;
-pub use self::map::{GetAll, HeaderMap, Removed};
+pub use self::map::HeaderMap;
 pub use self::utils::{
     fmt_comma_delimited, from_comma_delimited, from_one_raw_str, http_percent_encode,
 };
 
-/// A trait for any object that already represents a valid header field and value.
+/// An interface for types that already represent a valid header.
 pub trait Header: IntoHeaderValue {
     /// Returns the name of the header field
     fn name() -> HeaderName;

--- a/actix-http/src/header/shared/content_encoding.rs
+++ b/actix-http/src/header/shared/content_encoding.rs
@@ -9,14 +9,17 @@ use crate::{
     HttpMessage,
 };
 
-/// Error return when a content encoding is unknown.
-///
-/// Example: 'compress'
+/// Error returned when a content encoding is unknown.
 #[derive(Debug, Display, Error)]
 #[display(fmt = "unsupported content encoding")]
 pub struct ContentEncodingParseError;
 
 /// Represents a supported content encoding.
+///
+/// Includes a commonly-used subset of media types appropriate for use as HTTP content encodings.
+/// See [IANA HTTP Content Coding Registry].
+///
+/// [IANA HTTP Content Coding Registry]: https://www.iana.org/assignments/http-parameters/http-parameters.xhtml
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[non_exhaustive]
 pub enum ContentEncoding {
@@ -32,7 +35,7 @@ pub enum ContentEncoding {
     /// Gzip algorithm.
     Gzip,
 
-    // Zstd algorithm.
+    /// Zstd algorithm.
     Zstd,
 
     /// Indicates the identity function (i.e. no compression, nor modification).

--- a/actix-http/src/header/utils.rs
+++ b/actix-http/src/header/utils.rs
@@ -1,3 +1,5 @@
+//! Header parsing utilities.
+
 use std::{fmt, str::FromStr};
 
 use super::HeaderValue;

--- a/src/response/response.rs
+++ b/src/response/response.rs
@@ -296,7 +296,7 @@ impl Future for HttpResponse<AnyBody> {
 
 #[cfg(feature = "cookies")]
 pub struct CookieIter<'a> {
-    iter: header::GetAll<'a>,
+    iter: header::map::GetAll<'a>,
 }
 
 #[cfg(feature = "cookies")]


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Refactor / Docs


## PR Checklist
<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
- Expose header::map module, including all it's iterators.
- Implement `ExactSizeIterator` and `FusedIterator` for all header map iterators.
