### PR TITLE
enable scope middleware with generic res body.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@
 * Rename `Accept::{mime_preference => preference}`. [#2480]
 * Un-deprecate `App::data_factory`. [#2484]
 * `HttpRequest::url_for` no longer constructs URLs with query or fragment components. [#2430]
+* Remove `B` (body) type parameter on `App`. [#2493]
+* Add `B` (body) type parameter on `Scope`. [#2492]
 
 ### Fixed
 * Accept wildcard `*` items in `AcceptLanguage`. [#2480]
@@ -25,6 +27,8 @@
 [#2482]: https://github.com/actix/actix-web/pull/2482
 [#2484]: https://github.com/actix/actix-web/pull/2484
 [#2485]: https://github.com/actix/actix-web/pull/2485
+[#2492]: https://github.com/actix/actix-web/pull/2492
+[#2493]: https://github.com/actix/actix-web/pull/2493
 
 
 ## 4.0.0-beta.13 - 2021-11-30

--- a/src/middleware/compat.rs
+++ b/src/middleware/compat.rs
@@ -154,7 +154,7 @@ mod tests {
         let srv = init_service(
             App::new().service(
                 web::scope("app")
-                    .wrap(Compat::new(logger))
+                    .wrap(logger)
                     .wrap(Compat::new(compress))
                     .service(web::resource("/test").route(web::get().to(HttpResponse::Ok))),
             ),

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -298,13 +298,9 @@ where
         self
     }
 
-    /// Registers middleware, in the form of a middleware component (type),
-    /// that runs during inbound processing in the request
-    /// life-cycle (request -> response), modifying request as
-    /// necessary, across all requests managed by the *Scope*.  Scope-level
-    /// middleware is more limited in what it can modify, relative to Route or
-    /// Application level middleware, in that Scope-level middleware can not modify
-    /// ServiceResponse.
+    /// Registers middleware, in the form of a middleware component (type), that runs during inbound
+    /// processing in the request life-cycle (request -> response), modifying request as necessary,
+    /// across all requests managed by the *Scope*.
     ///
     /// Use middleware when you need to read or modify *every* request in some way.
     pub fn wrap<M, B1>(
@@ -342,13 +338,11 @@ where
         }
     }
 
-    /// Registers middleware, in the form of a closure, that runs during inbound
-    /// processing in the request life-cycle (request -> response), modifying
-    /// request as necessary, across all requests managed by the *Scope*.
-    /// Scope-level middleware is more limited in what it can modify, relative
-    /// to Route or Application level middleware, in that Scope-level middleware
-    /// can not modify ServiceResponse.
+    /// Registers middleware, in the form of a closure, that runs during inbound processing in the
+    /// request life-cycle (request -> response), modifying request as necessary, across all
+    /// requests managed by the *Scope*.
     ///
+    /// # Examples
     /// ```
     /// use actix_service::Service;
     /// use actix_web::{web, App};


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Feature


## PR Checklist
<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Enable `Scope::wrap` and `Scope::wrap_fn` accepting middlware that transform response body without boxing.
The final output `Scope` must still have `BoxBody`. This can be achieved with `Compat` or another middleware does the same job without recieving any other middleware type

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
