### PR TITLE
workaround rustdoc bug for Error

### DIFF
--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -1,6 +1,12 @@
 //! Error and Result module
 
-pub use actix_http::error::*;
+/// This is meant to be a glob import of the whole error module, but rustdoc can't handle
+/// shadowing `Error` type, so it is expanded manually.
+/// See https://github.com/rust-lang/rust/issues/83375
+pub use actix_http::error::{
+    BlockingError, ContentTypeError, DispatchError, HttpError, ParseError, PayloadError,
+};
+
 use derive_more::{Display, Error, From};
 use serde_json::error::Error as JsonError;
 use serde_urlencoded::de::Error as FormDeError;


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Docs


## PR Checklist
<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Previously actix_web::error::Error redirects to actix-http Error


<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
