### PR TITLE
remove `actix_http::http` module

### DIFF
--- a/actix-files/src/named.rs
+++ b/actix-files/src/named.rs
@@ -19,9 +19,10 @@ use actix_web::{
     },
     http::{
         header::{
-            self, Charset, ContentDisposition, DispositionParam, DispositionType, ExtendedValue,
+            self, Charset, ContentDisposition, ContentEncoding, DispositionParam,
+            DispositionType, ExtendedValue,
         },
-        ContentEncoding, StatusCode,
+        StatusCode,
     },
     Error, HttpMessage, HttpRequest, HttpResponse, Responder,
 };

--- a/actix-http-test/src/lib.rs
+++ b/actix-http-test/src/lib.rs
@@ -13,7 +13,8 @@ use actix_codec::{AsyncRead, AsyncWrite, Framed};
 use actix_rt::{net::TcpStream, System};
 use actix_server::{Server, ServiceFactory};
 use awc::{
-    error::PayloadError, http::HeaderMap, ws, Client, ClientRequest, ClientResponse, Connector,
+    error::PayloadError, http::header::HeaderMap, ws, Client, ClientRequest, ClientResponse,
+    Connector,
 };
 use bytes::Bytes;
 use futures_core::stream::Stream;

--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -30,13 +30,15 @@
 * Remove unnecessary `MessageBody` bound on types passed to `body::AnyBody::new`. [#2468]
 * Move `body::AnyBody` to `awc`. Replaced with `EitherBody` and `BoxBody`. [#2468]
 * `impl Copy` for `ws::Codec`. [#1920]
-* `header::qitem` helper. Replaced with `header::QualityItem::max` [#2486]
-* `impl TryFrom<u16>` for `header::Quality` [#2486]
+* `header::qitem` helper. Replaced with `header::QualityItem::max`. [#2486]
+* `impl TryFrom<u16>` for `header::Quality`. [#2486]
+* `http` module. Most everything it contained is exported at the crate root. [#2488]
 
 [#2483]: https://github.com/actix/actix-web/pull/2483
 [#2468]: https://github.com/actix/actix-web/pull/2468
 [#1920]: https://github.com/actix/actix-web/pull/1920
 [#2486]: https://github.com/actix/actix-web/pull/2486
+[#2488]: https://github.com/actix/actix-web/pull/2488
 
 
 ## 3.0.0-beta.14 - 2021-11-30

--- a/actix-http/src/encoding/decoder.rs
+++ b/actix-http/src/encoding/decoder.rs
@@ -23,7 +23,7 @@ use zstd::stream::write::Decoder as ZstdDecoder;
 use crate::{
     encoding::Writer,
     error::{BlockingError, PayloadError},
-    http::header::{ContentEncoding, HeaderMap, CONTENT_ENCODING},
+    header::{ContentEncoding, HeaderMap, CONTENT_ENCODING},
 };
 
 const MAX_CHUNK_SIZE_DECODE_IN_PLACE: usize = 2049;

--- a/actix-http/src/encoding/encoder.rs
+++ b/actix-http/src/encoding/encoder.rs
@@ -27,11 +27,8 @@ use super::Writer;
 use crate::{
     body::{BodySize, MessageBody},
     error::BlockingError,
-    http::{
-        header::{ContentEncoding, CONTENT_ENCODING},
-        HeaderValue, StatusCode,
-    },
-    ResponseHead,
+    header::{self, ContentEncoding, HeaderValue, CONTENT_ENCODING},
+    ResponseHead, StatusCode,
 };
 
 const MAX_CHUNK_SIZE_ENCODE_IN_PLACE: usize = 1024;
@@ -222,7 +219,7 @@ where
 
 fn update_head(encoding: ContentEncoding, head: &mut ResponseHead) {
     head.headers_mut().insert(
-        CONTENT_ENCODING,
+        header::CONTENT_ENCODING,
         HeaderValue::from_static(encoding.as_str()),
     );
 }

--- a/actix-http/src/h1/decoder.rs
+++ b/actix-http/src/h1/decoder.rs
@@ -511,7 +511,7 @@ mod tests {
     use super::*;
     use crate::{
         error::ParseError,
-        http::header::{HeaderName, SET_COOKIE},
+        header::{HeaderName, SET_COOKIE},
         HttpMessage as _,
     };
 

--- a/actix-http/src/h1/dispatcher.rs
+++ b/actix-http/src/h1/dispatcher.rs
@@ -1037,9 +1037,8 @@ mod tests {
     use crate::{
         error::Error,
         h1::{ExpectHandler, UpgradeHandler},
-        http::Method,
         test::{TestBuffer, TestSeqBuffer},
-        HttpMessage, KeepAlive,
+        HttpMessage, KeepAlive, Method,
     };
 
     fn find_slice(haystack: &[u8], needle: &[u8], from: usize) -> Option<usize> {

--- a/actix-http/src/h1/encoder.rs
+++ b/actix-http/src/h1/encoder.rs
@@ -531,8 +531,10 @@ mod tests {
     use http::header::AUTHORIZATION;
 
     use super::*;
-    use crate::http::header::{HeaderValue, CONTENT_TYPE};
-    use crate::RequestHead;
+    use crate::{
+        header::{HeaderValue, CONTENT_TYPE},
+        RequestHead,
+    };
 
     #[test]
     fn test_chunked_te() {

--- a/actix-http/src/header/map.rs
+++ b/actix-http/src/header/map.rs
@@ -14,7 +14,7 @@ use crate::header::AsHeaderName;
 ///
 /// # Examples
 /// ```
-/// use actix_http::http::{header, HeaderMap, HeaderValue};
+/// use actix_http::header::{self, HeaderMap, HeaderValue};
 ///
 /// let mut map = HeaderMap::new();
 ///
@@ -75,7 +75,7 @@ impl HeaderMap {
     ///
     /// # Examples
     /// ```
-    /// # use actix_http::http::HeaderMap;
+    /// # use actix_http::header::HeaderMap;
     /// let map = HeaderMap::new();
     ///
     /// assert!(map.is_empty());
@@ -92,7 +92,7 @@ impl HeaderMap {
     ///
     /// # Examples
     /// ```
-    /// # use actix_http::http::HeaderMap;
+    /// # use actix_http::header::HeaderMap;
     /// let map = HeaderMap::with_capacity(16);
     ///
     /// assert!(map.is_empty());
@@ -139,7 +139,7 @@ impl HeaderMap {
     ///
     /// # Examples
     /// ```
-    /// # use actix_http::http::{header, HeaderMap, HeaderValue};
+    /// # use actix_http::header::{self, HeaderMap, HeaderValue};
     /// let mut map = HeaderMap::new();
     /// assert_eq!(map.len(), 0);
     ///
@@ -162,7 +162,7 @@ impl HeaderMap {
     ///
     /// # Examples
     /// ```
-    /// # use actix_http::http::{header, HeaderMap, HeaderValue};
+    /// # use actix_http::header::{self, HeaderMap, HeaderValue};
     /// let mut map = HeaderMap::new();
     /// assert_eq!(map.len_keys(), 0);
     ///
@@ -181,7 +181,7 @@ impl HeaderMap {
     ///
     /// # Examples
     /// ```
-    /// # use actix_http::http::{header, HeaderMap, HeaderValue};
+    /// # use actix_http::header::{self, HeaderMap, HeaderValue};
     /// let mut map = HeaderMap::new();
     /// assert!(map.is_empty());
     ///
@@ -198,7 +198,7 @@ impl HeaderMap {
     ///
     /// # Examples
     /// ```
-    /// # use actix_http::http::{header, HeaderMap, HeaderValue};
+    /// # use actix_http::header::{self, HeaderMap, HeaderValue};
     /// let mut map = HeaderMap::new();
     ///
     /// map.insert(header::ACCEPT, HeaderValue::from_static("text/plain"));
@@ -231,7 +231,7 @@ impl HeaderMap {
     ///
     /// # Examples
     /// ```
-    /// # use actix_http::http::{header, HeaderMap, HeaderValue};
+    /// # use actix_http::header::{self, HeaderMap, HeaderValue};
     /// let mut map = HeaderMap::new();
     ///
     /// map.insert(header::SET_COOKIE, HeaderValue::from_static("one=1"));
@@ -264,7 +264,7 @@ impl HeaderMap {
     ///
     /// # Examples
     /// ```
-    /// # use actix_http::http::{header, HeaderMap, HeaderValue};
+    /// # use actix_http::header::{self, HeaderMap, HeaderValue};
     /// let mut map = HeaderMap::new();
     ///
     /// map.insert(header::SET_COOKIE, HeaderValue::from_static("one=1"));
@@ -293,7 +293,7 @@ impl HeaderMap {
     ///
     /// # Examples
     /// ```
-    /// # use actix_http::http::{header, HeaderMap, HeaderValue};
+    /// # use actix_http::header::{self, HeaderMap, HeaderValue};
     /// let mut map = HeaderMap::new();
     ///
     /// let mut none_iter = map.get_all(header::ORIGIN);
@@ -319,7 +319,7 @@ impl HeaderMap {
     ///
     /// # Examples
     /// ```
-    /// # use actix_http::http::{header, HeaderMap, HeaderValue};
+    /// # use actix_http::header::{self, HeaderMap, HeaderValue};
     /// let mut map = HeaderMap::new();
     /// assert!(!map.contains_key(header::ACCEPT));
     ///
@@ -342,7 +342,7 @@ impl HeaderMap {
     ///
     /// # Examples
     /// ```
-    /// # use actix_http::http::{header, HeaderMap, HeaderValue};
+    /// # use actix_http::header::{self, HeaderMap, HeaderValue};
     /// let mut map = HeaderMap::new();
     ///
     /// map.insert(header::ACCEPT, HeaderValue::from_static("text/plain"));
@@ -359,7 +359,7 @@ impl HeaderMap {
     /// A convenience method is provided on the returned iterator to check if the insertion replaced
     /// any values.
     /// ```
-    /// # use actix_http::http::{header, HeaderMap, HeaderValue};
+    /// # use actix_http::header::{self, HeaderMap, HeaderValue};
     /// let mut map = HeaderMap::new();
     ///
     /// let removed = map.insert(header::ACCEPT, HeaderValue::from_static("text/plain"));
@@ -381,7 +381,7 @@ impl HeaderMap {
     ///
     /// # Examples
     /// ```
-    /// # use actix_http::http::{header, HeaderMap, HeaderValue};
+    /// # use actix_http::header::{self, HeaderMap, HeaderValue};
     /// let mut map = HeaderMap::new();
     ///
     /// map.append(header::HOST, HeaderValue::from_static("example.com"));
@@ -411,7 +411,7 @@ impl HeaderMap {
     ///
     /// # Examples
     /// ```
-    /// # use actix_http::http::{header, HeaderMap, HeaderValue};
+    /// # use actix_http::header::{self, HeaderMap, HeaderValue};
     /// let mut map = HeaderMap::new();
     ///
     /// map.append(header::SET_COOKIE, HeaderValue::from_static("one=1"));
@@ -430,7 +430,7 @@ impl HeaderMap {
     /// A convenience method is provided on the returned iterator to check if the `remove` call
     /// actually removed any values.
     /// ```
-    /// # use actix_http::http::{header, HeaderMap, HeaderValue};
+    /// # use actix_http::header::{self, HeaderMap, HeaderValue};
     /// let mut map = HeaderMap::new();
     ///
     /// let removed = map.remove("accept");
@@ -459,7 +459,7 @@ impl HeaderMap {
     ///
     /// # Examples
     /// ```
-    /// # use actix_http::http::HeaderMap;
+    /// # use actix_http::header::HeaderMap;
     /// let map = HeaderMap::with_capacity(16);
     ///
     /// assert!(map.is_empty());
@@ -479,7 +479,7 @@ impl HeaderMap {
     ///
     /// # Examples
     /// ```
-    /// # use actix_http::http::HeaderMap;
+    /// # use actix_http::header::HeaderMap;
     /// let mut map = HeaderMap::with_capacity(2);
     /// assert!(map.capacity() >= 2);
     ///
@@ -499,7 +499,7 @@ impl HeaderMap {
     ///
     /// # Examples
     /// ```
-    /// # use actix_http::http::{header, HeaderMap, HeaderValue};
+    /// # use actix_http::header::{self, HeaderMap, HeaderValue};
     /// let mut map = HeaderMap::new();
     ///
     /// let mut iter = map.iter();
@@ -531,7 +531,7 @@ impl HeaderMap {
     ///
     /// # Examples
     /// ```
-    /// # use actix_http::http::{header, HeaderMap, HeaderValue};
+    /// # use actix_http::header::{self, HeaderMap, HeaderValue};
     /// let mut map = HeaderMap::new();
     ///
     /// let mut iter = map.keys();
@@ -559,7 +559,7 @@ impl HeaderMap {
     /// Keeps the allocated memory for reuse.
     /// # Examples
     /// ```
-    /// # use actix_http::http::{header, HeaderMap, HeaderValue};
+    /// # use actix_http::header::{self, HeaderMap, HeaderValue};
     /// let mut map = HeaderMap::new();
     ///
     /// let mut iter = map.drain();

--- a/actix-http/src/lib.rs
+++ b/actix-http/src/lib.rs
@@ -67,26 +67,6 @@ pub use self::service::HttpService;
 pub use ::http::{uri, uri::Uri};
 pub use ::http::{Method, StatusCode, Version};
 
-// TODO: deprecate this mish-mash of random items
-pub mod http {
-    //! Various HTTP related types.
-
-    // re-exports
-    pub use http::header::{HeaderName, HeaderValue};
-    pub use http::uri::PathAndQuery;
-    pub use http::{uri, Error, Uri};
-    pub use http::{Method, StatusCode, Version};
-
-    pub use crate::header::HeaderMap;
-
-    /// A collection of HTTP headers and helpers.
-    pub mod header {
-        pub use crate::header::*;
-    }
-    pub use crate::header::ContentEncoding;
-    pub use crate::message::ConnectionType;
-}
-
 /// A major HTTP protocol version.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 #[non_exhaustive]

--- a/actix-http/src/response.rs
+++ b/actix-http/src/response.rs
@@ -11,10 +11,9 @@ use bytestring::ByteString;
 use crate::{
     body::{BoxBody, MessageBody},
     extensions::Extensions,
-    header::{self, IntoHeaderValue},
-    http::{HeaderMap, StatusCode},
+    header::{self, HeaderMap, IntoHeaderValue},
     message::{BoxedResponseHead, ResponseHead},
-    Error, ResponseBuilder,
+    Error, ResponseBuilder, StatusCode,
 };
 
 /// An HTTP response.
@@ -323,7 +322,7 @@ mod tests {
     use super::*;
     use crate::{
         body::to_bytes,
-        http::header::{HeaderValue, CONTENT_TYPE, COOKIE},
+        header::{HeaderValue, CONTENT_TYPE, COOKIE},
     };
 
     #[test]

--- a/actix-http/src/response_builder.rs
+++ b/actix-http/src/response_builder.rs
@@ -20,7 +20,7 @@ use crate::{
 ///
 /// # Examples
 /// ```
-/// use actix_http::{Response, ResponseBuilder, body, http::StatusCode, http::header};
+/// use actix_http::{Response, ResponseBuilder, StatusCode, body, header};
 ///
 /// # actix_rt::System::new().block_on(async {
 /// let mut res: Response<_> = Response::build(StatusCode::OK)
@@ -47,9 +47,7 @@ impl ResponseBuilder {
     /// Create response builder
     ///
     /// # Examples
-    /// ```
-    /// use actix_http::{Response, ResponseBuilder, http::StatusCode};
-    ///
+    //    /// use actix_http::{Response, ResponseBuilder, StatusCode};, / ``
     /// let res: Response<_> = ResponseBuilder::default().finish();
     /// assert_eq!(res.status(), StatusCode::OK);
     /// ```
@@ -64,9 +62,7 @@ impl ResponseBuilder {
     /// Set HTTP status code of this response.
     ///
     /// # Examples
-    /// ```
-    /// use actix_http::{ResponseBuilder, http::StatusCode};
-    ///
+    //    /// use actix_http::{ResponseBuilder, StatusCode};, / ``
     /// let res = ResponseBuilder::default().status(StatusCode::NOT_FOUND).finish();
     /// assert_eq!(res.status(), StatusCode::NOT_FOUND);
     /// ```
@@ -82,7 +78,7 @@ impl ResponseBuilder {
     ///
     /// # Examples
     /// ```
-    /// use actix_http::{ResponseBuilder, http::header};
+    /// use actix_http::{ResponseBuilder, header};
     ///
     /// let res = ResponseBuilder::default()
     ///     .insert_header((header::CONTENT_TYPE, mime::APPLICATION_JSON))
@@ -112,7 +108,7 @@ impl ResponseBuilder {
     ///
     /// # Examples
     /// ```
-    /// use actix_http::{ResponseBuilder, http::header};
+    /// use actix_http::{ResponseBuilder, header};
     ///
     /// let res = ResponseBuilder::default()
     ///     .append_header((header::CONTENT_TYPE, mime::APPLICATION_JSON))

--- a/actix-http/src/response_builder.rs
+++ b/actix-http/src/response_builder.rs
@@ -335,7 +335,7 @@ mod tests {
     use bytes::Bytes;
 
     use super::*;
-    use crate::http::header::{HeaderName, HeaderValue, CONTENT_TYPE};
+    use crate::header::{HeaderName, HeaderValue, CONTENT_TYPE};
 
     #[test]
     fn test_basic_builder() {

--- a/actix-http/tests/test_client.rs
+++ b/actix-http/tests/test_client.rs
@@ -1,7 +1,7 @@
 use std::convert::Infallible;
 
 use actix_http::{
-    body::BoxBody, http, http::StatusCode, HttpMessage, HttpService, Request, Response,
+    body::BoxBody, HttpMessage, HttpService, Request, Response, StatusCode,
 };
 use actix_http_test::test_server;
 use actix_service::ServiceFactoryExt;

--- a/actix-http/tests/test_openssl.rs
+++ b/actix-http/tests/test_openssl.rs
@@ -7,11 +7,8 @@ use std::{convert::Infallible, io};
 use actix_http::{
     body::{BodyStream, BoxBody, SizedStream},
     error::PayloadError,
-    http::{
-        header::{self, HeaderValue},
-        Method, StatusCode, Version,
-    },
-    Error, HttpMessage, HttpService, Request, Response,
+    header::{self, HeaderValue},
+    Error, HttpMessage, HttpService, Method, Request, Response, StatusCode, Version,
 };
 use actix_http_test::test_server;
 use actix_service::{fn_service, ServiceFactoryExt};

--- a/actix-http/tests/test_rustls.rs
+++ b/actix-http/tests/test_rustls.rs
@@ -12,11 +12,8 @@ use std::{
 use actix_http::{
     body::{BodyStream, BoxBody, SizedStream},
     error::PayloadError,
-    http::{
-        header::{self, HeaderName, HeaderValue},
-        Method, StatusCode, Version,
-    },
-    Error, HttpService, Request, Response,
+    header::{self, HeaderName, HeaderValue},
+    Error, HttpService, Method, Request, Response, StatusCode, Version,
 };
 use actix_http_test::test_server;
 use actix_service::{fn_factory_with_config, fn_service};

--- a/actix-http/tests/test_server.rs
+++ b/actix-http/tests/test_server.rs
@@ -7,8 +7,7 @@ use std::{
 
 use actix_http::{
     body::{self, BodyStream, BoxBody, SizedStream},
-    header, http, Error, HttpMessage, HttpService, KeepAlive, Request, Response,
-    StatusCode,
+    header, Error, HttpMessage, HttpService, KeepAlive, Request, Response, StatusCode,
 };
 use actix_http_test::test_server;
 use actix_rt::time::sleep;
@@ -383,7 +382,7 @@ async fn test_http1_keepalive_disabled() {
 
 #[actix_rt::test]
 async fn test_content_length() {
-    use actix_http::http::{
+    use actix_http::{
         header::{HeaderName, HeaderValue},
         StatusCode,
     };

--- a/actix-test/src/lib.rs
+++ b/actix-test/src/lib.rs
@@ -35,10 +35,7 @@ use std::{fmt, net, thread, time::Duration};
 
 use actix_codec::{AsyncRead, AsyncWrite, Framed};
 pub use actix_http::test::TestBuffer;
-use actix_http::{
-    http::{HeaderMap, Method},
-    ws, HttpService, Request, Response,
-};
+use actix_http::{header::HeaderMap, ws, HttpService, Method, Request, Response};
 use actix_service::{map_config, IntoServiceFactory, ServiceFactory, ServiceFactoryExt as _};
 use actix_web::{
     body::MessageBody,

--- a/actix-web-actors/src/ws.rs
+++ b/actix-web-actors/src/ws.rs
@@ -19,16 +19,16 @@ use actix::{
     SpawnHandle,
 };
 use actix_codec::{Decoder as _, Encoder as _};
+use actix_http::ws::{hash_key, Codec};
 pub use actix_http::ws::{
     CloseCode, CloseReason, Frame, HandshakeError, Message, ProtocolError,
 };
-use actix_http::{
-    http::HeaderValue,
-    ws::{hash_key, Codec},
-};
 use actix_web::{
     error::{Error, PayloadError},
-    http::{header, Method, StatusCode},
+    http::{
+        header::{self, HeaderValue},
+        Method, StatusCode,
+    },
     HttpRequest, HttpResponse, HttpResponseBuilder,
 };
 use bytes::{Bytes, BytesMut};

--- a/awc/src/builder.rs
+++ b/awc/src/builder.rs
@@ -1,6 +1,10 @@
 use std::{convert::TryFrom, fmt, net::IpAddr, rc::Rc, time::Duration};
 
-use actix_http::http::{self, header, Error as HttpError, HeaderMap, HeaderName, Uri};
+use actix_http::{
+    error::HttpError,
+    header::{self, HeaderMap, HeaderName},
+    Uri,
+};
 use actix_rt::net::{ActixStream, TcpStream};
 use actix_service::{boxed, Service};
 

--- a/awc/src/client/error.rs
+++ b/awc/src/client/error.rs
@@ -2,7 +2,7 @@ use std::{fmt, io};
 
 use derive_more::{Display, From};
 
-use actix_http::{error::ParseError, http::Error as HttpError};
+use actix_http::error::{HttpError, ParseError};
 
 #[cfg(feature = "openssl")]
 use actix_tls::accept::openssl::reexports::Error as OpensslError;

--- a/awc/src/client/h1proto.rs
+++ b/awc/src/client/h1proto.rs
@@ -9,11 +9,8 @@ use actix_http::{
     body::{BodySize, MessageBody},
     error::PayloadError,
     h1,
-    http::{
-        header::{HeaderMap, IntoHeaderValue, EXPECT, HOST},
-        StatusCode,
-    },
-    Payload, RequestHeadType, ResponseHead,
+    header::{HeaderMap, IntoHeaderValue, EXPECT, HOST},
+    Payload, RequestHeadType, ResponseHead, StatusCode,
 };
 use actix_utils::future::poll_fn;
 use bytes::buf::BufMut;

--- a/awc/src/error.rs
+++ b/awc/src/error.rs
@@ -1,9 +1,10 @@
 //! HTTP client errors
 
 pub use actix_http::{
-    error::PayloadError,
-    http::{header::HeaderValue, Error as HttpError, StatusCode},
+    error::{HttpError, PayloadError},
+    header::HeaderValue,
     ws::{HandshakeError as WsHandshakeError, ProtocolError as WsProtocolError},
+    StatusCode,
 };
 
 use derive_more::{Display, From};

--- a/awc/src/frozen.rs
+++ b/awc/src/frozen.rs
@@ -5,8 +5,9 @@ use futures_core::Stream;
 use serde::Serialize;
 
 use actix_http::{
-    http::{header::IntoHeaderValue, Error as HttpError, HeaderMap, HeaderName, Method, Uri},
-    RequestHead,
+    error::HttpError,
+    header::{HeaderMap, HeaderName, IntoHeaderValue},
+    Method, RequestHead, Uri,
 };
 
 use crate::{

--- a/awc/src/lib.rs
+++ b/awc/src/lib.rs
@@ -117,7 +117,8 @@ mod sender;
 pub mod test;
 pub mod ws;
 
-pub use actix_http::http;
+// TODO: hmmmmmm
+pub use actix_http as http;
 #[cfg(feature = "cookies")]
 pub use cookie;
 
@@ -131,10 +132,7 @@ pub use self::sender::SendClientRequest;
 
 use std::{convert::TryFrom, rc::Rc, time::Duration};
 
-use actix_http::{
-    http::{Error as HttpError, HeaderMap, Method, Uri},
-    RequestHead,
-};
+use actix_http::{error::HttpError, header::HeaderMap, Method, RequestHead, Uri};
 use actix_rt::net::TcpStream;
 use actix_service::Service;
 

--- a/awc/src/middleware/redirect.rs
+++ b/awc/src/middleware/redirect.rs
@@ -7,10 +7,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use actix_http::{
-    http::{header, Method, StatusCode, Uri},
-    RequestHead, RequestHeadType,
-};
+use actix_http::{header, Method, RequestHead, RequestHeadType, StatusCode, Uri};
 use actix_service::Service;
 use bytes::Bytes;
 use futures_core::ready;
@@ -284,12 +281,12 @@ fn remove_sensitive_headers(headers: &mut header::HeaderMap, prev_uri: &Uri, nex
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
     use actix_web::{web, App, Error, HttpRequest, HttpResponse};
 
     use super::*;
-    use crate::http::HeaderValue;
-    use crate::ClientBuilder;
-    use std::str::FromStr;
+    use crate::{http::header::HeaderValue, ClientBuilder};
 
     #[actix_rt::test]
     async fn test_basic_redirect() {

--- a/awc/src/request.rs
+++ b/awc/src/request.rs
@@ -5,11 +5,9 @@ use futures_core::Stream;
 use serde::Serialize;
 
 use actix_http::{
-    http::{
-        header::{self, IntoHeaderPair},
-        ConnectionType, Error as HttpError, HeaderMap, HeaderValue, Method, Uri, Version,
-    },
-    RequestHead,
+    error::HttpError,
+    header::{self, HeaderMap, HeaderValue, IntoHeaderPair},
+    ConnectionType, Method, RequestHead, Uri, Version,
 };
 
 use crate::{
@@ -539,7 +537,7 @@ impl fmt::Debug for ClientRequest {
 mod tests {
     use std::time::SystemTime;
 
-    use actix_http::http::header::HttpDate;
+    use actix_http::header::HttpDate;
 
     use super::*;
     use crate::Client;

--- a/awc/src/response.rs
+++ b/awc/src/response.rs
@@ -10,9 +10,8 @@ use std::{
 };
 
 use actix_http::{
-    error::PayloadError,
-    http::{header, HeaderMap, StatusCode, Version},
-    Extensions, HttpMessage, Payload, PayloadStream, ResponseHead,
+    error::PayloadError, header, header::HeaderMap, Extensions, HttpMessage, Payload,
+    PayloadStream, ResponseHead, StatusCode, Version,
 };
 use actix_rt::time::{sleep, Sleep};
 use bytes::{Bytes, BytesMut};

--- a/awc/src/sender.rs
+++ b/awc/src/sender.rs
@@ -9,10 +9,8 @@ use std::{
 
 use actix_http::{
     body::BodyStream,
-    http::{
-        header::{self, HeaderMap, HeaderName, IntoHeaderValue},
-        Error as HttpError,
-    },
+    error::HttpError,
+    header::{self, HeaderMap, HeaderName, IntoHeaderValue},
     RequestHead, RequestHeadType,
 };
 use actix_rt::time::{sleep, Sleep};
@@ -22,7 +20,7 @@ use futures_core::Stream;
 use serde::Serialize;
 
 #[cfg(feature = "__compress")]
-use actix_http::{encoding::Decoder, http::header::ContentEncoding, Payload, PayloadStream};
+use actix_http::{encoding::Decoder, header::ContentEncoding, Payload, PayloadStream};
 
 use crate::{
     any_body::AnyBody,

--- a/awc/src/test.rs
+++ b/awc/src/test.rs
@@ -1,7 +1,6 @@
 //! Test helpers for actix http client to use during testing.
-use actix_http::http::header::IntoHeaderPair;
-use actix_http::http::{StatusCode, Version};
-use actix_http::{h1, Payload, ResponseHead};
+
+use actix_http::{h1, header::IntoHeaderPair, Payload, ResponseHead, StatusCode, Version};
 use bytes::Bytes;
 
 #[cfg(feature = "cookies")]
@@ -89,7 +88,7 @@ impl TestResponse {
 
         #[cfg(feature = "cookies")]
         for cookie in self.cookies.delta() {
-            use actix_http::http::header::{self, HeaderValue};
+            use actix_http::header::{self, HeaderValue};
 
             head.headers.insert(
                 header::SET_COOKIE,
@@ -109,7 +108,7 @@ impl TestResponse {
 mod tests {
     use std::time::SystemTime;
 
-    use actix_http::http::header::HttpDate;
+    use actix_http::header::HttpDate;
 
     use super::*;
     use crate::{cookie, http::header};

--- a/awc/src/ws.rs
+++ b/awc/src/ws.rs
@@ -26,9 +26,7 @@
 //! }
 //! ```
 
-use std::convert::TryFrom;
-use std::net::SocketAddr;
-use std::{fmt, str};
+use std::{convert::TryFrom, fmt, net::SocketAddr, str};
 
 use actix_codec::Framed;
 use actix_http::{ws, Payload, RequestHead};
@@ -37,14 +35,19 @@ use actix_service::Service;
 
 pub use actix_http::ws::{CloseCode, CloseReason, Codec, Frame, Message};
 
-use crate::connect::{BoxedSocket, ConnectRequest};
+use crate::{
+    connect::{BoxedSocket, ConnectRequest},
+    error::{HttpError, InvalidUrl, SendRequestError, WsClientError},
+    http::{
+        header::{self, HeaderName, HeaderValue, IntoHeaderValue, AUTHORIZATION},
+        ConnectionType, Method, StatusCode, Uri, Version,
+    },
+    response::ClientResponse,
+    ClientConfig,
+};
+
 #[cfg(feature = "cookies")]
 use crate::cookie::{Cookie, CookieJar};
-use crate::error::{InvalidUrl, SendRequestError, WsClientError};
-use crate::http::header::{self, HeaderName, HeaderValue, IntoHeaderValue, AUTHORIZATION};
-use crate::http::{ConnectionType, Error as HttpError, Method, StatusCode, Uri, Version};
-use crate::response::ClientResponse;
-use crate::ClientConfig;
 
 /// WebSocket connection.
 pub struct WebsocketsRequest {

--- a/awc/tests/test_client.rs
+++ b/awc/tests/test_client.rs
@@ -21,10 +21,7 @@ use brotli2::write::BrotliEncoder;
 #[cfg(feature = "compress-gzip")]
 use flate2::{read::GzDecoder, write::GzEncoder, Compression};
 
-use actix_http::{
-    http::{self, StatusCode},
-    HttpService,
-};
+use actix_http::{ContentEncoding, HttpService, StatusCode};
 use actix_http_test::test_server;
 use actix_service::{fn_service, map_config, ServiceFactoryExt as _};
 use actix_web::{
@@ -647,9 +644,7 @@ async fn test_client_brotli_encoding_large_random() {
 async fn test_client_deflate_encoding() {
     let srv = actix_test::start(|| {
         App::new().default_service(web::to(|body: Bytes| {
-            HttpResponse::Ok()
-                .encoding(http::ContentEncoding::Br)
-                .body(body)
+            HttpResponse::Ok().encoding(ContentEncoding::Br).body(body)
         }))
     });
 
@@ -672,9 +667,7 @@ async fn test_client_deflate_encoding_large_random() {
 
     let srv = actix_test::start(|| {
         App::new().default_service(web::to(|body: Bytes| {
-            HttpResponse::Ok()
-                .encoding(http::ContentEncoding::Br)
-                .body(body)
+            HttpResponse::Ok().encoding(ContentEncoding::Br).body(body)
         }))
     });
 
@@ -692,7 +685,7 @@ async fn test_client_streaming_explicit() {
     let srv = actix_test::start(|| {
         App::new().default_service(web::to(|body: web::Payload| {
             HttpResponse::Ok()
-                .encoding(http::ContentEncoding::Identity)
+                .encoding(ContentEncoding::Identity)
                 .streaming(body)
         }))
     });
@@ -717,7 +710,7 @@ async fn test_body_streaming_implicit() {
             });
 
             HttpResponse::Ok()
-                .encoding(http::ContentEncoding::Gzip)
+                .encoding(ContentEncoding::Gzip)
                 .streaming(Box::pin(body))
         }))
     });

--- a/src/app.rs
+++ b/src/app.rs
@@ -494,7 +494,10 @@ mod tests {
     use bytes::Bytes;
 
     use super::*;
-    use crate::http::{header, HeaderValue, Method, StatusCode};
+    use crate::http::{
+        header::{self, HeaderValue},
+        Method, StatusCode,
+    };
     use crate::middleware::DefaultHeaders;
     use crate::service::ServiceRequest;
     use crate::test::{call_service, init_service, read_body, try_init_service, TestRequest};

--- a/src/app.rs
+++ b/src/app.rs
@@ -353,7 +353,7 @@ where
     /// ```
     /// use actix_service::Service;
     /// use actix_web::{middleware, web, App};
-    /// use actix_web::http::{header::CONTENT_TYPE, HeaderValue};
+    /// use actix_web::http::header::{CONTENT_TYPE, HeaderValue};
     ///
     /// async fn index() -> &'static str {
     ///     "Welcome!"
@@ -410,7 +410,7 @@ where
     /// ```
     /// use actix_service::Service;
     /// use actix_web::{web, App};
-    /// use actix_web::http::{header::CONTENT_TYPE, HeaderValue};
+    /// use actix_web::http::header::{CONTENT_TYPE, HeaderValue};
     ///
     /// async fn index() -> &'static str {
     ///     "Welcome!"

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -7,7 +7,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use actix_http::http::{Method, Uri};
+use actix_http::{Method, Uri};
 use actix_utils::future::{ok, Ready};
 use futures_core::ready;
 use pin_project_lite::pin_project;
@@ -402,7 +402,7 @@ mod tuple_from_req {
 
 #[cfg(test)]
 mod tests {
-    use actix_http::http::header;
+    use actix_http::header;
     use bytes::Bytes;
     use serde::Deserialize;
 

--- a/src/guard.rs
+++ b/src/guard.rs
@@ -24,13 +24,13 @@
 //!     );
 //! }
 //! ```
-#![allow(non_snake_case)]
-use std::convert::TryFrom;
-use std::ops::Deref;
-use std::rc::Rc;
 
-use actix_http::http::{self, header, uri::Uri};
-use actix_http::RequestHead;
+#![allow(non_snake_case)]
+
+use std::rc::Rc;
+use std::{convert::TryFrom, ops::Deref};
+
+use actix_http::{header, uri::Uri, Method as HttpMethod, RequestHead};
 
 /// Trait defines resource guards. Guards are used for route selection.
 ///
@@ -186,7 +186,7 @@ impl Guard for NotGuard {
 
 /// HTTP method guard.
 #[doc(hidden)]
-pub struct MethodGuard(http::Method);
+pub struct MethodGuard(HttpMethod);
 
 impl Guard for MethodGuard {
     fn check(&self, request: &RequestHead) -> bool {
@@ -196,51 +196,51 @@ impl Guard for MethodGuard {
 
 /// Guard to match *GET* HTTP method.
 pub fn Get() -> MethodGuard {
-    MethodGuard(http::Method::GET)
+    MethodGuard(HttpMethod::GET)
 }
 
 /// Predicate to match *POST* HTTP method.
 pub fn Post() -> MethodGuard {
-    MethodGuard(http::Method::POST)
+    MethodGuard(HttpMethod::POST)
 }
 
 /// Predicate to match *PUT* HTTP method.
 pub fn Put() -> MethodGuard {
-    MethodGuard(http::Method::PUT)
+    MethodGuard(HttpMethod::PUT)
 }
 
 /// Predicate to match *DELETE* HTTP method.
 pub fn Delete() -> MethodGuard {
-    MethodGuard(http::Method::DELETE)
+    MethodGuard(HttpMethod::DELETE)
 }
 
 /// Predicate to match *HEAD* HTTP method.
 pub fn Head() -> MethodGuard {
-    MethodGuard(http::Method::HEAD)
+    MethodGuard(HttpMethod::HEAD)
 }
 
 /// Predicate to match *OPTIONS* HTTP method.
 pub fn Options() -> MethodGuard {
-    MethodGuard(http::Method::OPTIONS)
+    MethodGuard(HttpMethod::OPTIONS)
 }
 
 /// Predicate to match *CONNECT* HTTP method.
 pub fn Connect() -> MethodGuard {
-    MethodGuard(http::Method::CONNECT)
+    MethodGuard(HttpMethod::CONNECT)
 }
 
 /// Predicate to match *PATCH* HTTP method.
 pub fn Patch() -> MethodGuard {
-    MethodGuard(http::Method::PATCH)
+    MethodGuard(HttpMethod::PATCH)
 }
 
 /// Predicate to match *TRACE* HTTP method.
 pub fn Trace() -> MethodGuard {
-    MethodGuard(http::Method::TRACE)
+    MethodGuard(HttpMethod::TRACE)
 }
 
 /// Predicate to match specified HTTP method.
-pub fn Method(method: http::Method) -> MethodGuard {
+pub fn Method(method: HttpMethod) -> MethodGuard {
     MethodGuard(method)
 }
 
@@ -331,7 +331,7 @@ impl Guard for HostGuard {
 
 #[cfg(test)]
 mod tests {
-    use actix_http::http::{header, Method};
+    use actix_http::{header, Method};
 
     use super::*;
     use crate::test::TestRequest;

--- a/src/http/header/allow.rs
+++ b/src/http/header/allow.rs
@@ -1,4 +1,4 @@
-use actix_http::http::Method;
+use actix_http::Method;
 
 use crate::http::header;
 

--- a/src/http/header/macros.rs
+++ b/src/http/header/macros.rs
@@ -6,7 +6,7 @@ macro_rules! common_header_test_module {
 
             use ::core::str;
 
-            use ::actix_http::{http::Method, test};
+            use ::actix_http::{Method, test};
             use ::mime::*;
 
             use $crate::http::header::{self, *};

--- a/src/http/header/mod.rs
+++ b/src/http/header/mod.rs
@@ -15,7 +15,7 @@ use bytes::{Bytes, BytesMut};
 // - header map
 // - the few typed headers from actix-http
 // - header parsing utils
-pub use actix_http::http::header::*;
+pub use actix_http::header::*;
 
 mod accept;
 mod accept_charset;

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -1,2 +1,5 @@
+//! Various HTTP related types.
+
 pub mod header;
-pub use actix_http::http::*;
+
+pub use actix_http::{uri, ConnectionType, Error, Method, StatusCode, Uri, Version};

--- a/src/middleware/compress.rs
+++ b/src/middleware/compress.rs
@@ -2,7 +2,7 @@
 
 use std::{
     cmp,
-    convert::TryFrom,
+    convert::TryFrom as _,
     future::Future,
     marker::PhantomData,
     pin::Pin,
@@ -12,7 +12,7 @@ use std::{
 use actix_http::{
     body::{EitherBody, MessageBody},
     encoding::Encoder,
-    http::header::{ContentEncoding, ACCEPT_ENCODING},
+    header::{ContentEncoding, ACCEPT_ENCODING},
     StatusCode,
 };
 use actix_service::{Service, Transform};

--- a/src/middleware/condition.rs
+++ b/src/middleware/condition.rs
@@ -102,7 +102,10 @@ mod tests {
     use crate::{
         dev::{ServiceRequest, ServiceResponse},
         error::Result,
-        http::{header::CONTENT_TYPE, HeaderValue, StatusCode},
+        http::{
+            header::{HeaderValue, CONTENT_TYPE},
+            StatusCode,
+        },
         middleware::err_handlers::*,
         test::{self, TestRequest},
         HttpResponse,

--- a/src/middleware/default_headers.rs
+++ b/src/middleware/default_headers.rs
@@ -9,16 +9,14 @@ use std::{
     task::{Context, Poll},
 };
 
+use actix_http::error::HttpError;
 use actix_utils::future::{ready, Ready};
 use futures_core::ready;
 use pin_project_lite::pin_project;
 
 use crate::{
     dev::{Service, Transform},
-    http::{
-        header::{HeaderName, HeaderValue, CONTENT_TYPE},
-        Error as HttpError, HeaderMap,
-    },
+    http::header::{HeaderMap, HeaderName, HeaderValue, CONTENT_TYPE},
     service::{ServiceRequest, ServiceResponse},
     Error,
 };

--- a/src/middleware/err_handlers.rs
+++ b/src/middleware/err_handlers.rs
@@ -37,19 +37,20 @@ type ErrorHandler<B> = dyn Fn(ServiceResponse<B>) -> Result<ErrorHandlerResponse
 /// # Examples
 /// ```
 /// use actix_web::middleware::{ErrorHandlers, ErrorHandlerResponse};
-/// use actix_web::{web, http, dev, App, HttpRequest, HttpResponse, Result};
+/// use actix_web::{web, dev, App, HttpRequest, HttpResponse, Result};
+/// use actix_web::http::{StatusCode, header};
 ///
 /// fn render_500<B>(mut res: dev::ServiceResponse<B>) -> Result<ErrorHandlerResponse<B>> {
 ///     res.response_mut()
 ///        .headers_mut()
-///        .insert(http::header::CONTENT_TYPE, http::HeaderValue::from_static("Error"));
+///        .insert(header::CONTENT_TYPE, header::HeaderValue::from_static("Error"));
 ///     Ok(ErrorHandlerResponse::Response(res))
 /// }
 ///
 /// let app = App::new()
 ///     .wrap(
 ///         ErrorHandlers::new()
-///             .handler(http::StatusCode::INTERNAL_SERVER_ERROR, render_500),
+///             .handler(StatusCode::INTERNAL_SERVER_ERROR, render_500),
 ///     )
 ///     .service(web::resource("/test")
 ///         .route(web::get().to(|| HttpResponse::Ok()))

--- a/src/middleware/err_handlers.rs
+++ b/src/middleware/err_handlers.rs
@@ -182,7 +182,10 @@ mod tests {
     use futures_util::future::FutureExt as _;
 
     use super::*;
-    use crate::http::{header::CONTENT_TYPE, HeaderValue, StatusCode};
+    use crate::http::{
+        header::{HeaderValue, CONTENT_TYPE},
+        StatusCode,
+    };
     use crate::test::{self, TestRequest};
     use crate::HttpResponse;
 

--- a/src/middleware/logger.rs
+++ b/src/middleware/logger.rs
@@ -126,7 +126,8 @@ impl Logger {
     ///
     /// # Example
     /// ```
-    /// # use actix_web::{http::HeaderValue, middleware::Logger};
+    /// # use actix_web::http::{header::HeaderValue};
+    /// # use actix_web::middleware::Logger;
     /// # fn parse_jwt_id (_req: Option<&HeaderValue>) -> String { "jwt_uid".to_owned() }
     /// Logger::new("example %{JWT_ID}xi")
     ///     .custom_request_replace("JWT_ID", |req| parse_jwt_id(req.headers().get("Authorization")));

--- a/src/middleware/logger.rs
+++ b/src/middleware/logger.rs
@@ -23,7 +23,7 @@ use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 
 use crate::{
     body::{BodySize, MessageBody},
-    http::HeaderName,
+    http::header::HeaderName,
     service::{ServiceRequest, ServiceResponse},
     Error, HttpResponse, Result,
 };

--- a/src/middleware/normalize.rs
+++ b/src/middleware/normalize.rs
@@ -1,6 +1,6 @@
 //! For middleware documentation, see [`NormalizePath`].
 
-use actix_http::http::{PathAndQuery, Uri};
+use actix_http::uri::{PathAndQuery, Uri};
 use actix_service::{Service, Transform};
 use actix_utils::future::{ready, Ready};
 use bytes::Bytes;

--- a/src/request.rs
+++ b/src/request.rs
@@ -6,8 +6,8 @@ use std::{
 };
 
 use actix_http::{
-    http::{HeaderMap, Method, Uri, Version},
-    Extensions, HttpMessage, Message, Payload, RequestHead,
+    header::HeaderMap, Extensions, HttpMessage, Message, Method, Payload, RequestHead, Uri,
+    Version,
 };
 use actix_router::{Path, Url};
 use actix_utils::future::{ok, Ready};
@@ -266,7 +266,7 @@ impl HttpRequest {
     /// Load request cookies.
     #[cfg(feature = "cookies")]
     pub fn cookies(&self) -> Result<Ref<'_, Vec<Cookie<'static>>>, CookieParseError> {
-        use actix_http::http::header::COOKIE;
+        use actix_http::header::COOKIE;
 
         if self.extensions().get::<Cookies>().is_none() {
             let mut cookies = Vec::new();

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -298,7 +298,7 @@ where
     /// ```
     /// use actix_service::Service;
     /// use actix_web::{web, App};
-    /// use actix_web::http::{header::CONTENT_TYPE, HeaderValue};
+    /// use actix_web::http::header::{CONTENT_TYPE, HeaderValue};
     ///
     /// async fn index() -> &'static str {
     ///     "Welcome!"

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -508,7 +508,10 @@ mod tests {
 
     use crate::{
         guard,
-        http::{header, HeaderValue, Method, StatusCode},
+        http::{
+            header::{self, HeaderValue},
+            Method, StatusCode,
+        },
         middleware::DefaultHeaders,
         service::{ServiceRequest, ServiceResponse},
         test::{call_service, init_service, TestRequest},

--- a/src/responder.rs
+++ b/src/responder.rs
@@ -2,7 +2,10 @@ use std::borrow::Cow;
 
 use actix_http::{
     body::{BoxBody, EitherBody, MessageBody},
-    http::{header::IntoHeaderPair, Error as HttpError, HeaderMap, StatusCode},
+    error::HttpError,
+    header::HeaderMap,
+    header::IntoHeaderPair,
+    StatusCode,
 };
 use bytes::{Bytes, BytesMut};
 
@@ -280,7 +283,10 @@ pub(crate) mod tests {
     use super::*;
     use crate::{
         error,
-        http::{header::CONTENT_TYPE, HeaderValue, StatusCode},
+        http::{
+            header::{HeaderValue, CONTENT_TYPE},
+            StatusCode,
+        },
         test::{assert_body_eq, init_service, TestRequest},
         web, App,
     };

--- a/src/response/builder.rs
+++ b/src/response/builder.rs
@@ -8,18 +8,16 @@ use std::{
 
 use actix_http::{
     body::{BodyStream, BoxBody, MessageBody},
-    http::{
-        header::{self, HeaderName, IntoHeaderPair, IntoHeaderValue},
-        ConnectionType, Error as HttpError, StatusCode,
-    },
-    Extensions, Response, ResponseHead,
+    error::HttpError,
+    header::{self, HeaderName, IntoHeaderPair, IntoHeaderValue},
+    ConnectionType, Extensions, Response, ResponseHead, StatusCode,
 };
 use bytes::Bytes;
 use futures_core::Stream;
 use serde::Serialize;
 
 #[cfg(feature = "cookies")]
-use actix_http::http::header::HeaderValue;
+use actix_http::header::HeaderValue;
 #[cfg(feature = "cookies")]
 use cookie::{Cookie, CookieJar};
 

--- a/src/response/http_codes.rs
+++ b/src/response/http_codes.rs
@@ -1,6 +1,6 @@
 //! Status code based HTTP response builders.
 
-use actix_http::http::StatusCode;
+use actix_http::StatusCode;
 
 use crate::{HttpResponse, HttpResponseBuilder};
 

--- a/src/response/response.rs
+++ b/src/response/response.rs
@@ -9,15 +9,15 @@ use std::{
 
 use actix_http::{
     body::{BoxBody, EitherBody, MessageBody},
-    http::{header::HeaderMap, StatusCode},
-    Extensions, Response, ResponseHead,
+    header::HeaderMap,
+    Extensions, Response, ResponseHead, StatusCode,
 };
 
 #[cfg(feature = "cookies")]
 use {
-    actix_http::http::{
+    actix_http::{
+        error::HttpError,
         header::{self, HeaderValue},
-        Error as HttpError,
     },
     cookie::Cookie,
 };

--- a/src/route.rs
+++ b/src/route.rs
@@ -1,6 +1,6 @@
 use std::{future::Future, mem, rc::Rc};
 
-use actix_http::http::Method;
+use actix_http::Method;
 use actix_service::{
     boxed::{self, BoxService},
     fn_service, Service, ServiceFactory, ServiceFactoryExt,

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -587,7 +587,10 @@ mod tests {
 
     use crate::{
         guard,
-        http::{header, HeaderValue, Method, StatusCode},
+        http::{
+            header::{self, HeaderValue},
+            Method, StatusCode,
+        },
         middleware::DefaultHeaders,
         service::{ServiceRequest, ServiceResponse},
         test::{assert_body_eq, call_service, init_service, read_body, TestRequest},

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -347,7 +347,7 @@ where
     /// ```
     /// use actix_service::Service;
     /// use actix_web::{web, App};
-    /// use actix_web::http::{header::CONTENT_TYPE, HeaderValue};
+    /// use actix_web::http::header::{CONTENT_TYPE, HeaderValue};
     ///
     /// async fn index() -> &'static str {
     ///     "Welcome!"

--- a/src/service.rs
+++ b/src/service.rs
@@ -6,8 +6,9 @@ use std::{
 
 use actix_http::{
     body::{BoxBody, EitherBody, MessageBody},
-    http::{HeaderMap, Method, StatusCode, Uri, Version},
-    Extensions, HttpMessage, Payload, PayloadStream, RequestHead, Response, ResponseHead,
+    header::HeaderMap,
+    Extensions, HttpMessage, Method, Payload, PayloadStream, RequestHead, Response,
+    ResponseHead, StatusCode, Uri, Version,
 };
 use actix_router::{IntoPatterns, Path, Patterns, Resource, ResourceDef, Url};
 use actix_service::{

--- a/src/test.rs
+++ b/src/test.rs
@@ -4,9 +4,8 @@ use std::{borrow::Cow, net::SocketAddr, rc::Rc};
 
 pub use actix_http::test::TestBuffer;
 use actix_http::{
-    http::{header::IntoHeaderPair, Method, StatusCode, Uri, Version},
-    test::TestRequest as HttpTestRequest,
-    Extensions, Request,
+    header::IntoHeaderPair, test::TestRequest as HttpTestRequest, Extensions, Method, Request,
+    StatusCode, Uri, Version,
 };
 use actix_router::{Path, ResourceDef, Url};
 use actix_service::{IntoService, IntoServiceFactory, Service, ServiceFactory};
@@ -547,7 +546,7 @@ impl TestRequest {
 
         #[cfg(feature = "cookies")]
         {
-            use actix_http::http::header::{HeaderValue, COOKIE};
+            use actix_http::header::{HeaderValue, COOKIE};
 
             let cookie: String = self
                 .cookies

--- a/src/types/query.rs
+++ b/src/types/query.rs
@@ -185,14 +185,12 @@ impl QueryConfig {
 
 #[cfg(test)]
 mod tests {
-    use actix_http::http::StatusCode;
+    use actix_http::StatusCode;
     use derive_more::Display;
     use serde::Deserialize;
 
     use super::*;
-    use crate::error::InternalError;
-    use crate::test::TestRequest;
-    use crate::HttpResponse;
+    use crate::{error::InternalError, test::TestRequest, HttpResponse};
 
     #[derive(Deserialize, Debug, Display)]
     struct Id {

--- a/src/web.rs
+++ b/src/web.rs
@@ -2,7 +2,7 @@
 
 use std::{error::Error as StdError, future::Future};
 
-use actix_http::http::Method;
+use actix_http::Method;
 use actix_router::IntoPatterns;
 pub use bytes::{Buf, BufMut, Bytes, BytesMut};
 

--- a/tests/test_server.rs
+++ b/tests/test_server.rs
@@ -10,7 +10,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use actix_http::http::header::{
+use actix_http::header::{
     ContentEncoding, ACCEPT_ENCODING, CONTENT_ENCODING, CONTENT_LENGTH, TRANSFER_ENCODING,
 };
 use brotli2::write::{BrotliDecoder, BrotliEncoder};
@@ -902,7 +902,7 @@ async fn test_brotli_encoding_large_openssl() {
         actix_test::start_with(actix_test::config().openssl(openssl_config()), move || {
             App::new().service(web::resource("/").route(web::to(|bytes: Bytes| {
                 HttpResponse::Ok()
-                    .encoding(actix_web::http::ContentEncoding::Identity)
+                    .encoding(ContentEncoding::Identity)
                     .body(bytes)
             })))
         });
@@ -970,7 +970,7 @@ mod plus_rustls {
         let srv = actix_test::start_with(actix_test::config().rustls(tls_config()), || {
             App::new().service(web::resource("/").route(web::to(|bytes: Bytes| {
                 HttpResponse::Ok()
-                    .encoding(actix_web::http::ContentEncoding::Identity)
+                    .encoding(ContentEncoding::Identity)
                     .body(bytes)
             })))
         });


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Refactor


## PR Checklist
<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
Remove useless module where everything in it is re-exported in better places.