### PR TITLE
align remaining header map terminology

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,13 @@
 # Changes
 
 ## Unreleased - 2021-xx-xx
+### Added
+* Method on `Responder` trait (`customize`) for customizing responders and `CustomizeResponder` struct. [#????]
+
+### Changed
+* Align `DefaultHeader` method terminology, deprecating previous methods. [#????]
+
+[#????]: https://github.com/actix/actix-web/pull/????
 
 
 ## 4.0.0-beta.14 - 2021-12-11

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,12 +2,16 @@
 
 ## Unreleased - 2021-xx-xx
 ### Added
-* Method on `Responder` trait (`customize`) for customizing responders and `CustomizeResponder` struct. [#????]
+* Method on `Responder` trait (`customize`) for customizing responders and `CustomizeResponder` struct. [#2510]
+* Implement `Debug` for `DefaultHeaders`. [#2510]
 
 ### Changed
-* Align `DefaultHeader` method terminology, deprecating previous methods. [#????]
+* Align `DefaultHeader` method terminology, deprecating previous methods. [#2510]
 
-[#????]: https://github.com/actix/actix-web/pull/????
+### Removed
+* Top-level `EitherExtractError` export. [#2510]
+
+[#2510]: https://github.com/actix/actix-web/pull/2510
 
 
 ## 4.0.0-beta.14 - 2021-12-11

--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -2,9 +2,10 @@
 
 ## Unreleased - 2021-xx-xx
 ### Changed
-* Rename trait `IntoHeaderPair => TryIntoHeaderPair`. [#????]
+* Rename trait `IntoHeaderPair => TryIntoHeaderPair`. [#2510]
+* Rename trait `IntoHeaderValue => TryIntoHeaderValue`. [#2510]
 
-[#????]: https://github.com/actix/actix-web/pull/????
+[#2510]: https://github.com/actix/actix-web/pull/2510
 
 
 ## 3.0.0-beta.15 - 2021-12-11
@@ -275,9 +276,9 @@
 * `trust-dns` optional feature to enable `trust-dns-resolver` as client dns resolver. [#1969]
 
 ### Changed
-* `ResponseBuilder::content_type` now takes an `impl IntoHeaderValue` to support using typed
+* `ResponseBuilder::content_type` now takes an `impl TryIntoHeaderValue` to support using typed
   `mime` types. [#1894]
-* Renamed `IntoHeaderValue::{try_into => try_into_value}` to avoid ambiguity with std
+* Renamed `TryIntoHeaderValue::{try_into => try_into_value}` to avoid ambiguity with std
   `TryInto` trait. [#1894]
 * `Extensions::insert` returns Option of replaced item. [#1904]
 * Remove `HttpResponseBuilder::json2()`. [#1903]

--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -3,6 +3,7 @@
 ## Unreleased - 2021-xx-xx
 ### Changed
 * Rename trait `IntoHeaderPair => TryIntoHeaderPair`. [#2510]
+* Rename `TryIntoHeaderPair::{try_into_header_pair => try_into_pair}`. [#2510]
 * Rename trait `IntoHeaderValue => TryIntoHeaderValue`. [#2510]
 
 [#2510]: https://github.com/actix/actix-web/pull/2510

--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -1,6 +1,10 @@
 # Changes
 
 ## Unreleased - 2021-xx-xx
+### Changed
+* Rename trait `IntoHeaderPair => TryIntoHeaderPair`. [#????]
+
+[#????]: https://github.com/actix/actix-web/pull/????
 
 
 ## 3.0.0-beta.15 - 2021-12-11
@@ -260,7 +264,7 @@
 
 ## 3.0.0-beta.2 - 2021-02-10
 ### Added
-* `IntoHeaderPair` trait that allows using typed and untyped headers in the same methods. [#1869]
+* `TryIntoHeaderPair` trait that allows using typed and untyped headers in the same methods. [#1869]
 * `ResponseBuilder::insert_header` method which allows using typed headers. [#1869]
 * `ResponseBuilder::append_header` method which allows using typed headers. [#1869]
 * `TestRequest::insert_header` method which allows using typed headers. [#1869]

--- a/actix-http/src/header/as_name.rs
+++ b/actix-http/src/header/as_name.rs
@@ -16,6 +16,7 @@ pub trait Sealed {
 }
 
 impl Sealed for HeaderName {
+    #[inline]
     fn try_as_name(&self, _: Seal) -> Result<Cow<'_, HeaderName>, InvalidHeaderName> {
         Ok(Cow::Borrowed(self))
     }
@@ -23,6 +24,7 @@ impl Sealed for HeaderName {
 impl AsHeaderName for HeaderName {}
 
 impl Sealed for &HeaderName {
+    #[inline]
     fn try_as_name(&self, _: Seal) -> Result<Cow<'_, HeaderName>, InvalidHeaderName> {
         Ok(Cow::Borrowed(*self))
     }
@@ -30,6 +32,7 @@ impl Sealed for &HeaderName {
 impl AsHeaderName for &HeaderName {}
 
 impl Sealed for &str {
+    #[inline]
     fn try_as_name(&self, _: Seal) -> Result<Cow<'_, HeaderName>, InvalidHeaderName> {
         HeaderName::from_str(self).map(Cow::Owned)
     }
@@ -37,6 +40,7 @@ impl Sealed for &str {
 impl AsHeaderName for &str {}
 
 impl Sealed for String {
+    #[inline]
     fn try_as_name(&self, _: Seal) -> Result<Cow<'_, HeaderName>, InvalidHeaderName> {
         HeaderName::from_str(self).map(Cow::Owned)
     }
@@ -44,6 +48,7 @@ impl Sealed for String {
 impl AsHeaderName for String {}
 
 impl Sealed for &String {
+    #[inline]
     fn try_as_name(&self, _: Seal) -> Result<Cow<'_, HeaderName>, InvalidHeaderName> {
         HeaderName::from_str(self).map(Cow::Owned)
     }

--- a/actix-http/src/header/into_pair.rs
+++ b/actix-http/src/header/into_pair.rs
@@ -3,7 +3,7 @@
 use std::convert::TryFrom as _;
 
 use super::{
-    Header, HeaderName, HeaderValue, IntoHeaderValue, InvalidHeaderName, InvalidHeaderValue,
+    Header, HeaderName, HeaderValue, InvalidHeaderName, InvalidHeaderValue, TryIntoHeaderValue,
 };
 use crate::error::HttpError;
 
@@ -34,7 +34,7 @@ impl From<InvalidHeaderPart> for HttpError {
 
 impl<V> TryIntoHeaderPair for (HeaderName, V)
 where
-    V: IntoHeaderValue,
+    V: TryIntoHeaderValue,
     V::Error: Into<InvalidHeaderValue>,
 {
     type Error = InvalidHeaderPart;
@@ -50,7 +50,7 @@ where
 
 impl<V> TryIntoHeaderPair for (&HeaderName, V)
 where
-    V: IntoHeaderValue,
+    V: TryIntoHeaderValue,
     V::Error: Into<InvalidHeaderValue>,
 {
     type Error = InvalidHeaderPart;
@@ -66,7 +66,7 @@ where
 
 impl<V> TryIntoHeaderPair for (&[u8], V)
 where
-    V: IntoHeaderValue,
+    V: TryIntoHeaderValue,
     V::Error: Into<InvalidHeaderValue>,
 {
     type Error = InvalidHeaderPart;
@@ -83,7 +83,7 @@ where
 
 impl<V> TryIntoHeaderPair for (&str, V)
 where
-    V: IntoHeaderValue,
+    V: TryIntoHeaderValue,
     V::Error: Into<InvalidHeaderValue>,
 {
     type Error = InvalidHeaderPart;
@@ -100,7 +100,7 @@ where
 
 impl<V> TryIntoHeaderPair for (String, V)
 where
-    V: IntoHeaderValue,
+    V: TryIntoHeaderValue,
     V::Error: Into<InvalidHeaderValue>,
 {
     type Error = InvalidHeaderPart;
@@ -113,7 +113,7 @@ where
 }
 
 impl<T: Header> TryIntoHeaderPair for T {
-    type Error = <T as IntoHeaderValue>::Error;
+    type Error = <T as TryIntoHeaderValue>::Error;
 
     #[inline]
     fn try_into_header_pair(self) -> Result<(HeaderName, HeaderValue), Self::Error> {

--- a/actix-http/src/header/into_pair.rs
+++ b/actix-http/src/header/into_pair.rs
@@ -14,7 +14,7 @@ use crate::error::HttpError;
 pub trait TryIntoHeaderPair: Sized {
     type Error: Into<HttpError>;
 
-    fn try_into_header_pair(self) -> Result<(HeaderName, HeaderValue), Self::Error>;
+    fn try_into_pair(self) -> Result<(HeaderName, HeaderValue), Self::Error>;
 }
 
 #[derive(Debug)]
@@ -39,7 +39,7 @@ where
 {
     type Error = InvalidHeaderPart;
 
-    fn try_into_header_pair(self) -> Result<(HeaderName, HeaderValue), Self::Error> {
+    fn try_into_pair(self) -> Result<(HeaderName, HeaderValue), Self::Error> {
         let (name, value) = self;
         let value = value
             .try_into_value()
@@ -55,7 +55,7 @@ where
 {
     type Error = InvalidHeaderPart;
 
-    fn try_into_header_pair(self) -> Result<(HeaderName, HeaderValue), Self::Error> {
+    fn try_into_pair(self) -> Result<(HeaderName, HeaderValue), Self::Error> {
         let (name, value) = self;
         let value = value
             .try_into_value()
@@ -71,7 +71,7 @@ where
 {
     type Error = InvalidHeaderPart;
 
-    fn try_into_header_pair(self) -> Result<(HeaderName, HeaderValue), Self::Error> {
+    fn try_into_pair(self) -> Result<(HeaderName, HeaderValue), Self::Error> {
         let (name, value) = self;
         let name = HeaderName::try_from(name).map_err(InvalidHeaderPart::Name)?;
         let value = value
@@ -88,7 +88,7 @@ where
 {
     type Error = InvalidHeaderPart;
 
-    fn try_into_header_pair(self) -> Result<(HeaderName, HeaderValue), Self::Error> {
+    fn try_into_pair(self) -> Result<(HeaderName, HeaderValue), Self::Error> {
         let (name, value) = self;
         let name = HeaderName::try_from(name).map_err(InvalidHeaderPart::Name)?;
         let value = value
@@ -106,9 +106,9 @@ where
     type Error = InvalidHeaderPart;
 
     #[inline]
-    fn try_into_header_pair(self) -> Result<(HeaderName, HeaderValue), Self::Error> {
+    fn try_into_pair(self) -> Result<(HeaderName, HeaderValue), Self::Error> {
         let (name, value) = self;
-        (name.as_str(), value).try_into_header_pair()
+        (name.as_str(), value).try_into_pair()
     }
 }
 
@@ -116,7 +116,7 @@ impl<T: Header> TryIntoHeaderPair for T {
     type Error = <T as TryIntoHeaderValue>::Error;
 
     #[inline]
-    fn try_into_header_pair(self) -> Result<(HeaderName, HeaderValue), Self::Error> {
+    fn try_into_pair(self) -> Result<(HeaderName, HeaderValue), Self::Error> {
         Ok((T::name(), self.try_into_value()?))
     }
 }

--- a/actix-http/src/header/into_value.rs
+++ b/actix-http/src/header/into_value.rs
@@ -1,4 +1,4 @@
-//! [`IntoHeaderValue`] trait and implementations.
+//! [`TryIntoHeaderValue`] trait and implementations.
 
 use std::convert::TryFrom as _;
 
@@ -7,7 +7,7 @@ use http::{header::InvalidHeaderValue, Error as HttpError, HeaderValue};
 use mime::Mime;
 
 /// An interface for types that can be converted into a [`HeaderValue`].
-pub trait IntoHeaderValue: Sized {
+pub trait TryIntoHeaderValue: Sized {
     /// The type returned in the event of a conversion error.
     type Error: Into<HttpError>;
 
@@ -15,7 +15,7 @@ pub trait IntoHeaderValue: Sized {
     fn try_into_value(self) -> Result<HeaderValue, Self::Error>;
 }
 
-impl IntoHeaderValue for HeaderValue {
+impl TryIntoHeaderValue for HeaderValue {
     type Error = InvalidHeaderValue;
 
     #[inline]
@@ -24,7 +24,7 @@ impl IntoHeaderValue for HeaderValue {
     }
 }
 
-impl IntoHeaderValue for &HeaderValue {
+impl TryIntoHeaderValue for &HeaderValue {
     type Error = InvalidHeaderValue;
 
     #[inline]
@@ -33,7 +33,7 @@ impl IntoHeaderValue for &HeaderValue {
     }
 }
 
-impl IntoHeaderValue for &str {
+impl TryIntoHeaderValue for &str {
     type Error = InvalidHeaderValue;
 
     #[inline]
@@ -42,7 +42,7 @@ impl IntoHeaderValue for &str {
     }
 }
 
-impl IntoHeaderValue for &[u8] {
+impl TryIntoHeaderValue for &[u8] {
     type Error = InvalidHeaderValue;
 
     #[inline]
@@ -51,7 +51,7 @@ impl IntoHeaderValue for &[u8] {
     }
 }
 
-impl IntoHeaderValue for Bytes {
+impl TryIntoHeaderValue for Bytes {
     type Error = InvalidHeaderValue;
 
     #[inline]
@@ -60,7 +60,7 @@ impl IntoHeaderValue for Bytes {
     }
 }
 
-impl IntoHeaderValue for Vec<u8> {
+impl TryIntoHeaderValue for Vec<u8> {
     type Error = InvalidHeaderValue;
 
     #[inline]
@@ -69,7 +69,7 @@ impl IntoHeaderValue for Vec<u8> {
     }
 }
 
-impl IntoHeaderValue for String {
+impl TryIntoHeaderValue for String {
     type Error = InvalidHeaderValue;
 
     #[inline]
@@ -78,7 +78,7 @@ impl IntoHeaderValue for String {
     }
 }
 
-impl IntoHeaderValue for usize {
+impl TryIntoHeaderValue for usize {
     type Error = InvalidHeaderValue;
 
     #[inline]
@@ -87,7 +87,7 @@ impl IntoHeaderValue for usize {
     }
 }
 
-impl IntoHeaderValue for i64 {
+impl TryIntoHeaderValue for i64 {
     type Error = InvalidHeaderValue;
 
     #[inline]
@@ -96,7 +96,7 @@ impl IntoHeaderValue for i64 {
     }
 }
 
-impl IntoHeaderValue for u64 {
+impl TryIntoHeaderValue for u64 {
     type Error = InvalidHeaderValue;
 
     #[inline]
@@ -105,7 +105,7 @@ impl IntoHeaderValue for u64 {
     }
 }
 
-impl IntoHeaderValue for i32 {
+impl TryIntoHeaderValue for i32 {
     type Error = InvalidHeaderValue;
 
     #[inline]
@@ -114,7 +114,7 @@ impl IntoHeaderValue for i32 {
     }
 }
 
-impl IntoHeaderValue for u32 {
+impl TryIntoHeaderValue for u32 {
     type Error = InvalidHeaderValue;
 
     #[inline]
@@ -123,7 +123,7 @@ impl IntoHeaderValue for u32 {
     }
 }
 
-impl IntoHeaderValue for Mime {
+impl TryIntoHeaderValue for Mime {
     type Error = InvalidHeaderValue;
 
     #[inline]

--- a/actix-http/src/header/map.rs
+++ b/actix-http/src/header/map.rs
@@ -333,7 +333,7 @@ impl HeaderMap {
         }
     }
 
-    /// Inserts a name-value pair into the map.
+    /// Inserts (overrides) a name-value pair in the map.
     ///
     /// If the map already contained this key, the new value is associated with the key and all
     /// previous values are removed and returned as a `Removed` iterator. The key is not updated;
@@ -372,7 +372,7 @@ impl HeaderMap {
         Removed::new(value)
     }
 
-    /// Inserts a name-value pair into the map.
+    /// Appends a name-value pair to the map.
     ///
     /// If the map already contained this key, the new value is added to the list of values
     /// currently associated with the key. The key is not updated; this matters for types that can

--- a/actix-http/src/header/mod.rs
+++ b/actix-http/src/header/mod.rs
@@ -37,7 +37,7 @@ mod shared;
 mod utils;
 
 pub use self::as_name::AsHeaderName;
-pub use self::into_pair::IntoHeaderPair;
+pub use self::into_pair::TryIntoHeaderPair;
 pub use self::into_value::IntoHeaderValue;
 pub use self::map::HeaderMap;
 pub use self::shared::{

--- a/actix-http/src/header/mod.rs
+++ b/actix-http/src/header/mod.rs
@@ -38,7 +38,7 @@ mod utils;
 
 pub use self::as_name::AsHeaderName;
 pub use self::into_pair::TryIntoHeaderPair;
-pub use self::into_value::IntoHeaderValue;
+pub use self::into_value::TryIntoHeaderValue;
 pub use self::map::HeaderMap;
 pub use self::shared::{
     parse_extended_value, q, Charset, ContentEncoding, ExtendedValue, HttpDate, LanguageTag,
@@ -49,7 +49,7 @@ pub use self::utils::{
 };
 
 /// An interface for types that already represent a valid header.
-pub trait Header: IntoHeaderValue {
+pub trait Header: TryIntoHeaderValue {
     /// Returns the name of the header field
     fn name() -> HeaderName;
 

--- a/actix-http/src/header/shared/content_encoding.rs
+++ b/actix-http/src/header/shared/content_encoding.rs
@@ -5,7 +5,7 @@ use http::header::InvalidHeaderValue;
 
 use crate::{
     error::ParseError,
-    header::{self, from_one_raw_str, Header, HeaderName, HeaderValue, IntoHeaderValue},
+    header::{self, from_one_raw_str, Header, HeaderName, HeaderValue, TryIntoHeaderValue},
     HttpMessage,
 };
 
@@ -96,7 +96,7 @@ impl TryFrom<&str> for ContentEncoding {
     }
 }
 
-impl IntoHeaderValue for ContentEncoding {
+impl TryIntoHeaderValue for ContentEncoding {
     type Error = InvalidHeaderValue;
 
     fn try_into_value(self) -> Result<http::HeaderValue, Self::Error> {

--- a/actix-http/src/header/shared/http_date.rs
+++ b/actix-http/src/header/shared/http_date.rs
@@ -4,7 +4,8 @@ use bytes::BytesMut;
 use http::header::{HeaderValue, InvalidHeaderValue};
 
 use crate::{
-    config::DATE_VALUE_LENGTH, error::ParseError, header::IntoHeaderValue, helpers::MutWriter,
+    config::DATE_VALUE_LENGTH, error::ParseError, header::TryIntoHeaderValue,
+    helpers::MutWriter,
 };
 
 /// A timestamp with HTTP-style formatting and parsing.
@@ -29,7 +30,7 @@ impl fmt::Display for HttpDate {
     }
 }
 
-impl IntoHeaderValue for HttpDate {
+impl TryIntoHeaderValue for HttpDate {
     type Error = InvalidHeaderValue;
 
     fn try_into_value(self) -> Result<HeaderValue, Self::Error> {

--- a/actix-http/src/response.rs
+++ b/actix-http/src/response.rs
@@ -11,7 +11,7 @@ use bytestring::ByteString;
 use crate::{
     body::{BoxBody, MessageBody},
     extensions::Extensions,
-    header::{self, HeaderMap, IntoHeaderValue},
+    header::{self, HeaderMap, TryIntoHeaderValue},
     message::{BoxedResponseHead, ResponseHead},
     Error, ResponseBuilder, StatusCode,
 };

--- a/actix-http/src/response_builder.rs
+++ b/actix-http/src/response_builder.rs
@@ -92,7 +92,7 @@ impl ResponseBuilder {
     /// ```
     pub fn insert_header(&mut self, header: impl TryIntoHeaderPair) -> &mut Self {
         if let Some(parts) = self.inner() {
-            match header.try_into_header_pair() {
+            match header.try_into_pair() {
                 Ok((key, value)) => {
                     parts.headers.insert(key, value);
                 }
@@ -120,7 +120,7 @@ impl ResponseBuilder {
     /// ```
     pub fn append_header(&mut self, header: impl TryIntoHeaderPair) -> &mut Self {
         if let Some(parts) = self.inner() {
-            match header.try_into_header_pair() {
+            match header.try_into_pair() {
                 Ok((key, value)) => parts.headers.append(key, value),
                 Err(e) => self.err = Some(e.into()),
             };

--- a/actix-http/src/response_builder.rs
+++ b/actix-http/src/response_builder.rs
@@ -8,7 +8,7 @@ use std::{
 use crate::{
     body::{EitherBody, MessageBody},
     error::{Error, HttpError},
-    header::{self, IntoHeaderPair, IntoHeaderValue},
+    header::{self, IntoHeaderValue, TryIntoHeaderPair},
     message::{BoxedResponseHead, ConnectionType, ResponseHead},
     Extensions, Response, StatusCode,
 };
@@ -90,10 +90,7 @@ impl ResponseBuilder {
     /// assert!(res.headers().contains_key("content-type"));
     /// assert!(res.headers().contains_key("x-test"));
     /// ```
-    pub fn insert_header<H>(&mut self, header: H) -> &mut Self
-    where
-        H: IntoHeaderPair,
-    {
+    pub fn insert_header(&mut self, header: impl TryIntoHeaderPair) -> &mut Self {
         if let Some(parts) = self.inner() {
             match header.try_into_header_pair() {
                 Ok((key, value)) => {
@@ -121,10 +118,7 @@ impl ResponseBuilder {
     /// assert_eq!(res.headers().get_all("content-type").count(), 1);
     /// assert_eq!(res.headers().get_all("x-test").count(), 2);
     /// ```
-    pub fn append_header<H>(&mut self, header: H) -> &mut Self
-    where
-        H: IntoHeaderPair,
-    {
+    pub fn append_header(&mut self, header: impl TryIntoHeaderPair) -> &mut Self {
         if let Some(parts) = self.inner() {
             match header.try_into_header_pair() {
                 Ok((key, value)) => parts.headers.append(key, value),

--- a/actix-http/src/response_builder.rs
+++ b/actix-http/src/response_builder.rs
@@ -8,7 +8,7 @@ use std::{
 use crate::{
     body::{EitherBody, MessageBody},
     error::{Error, HttpError},
-    header::{self, IntoHeaderValue, TryIntoHeaderPair},
+    header::{self, TryIntoHeaderPair, TryIntoHeaderValue},
     message::{BoxedResponseHead, ConnectionType, ResponseHead},
     Extensions, Response, StatusCode,
 };
@@ -151,7 +151,7 @@ impl ResponseBuilder {
     #[inline]
     pub fn upgrade<V>(&mut self, value: V) -> &mut Self
     where
-        V: IntoHeaderValue,
+        V: TryIntoHeaderValue,
     {
         if let Some(parts) = self.inner() {
             parts.set_connection_type(ConnectionType::Upgrade);
@@ -189,7 +189,7 @@ impl ResponseBuilder {
     #[inline]
     pub fn content_type<V>(&mut self, value: V) -> &mut Self
     where
-        V: IntoHeaderValue,
+        V: TryIntoHeaderValue,
     {
         if let Some(parts) = self.inner() {
             match value.try_into_value() {

--- a/actix-http/src/test.rs
+++ b/actix-http/src/test.rs
@@ -93,7 +93,7 @@ impl TestRequest {
 
     /// Insert a header, replacing any that were set with an equivalent field name.
     pub fn insert_header(&mut self, header: impl TryIntoHeaderPair) -> &mut Self {
-        match header.try_into_header_pair() {
+        match header.try_into_pair() {
             Ok((key, value)) => {
                 parts(&mut self.0).headers.insert(key, value);
             }
@@ -107,7 +107,7 @@ impl TestRequest {
 
     /// Append a header, keeping any that were set with an equivalent field name.
     pub fn append_header(&mut self, header: impl TryIntoHeaderPair) -> &mut Self {
-        match header.try_into_header_pair() {
+        match header.try_into_pair() {
             Ok((key, value)) => {
                 parts(&mut self.0).headers.append(key, value);
             }

--- a/actix-http/src/test.rs
+++ b/actix-http/src/test.rs
@@ -14,7 +14,7 @@ use bytes::{Bytes, BytesMut};
 use http::{Method, Uri, Version};
 
 use crate::{
-    header::{HeaderMap, IntoHeaderPair},
+    header::{HeaderMap, TryIntoHeaderPair},
     payload::Payload,
     Request,
 };
@@ -92,10 +92,7 @@ impl TestRequest {
     }
 
     /// Insert a header, replacing any that were set with an equivalent field name.
-    pub fn insert_header<H>(&mut self, header: H) -> &mut Self
-    where
-        H: IntoHeaderPair,
-    {
+    pub fn insert_header(&mut self, header: impl TryIntoHeaderPair) -> &mut Self {
         match header.try_into_header_pair() {
             Ok((key, value)) => {
                 parts(&mut self.0).headers.insert(key, value);
@@ -109,10 +106,7 @@ impl TestRequest {
     }
 
     /// Append a header, keeping any that were set with an equivalent field name.
-    pub fn append_header<H>(&mut self, header: H) -> &mut Self
-    where
-        H: IntoHeaderPair,
-    {
+    pub fn append_header(&mut self, header: impl TryIntoHeaderPair) -> &mut Self {
         match header.try_into_header_pair() {
             Ok((key, value)) => {
                 parts(&mut self.0).headers.append(key, value);

--- a/awc/CHANGES.md
+++ b/awc/CHANGES.md
@@ -60,7 +60,7 @@
 * `ConnectorService` type is renamed to `BoxConnectorService`. [#2081]
 * Fix http/https encoding when enabling `compress` feature. [#2116]
 * Rename `TestResponse::header` to `append_header`, `set` to `insert_header`. `TestResponse` header
-  methods now take `IntoHeaderPair` tuples. [#2094]
+  methods now take `TryIntoHeaderPair` tuples. [#2094]
 
 [#2081]: https://github.com/actix/actix-web/pull/2081
 [#2094]: https://github.com/actix/actix-web/pull/2094

--- a/awc/CHANGES.md
+++ b/awc/CHANGES.md
@@ -1,6 +1,9 @@
 # Changes
 
 ## Unreleased - 2021-xx-xx
+* Add `ClientBuilder::add_default_header` and deprecate `ClientBuilder::header`. [#2510]
+
+[#2510]: https://github.com/actix/actix-web/pull/2510
 
 
 ## 3.0.0-beta.13 - 2021-12-11

--- a/awc/src/builder.rs
+++ b/awc/src/builder.rs
@@ -168,7 +168,7 @@ where
     /// # Panics
     /// Panics if header name or value is invalid.
     pub fn add_default_header(mut self, header: impl TryIntoHeaderPair) -> Self {
-        match header.try_into_header_pair() {
+        match header.try_into_pair() {
             Ok((key, value)) => self.default_headers.append(key, value),
             Err(err) => panic!("Header error: {:?}", err.into()),
         }

--- a/awc/src/builder.rs
+++ b/awc/src/builder.rs
@@ -2,7 +2,7 @@ use std::{convert::TryFrom, fmt, net::IpAddr, rc::Rc, time::Duration};
 
 use actix_http::{
     error::HttpError,
-    header::{self, HeaderMap, HeaderName},
+    header::{self, HeaderMap, HeaderName, TryIntoHeaderPair},
     Uri,
 };
 use actix_rt::net::{ActixStream, TcpStream};
@@ -21,11 +21,11 @@ use crate::{
 /// This type can be used to construct an instance of `Client` through a
 /// builder-like pattern.
 pub struct ClientBuilder<S = (), M = ()> {
-    default_headers: bool,
     max_http_version: Option<http::Version>,
     stream_window_size: Option<u32>,
     conn_window_size: Option<u32>,
-    headers: HeaderMap,
+    fundamental_headers: bool,
+    default_headers: HeaderMap,
     timeout: Option<Duration>,
     connector: Connector<S>,
     middleware: M,
@@ -44,15 +44,15 @@ impl ClientBuilder {
         (),
     > {
         ClientBuilder {
-            middleware: (),
-            default_headers: true,
-            headers: HeaderMap::new(),
-            timeout: Some(Duration::from_secs(5)),
-            local_address: None,
-            connector: Connector::new(),
             max_http_version: None,
             stream_window_size: None,
             conn_window_size: None,
+            fundamental_headers: true,
+            default_headers: HeaderMap::new(),
+            timeout: Some(Duration::from_secs(5)),
+            connector: Connector::new(),
+            middleware: (),
+            local_address: None,
             max_redirects: 10,
         }
     }
@@ -78,8 +78,8 @@ where
     {
         ClientBuilder {
             middleware: self.middleware,
+            fundamental_headers: self.fundamental_headers,
             default_headers: self.default_headers,
-            headers: self.headers,
             timeout: self.timeout,
             local_address: self.local_address,
             connector,
@@ -153,15 +153,31 @@ where
         self
     }
 
-    /// Do not add default request headers.
+    /// Do not add fundamental default request headers.
+    ///
     /// By default `Date` and `User-Agent` headers are set.
     pub fn no_default_headers(mut self) -> Self {
-        self.default_headers = false;
+        self.fundamental_headers = false;
         self
     }
 
-    /// Add default header. Headers added by this method
-    /// get added to every request.
+    /// Add default header.
+    ///
+    /// Headers added by this method get added to every request unless overriden by .
+    ///
+    /// # Panics
+    /// Panics if header name or value is invalid.
+    pub fn add_default_header(mut self, header: impl TryIntoHeaderPair) -> Self {
+        match header.try_into_header_pair() {
+            Ok((key, value)) => self.default_headers.append(key, value),
+            Err(err) => panic!("Header error: {:?}", err.into()),
+        }
+
+        self
+    }
+
+    #[doc(hidden)]
+    #[deprecated(since = "3.0.0", note = "Prefer `add_default_header((key, value))`.")]
     pub fn header<K, V>(mut self, key: K, value: V) -> Self
     where
         HeaderName: TryFrom<K>,
@@ -172,11 +188,11 @@ where
         match HeaderName::try_from(key) {
             Ok(key) => match value.try_into_value() {
                 Ok(value) => {
-                    self.headers.append(key, value);
+                    self.default_headers.append(key, value);
                 }
-                Err(e) => log::error!("Header value error: {:?}", e),
+                Err(err) => log::error!("Header value error: {:?}", err),
             },
-            Err(e) => log::error!("Header name error: {:?}", e),
+            Err(err) => log::error!("Header name error: {:?}", err),
         }
         self
     }
@@ -190,10 +206,10 @@ where
             Some(password) => format!("{}:{}", username, password),
             None => format!("{}:", username),
         };
-        self.header(
+        self.add_default_header((
             header::AUTHORIZATION,
             format!("Basic {}", base64::encode(&auth)),
-        )
+        ))
     }
 
     /// Set client wide HTTP bearer authentication header
@@ -201,13 +217,12 @@ where
     where
         T: fmt::Display,
     {
-        self.header(header::AUTHORIZATION, format!("Bearer {}", token))
+        self.add_default_header((header::AUTHORIZATION, format!("Bearer {}", token)))
     }
 
-    /// Registers middleware, in the form of a middleware component (type),
-    /// that runs during inbound and/or outbound processing in the request
-    /// life-cycle (request -> response), modifying request/response as
-    /// necessary, across all requests managed by the Client.
+    /// Registers middleware, in the form of a middleware component (type), that runs during inbound
+    /// and/or outbound processing in the request life-cycle (request -> response),
+    /// modifying request/response as necessary, across all requests managed by the `Client`.
     pub fn wrap<S1, M1>(
         self,
         mw: M1,
@@ -218,11 +233,11 @@ where
     {
         ClientBuilder {
             middleware: NestTransform::new(self.middleware, mw),
-            default_headers: self.default_headers,
+            fundamental_headers: self.fundamental_headers,
             max_http_version: self.max_http_version,
             stream_window_size: self.stream_window_size,
             conn_window_size: self.conn_window_size,
-            headers: self.headers,
+            default_headers: self.default_headers,
             timeout: self.timeout,
             connector: self.connector,
             local_address: self.local_address,
@@ -237,10 +252,10 @@ where
         M::Transform:
             Service<ConnectRequest, Response = ConnectResponse, Error = SendRequestError>,
     {
-        let redirect_time = self.max_redirects;
+        let max_redirects = self.max_redirects;
 
-        if redirect_time > 0 {
-            self.wrap(Redirect::new().max_redirect_times(redirect_time))
+        if max_redirects > 0 {
+            self.wrap(Redirect::new().max_redirect_times(max_redirects))
                 ._finish()
         } else {
             self._finish()
@@ -272,7 +287,7 @@ where
         let connector = boxed::rc_service(self.middleware.new_transform(connector));
 
         Client(ClientConfig {
-            headers: Rc::new(self.headers),
+            default_headers: Rc::new(self.default_headers),
             timeout: self.timeout,
             connector,
         })
@@ -288,7 +303,7 @@ mod tests {
         let client = ClientBuilder::new().basic_auth("username", Some("password"));
         assert_eq!(
             client
-                .headers
+                .default_headers
                 .get(header::AUTHORIZATION)
                 .unwrap()
                 .to_str()
@@ -299,7 +314,7 @@ mod tests {
         let client = ClientBuilder::new().basic_auth("username", None);
         assert_eq!(
             client
-                .headers
+                .default_headers
                 .get(header::AUTHORIZATION)
                 .unwrap()
                 .to_str()
@@ -313,7 +328,7 @@ mod tests {
         let client = ClientBuilder::new().bearer_auth("someS3cr3tAutht0k3n");
         assert_eq!(
             client
-                .headers
+                .default_headers
                 .get(header::AUTHORIZATION)
                 .unwrap()
                 .to_str()

--- a/awc/src/builder.rs
+++ b/awc/src/builder.rs
@@ -166,7 +166,7 @@ where
     where
         HeaderName: TryFrom<K>,
         <HeaderName as TryFrom<K>>::Error: fmt::Debug + Into<HttpError>,
-        V: header::IntoHeaderValue,
+        V: header::TryIntoHeaderValue,
         V::Error: fmt::Debug,
     {
         match HeaderName::try_from(key) {

--- a/awc/src/client/h1proto.rs
+++ b/awc/src/client/h1proto.rs
@@ -9,7 +9,7 @@ use actix_http::{
     body::{BodySize, MessageBody},
     error::PayloadError,
     h1,
-    header::{HeaderMap, IntoHeaderValue, EXPECT, HOST},
+    header::{HeaderMap, TryIntoHeaderValue, EXPECT, HOST},
     Payload, RequestHeadType, ResponseHead, StatusCode,
 };
 use actix_utils::future::poll_fn;

--- a/awc/src/frozen.rs
+++ b/awc/src/frozen.rs
@@ -6,7 +6,7 @@ use serde::Serialize;
 
 use actix_http::{
     error::HttpError,
-    header::{HeaderMap, HeaderName, IntoHeaderValue},
+    header::{HeaderMap, HeaderName, TryIntoHeaderValue},
     Method, RequestHead, Uri,
 };
 
@@ -114,7 +114,7 @@ impl FrozenClientRequest {
     where
         HeaderName: TryFrom<K>,
         <HeaderName as TryFrom<K>>::Error: Into<HttpError>,
-        V: IntoHeaderValue,
+        V: TryIntoHeaderValue,
     {
         self.extra_headers(HeaderMap::new())
             .extra_header(key, value)
@@ -142,7 +142,7 @@ impl FrozenSendBuilder {
     where
         HeaderName: TryFrom<K>,
         <HeaderName as TryFrom<K>>::Error: Into<HttpError>,
-        V: IntoHeaderValue,
+        V: TryIntoHeaderValue,
     {
         match HeaderName::try_from(key) {
             Ok(key) => match value.try_into_value() {

--- a/awc/src/lib.rs
+++ b/awc/src/lib.rs
@@ -168,7 +168,7 @@ pub struct Client(ClientConfig);
 #[derive(Clone)]
 pub(crate) struct ClientConfig {
     pub(crate) connector: BoxConnectorService,
-    pub(crate) headers: Rc<HeaderMap>,
+    pub(crate) default_headers: Rc<HeaderMap>,
     pub(crate) timeout: Option<Duration>,
 }
 
@@ -204,7 +204,9 @@ impl Client {
     {
         let mut req = ClientRequest::new(method, url, self.0.clone());
 
-        for header in self.0.headers.iter() {
+        for header in self.0.default_headers.iter() {
+            // header map is empty
+            // TODO: probably append instead
             req = req.insert_header_if_none(header);
         }
         req
@@ -297,7 +299,7 @@ impl Client {
         <Uri as TryFrom<U>>::Error: Into<HttpError>,
     {
         let mut req = ws::WebsocketsRequest::new(url, self.0.clone());
-        for (key, value) in self.0.headers.iter() {
+        for (key, value) in self.0.default_headers.iter() {
             req.head.headers.insert(key.clone(), value.clone());
         }
         req
@@ -308,6 +310,6 @@ impl Client {
     /// Returns Some(&mut HeaderMap) when Client object is unique
     /// (No other clone of client exists at the same time).
     pub fn headers(&mut self) -> Option<&mut HeaderMap> {
-        Rc::get_mut(&mut self.0.headers)
+        Rc::get_mut(&mut self.0.default_headers)
     }
 }

--- a/awc/src/middleware/redirect.rs
+++ b/awc/src/middleware/redirect.rs
@@ -442,13 +442,15 @@ mod tests {
         });
 
         let client = ClientBuilder::new()
-            .header("custom", "value")
+            .add_default_header(("custom", "value"))
             .disable_redirects()
             .finish();
         let res = client.get(srv.url("/")).send().await.unwrap();
         assert_eq!(res.status().as_u16(), 302);
 
-        let client = ClientBuilder::new().header("custom", "value").finish();
+        let client = ClientBuilder::new()
+            .add_default_header(("custom", "value"))
+            .finish();
         let res = client.get(srv.url("/")).send().await.unwrap();
         assert_eq!(res.status().as_u16(), 200);
 
@@ -520,7 +522,7 @@ mod tests {
 
         // send a request to different origins, http://srv1/ then http://srv2/. So it should remove the header
         let client = ClientBuilder::new()
-            .header(header::AUTHORIZATION, "auth_key_value")
+            .add_default_header((header::AUTHORIZATION, "auth_key_value"))
             .finish();
         let res = client.get(srv1.url("/")).send().await.unwrap();
         assert_eq!(res.status().as_u16(), 200);

--- a/awc/src/request.rs
+++ b/awc/src/request.rs
@@ -579,7 +579,7 @@ mod tests {
     #[actix_rt::test]
     async fn test_client_header() {
         let req = Client::builder()
-            .header(header::CONTENT_TYPE, "111")
+            .add_default_header((header::CONTENT_TYPE, "111"))
             .finish()
             .get("/");
 
@@ -597,7 +597,7 @@ mod tests {
     #[actix_rt::test]
     async fn test_client_header_override() {
         let req = Client::builder()
-            .header(header::CONTENT_TYPE, "111")
+            .add_default_header((header::CONTENT_TYPE, "111"))
             .finish()
             .get("/")
             .insert_header((header::CONTENT_TYPE, "222"));

--- a/awc/src/request.rs
+++ b/awc/src/request.rs
@@ -6,7 +6,7 @@ use serde::Serialize;
 
 use actix_http::{
     error::HttpError,
-    header::{self, HeaderMap, HeaderValue, IntoHeaderPair},
+    header::{self, HeaderMap, HeaderValue, TryIntoHeaderPair},
     ConnectionType, Method, RequestHead, Uri, Version,
 };
 
@@ -147,10 +147,7 @@ impl ClientRequest {
     }
 
     /// Insert a header, replacing any that were set with an equivalent field name.
-    pub fn insert_header<H>(mut self, header: H) -> Self
-    where
-        H: IntoHeaderPair,
-    {
+    pub fn insert_header(mut self, header: impl TryIntoHeaderPair) -> Self {
         match header.try_into_header_pair() {
             Ok((key, value)) => {
                 self.head.headers.insert(key, value);
@@ -162,10 +159,7 @@ impl ClientRequest {
     }
 
     /// Insert a header only if it is not yet set.
-    pub fn insert_header_if_none<H>(mut self, header: H) -> Self
-    where
-        H: IntoHeaderPair,
-    {
+    pub fn insert_header_if_none(mut self, header: impl TryIntoHeaderPair) -> Self {
         match header.try_into_header_pair() {
             Ok((key, value)) => {
                 if !self.head.headers.contains_key(&key) {
@@ -192,10 +186,7 @@ impl ClientRequest {
     ///     .insert_header((CONTENT_TYPE, mime::APPLICATION_JSON));
     /// # }
     /// ```
-    pub fn append_header<H>(mut self, header: H) -> Self
-    where
-        H: IntoHeaderPair,
-    {
+    pub fn append_header(mut self, header: impl TryIntoHeaderPair) -> Self {
         match header.try_into_header_pair() {
             Ok((key, value)) => self.head.headers.append(key, value),
             Err(e) => self.err = Some(e.into()),

--- a/awc/src/request.rs
+++ b/awc/src/request.rs
@@ -148,7 +148,7 @@ impl ClientRequest {
 
     /// Insert a header, replacing any that were set with an equivalent field name.
     pub fn insert_header(mut self, header: impl TryIntoHeaderPair) -> Self {
-        match header.try_into_header_pair() {
+        match header.try_into_pair() {
             Ok((key, value)) => {
                 self.head.headers.insert(key, value);
             }
@@ -160,7 +160,7 @@ impl ClientRequest {
 
     /// Insert a header only if it is not yet set.
     pub fn insert_header_if_none(mut self, header: impl TryIntoHeaderPair) -> Self {
-        match header.try_into_header_pair() {
+        match header.try_into_pair() {
             Ok((key, value)) => {
                 if !self.head.headers.contains_key(&key) {
                     self.head.headers.insert(key, value);
@@ -187,7 +187,7 @@ impl ClientRequest {
     /// # }
     /// ```
     pub fn append_header(mut self, header: impl TryIntoHeaderPair) -> Self {
-        match header.try_into_header_pair() {
+        match header.try_into_pair() {
             Ok((key, value)) => self.head.headers.append(key, value),
             Err(e) => self.err = Some(e.into()),
         };

--- a/awc/src/sender.rs
+++ b/awc/src/sender.rs
@@ -10,7 +10,7 @@ use std::{
 use actix_http::{
     body::BodyStream,
     error::HttpError,
-    header::{self, HeaderMap, HeaderName, IntoHeaderValue},
+    header::{self, HeaderMap, HeaderName, TryIntoHeaderValue},
     RequestHead, RequestHeadType,
 };
 use actix_rt::time::{sleep, Sleep};
@@ -298,7 +298,7 @@ impl RequestSender {
 
     fn set_header_if_none<V>(&mut self, key: HeaderName, value: V) -> Result<(), HttpError>
     where
-        V: IntoHeaderValue,
+        V: TryIntoHeaderValue,
     {
         match self {
             RequestSender::Owned(head) => {

--- a/awc/src/test.rs
+++ b/awc/src/test.rs
@@ -1,6 +1,6 @@
 //! Test helpers for actix http client to use during testing.
 
-use actix_http::{h1, header::IntoHeaderPair, Payload, ResponseHead, StatusCode, Version};
+use actix_http::{h1, header::TryIntoHeaderPair, Payload, ResponseHead, StatusCode, Version};
 use bytes::Bytes;
 
 #[cfg(feature = "cookies")]
@@ -28,10 +28,7 @@ impl Default for TestResponse {
 
 impl TestResponse {
     /// Create TestResponse and set header
-    pub fn with_header<H>(header: H) -> Self
-    where
-        H: IntoHeaderPair,
-    {
+    pub fn with_header(header: impl TryIntoHeaderPair) -> Self {
         Self::default().insert_header(header)
     }
 
@@ -42,10 +39,7 @@ impl TestResponse {
     }
 
     /// Insert a header
-    pub fn insert_header<H>(mut self, header: H) -> Self
-    where
-        H: IntoHeaderPair,
-    {
+    pub fn insert_header(mut self, header: impl TryIntoHeaderPair) -> Self {
         if let Ok((key, value)) = header.try_into_header_pair() {
             self.head.headers.insert(key, value);
             return self;
@@ -54,10 +48,7 @@ impl TestResponse {
     }
 
     /// Append a header
-    pub fn append_header<H>(mut self, header: H) -> Self
-    where
-        H: IntoHeaderPair,
-    {
+    pub fn append_header(mut self, header: impl TryIntoHeaderPair) -> Self {
         if let Ok((key, value)) = header.try_into_header_pair() {
             self.head.headers.append(key, value);
             return self;

--- a/awc/src/test.rs
+++ b/awc/src/test.rs
@@ -40,7 +40,7 @@ impl TestResponse {
 
     /// Insert a header
     pub fn insert_header(mut self, header: impl TryIntoHeaderPair) -> Self {
-        if let Ok((key, value)) = header.try_into_header_pair() {
+        if let Ok((key, value)) = header.try_into_pair() {
             self.head.headers.insert(key, value);
             return self;
         }
@@ -49,7 +49,7 @@ impl TestResponse {
 
     /// Append a header
     pub fn append_header(mut self, header: impl TryIntoHeaderPair) -> Self {
-        if let Ok((key, value)) = header.try_into_header_pair() {
+        if let Ok((key, value)) = header.try_into_pair() {
             self.head.headers.append(key, value);
             return self;
         }

--- a/awc/src/ws.rs
+++ b/awc/src/ws.rs
@@ -39,7 +39,7 @@ use crate::{
     connect::{BoxedSocket, ConnectRequest},
     error::{HttpError, InvalidUrl, SendRequestError, WsClientError},
     http::{
-        header::{self, HeaderName, HeaderValue, IntoHeaderValue, AUTHORIZATION},
+        header::{self, HeaderName, HeaderValue, TryIntoHeaderValue, AUTHORIZATION},
         ConnectionType, Method, StatusCode, Uri, Version,
     },
     response::ClientResponse,
@@ -171,7 +171,7 @@ impl WebsocketsRequest {
     where
         HeaderName: TryFrom<K>,
         <HeaderName as TryFrom<K>>::Error: Into<HttpError>,
-        V: IntoHeaderValue,
+        V: TryIntoHeaderValue,
     {
         match HeaderName::try_from(key) {
             Ok(key) => match value.try_into_value() {
@@ -190,7 +190,7 @@ impl WebsocketsRequest {
     where
         HeaderName: TryFrom<K>,
         <HeaderName as TryFrom<K>>::Error: Into<HttpError>,
-        V: IntoHeaderValue,
+        V: TryIntoHeaderValue,
     {
         match HeaderName::try_from(key) {
             Ok(key) => match value.try_into_value() {
@@ -209,7 +209,7 @@ impl WebsocketsRequest {
     where
         HeaderName: TryFrom<K>,
         <HeaderName as TryFrom<K>>::Error: Into<HttpError>,
-        V: IntoHeaderValue,
+        V: TryIntoHeaderValue,
     {
         match HeaderName::try_from(key) {
             Ok(key) => {

--- a/awc/src/ws.rs
+++ b/awc/src/ws.rs
@@ -445,7 +445,7 @@ mod tests {
     #[actix_rt::test]
     async fn test_header_override() {
         let req = Client::builder()
-            .header(header::CONTENT_TYPE, "111")
+            .add_default_header((header::CONTENT_TYPE, "111"))
             .finish()
             .ws("/")
             .set_header(header::CONTENT_TYPE, "222");

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -22,14 +22,14 @@ async fn main() -> std::io::Result<()> {
 
     HttpServer::new(|| {
         App::new()
-            .wrap(middleware::DefaultHeaders::new().insert(("X-Version", "0.2")))
+            .wrap(middleware::DefaultHeaders::new().add(("X-Version", "0.2")))
             .wrap(middleware::Compress::default())
             .wrap(middleware::Logger::default())
             .service(index)
             .service(no_params)
             .service(
                 web::resource("/resource2/index.html")
-                    .wrap(middleware::DefaultHeaders::new().insert(("X-Version-R2", "0.3")))
+                    .wrap(middleware::DefaultHeaders::new().add(("X-Version-R2", "0.3")))
                     .default_service(web::route().to(HttpResponse::MethodNotAllowed))
                     .route(web::get().to(index_async)),
             )

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -22,14 +22,14 @@ async fn main() -> std::io::Result<()> {
 
     HttpServer::new(|| {
         App::new()
-            .wrap(middleware::DefaultHeaders::new().header("X-Version", "0.2"))
+            .wrap(middleware::DefaultHeaders::new().insert(("X-Version", "0.2")))
             .wrap(middleware::Compress::default())
             .wrap(middleware::Logger::default())
             .service(index)
             .service(no_params)
             .service(
                 web::resource("/resource2/index.html")
-                    .wrap(middleware::DefaultHeaders::new().header("X-Version-R2", "0.3"))
+                    .wrap(middleware::DefaultHeaders::new().insert(("X-Version-R2", "0.3")))
                     .default_service(web::route().to(HttpResponse::MethodNotAllowed))
                     .route(web::get().to(index_async)),
             )

--- a/examples/uds.rs
+++ b/examples/uds.rs
@@ -26,14 +26,14 @@ async fn main() -> std::io::Result<()> {
 
     HttpServer::new(|| {
         App::new()
-            .wrap(middleware::DefaultHeaders::new().insert(("X-Version", "0.2")))
+            .wrap(middleware::DefaultHeaders::new().add(("X-Version", "0.2")))
             .wrap(middleware::Compress::default())
             .wrap(middleware::Logger::default())
             .service(index)
             .service(no_params)
             .service(
                 web::resource("/resource2/index.html")
-                    .wrap(middleware::DefaultHeaders::new().insert(("X-Version-R2", "0.3")))
+                    .wrap(middleware::DefaultHeaders::new().add(("X-Version-R2", "0.3")))
                     .default_service(web::route().to(HttpResponse::MethodNotAllowed))
                     .route(web::get().to(index_async)),
             )

--- a/examples/uds.rs
+++ b/examples/uds.rs
@@ -26,14 +26,14 @@ async fn main() -> std::io::Result<()> {
 
     HttpServer::new(|| {
         App::new()
-            .wrap(middleware::DefaultHeaders::new().header("X-Version", "0.2"))
+            .wrap(middleware::DefaultHeaders::new().insert(("X-Version", "0.2")))
             .wrap(middleware::Compress::default())
             .wrap(middleware::Logger::default())
             .service(index)
             .service(no_params)
             .service(
                 web::resource("/resource2/index.html")
-                    .wrap(middleware::DefaultHeaders::new().header("X-Version-R2", "0.3"))
+                    .wrap(middleware::DefaultHeaders::new().insert(("X-Version-R2", "0.3")))
                     .default_service(web::route().to(HttpResponse::MethodNotAllowed))
                     .route(web::get().to(index_async)),
             )

--- a/src/app.rs
+++ b/src/app.rs
@@ -602,7 +602,7 @@ mod tests {
             App::new()
                 .wrap(
                     DefaultHeaders::new()
-                        .insert((header::CONTENT_TYPE, HeaderValue::from_static("0001"))),
+                        .add((header::CONTENT_TYPE, HeaderValue::from_static("0001"))),
                 )
                 .route("/test", web::get().to(HttpResponse::Ok)),
         )
@@ -623,7 +623,7 @@ mod tests {
                 .route("/test", web::get().to(HttpResponse::Ok))
                 .wrap(
                     DefaultHeaders::new()
-                        .insert((header::CONTENT_TYPE, HeaderValue::from_static("0001"))),
+                        .add((header::CONTENT_TYPE, HeaderValue::from_static("0001"))),
                 ),
         )
         .await;

--- a/src/app.rs
+++ b/src/app.rs
@@ -602,7 +602,7 @@ mod tests {
             App::new()
                 .wrap(
                     DefaultHeaders::new()
-                        .header(header::CONTENT_TYPE, HeaderValue::from_static("0001")),
+                        .insert((header::CONTENT_TYPE, HeaderValue::from_static("0001"))),
                 )
                 .route("/test", web::get().to(HttpResponse::Ok)),
         )
@@ -623,7 +623,7 @@ mod tests {
                 .route("/test", web::get().to(HttpResponse::Ok))
                 .wrap(
                     DefaultHeaders::new()
-                        .header(header::CONTENT_TYPE, HeaderValue::from_static("0001")),
+                        .insert((header::CONTENT_TYPE, HeaderValue::from_static("0001"))),
                 ),
         )
         .await;

--- a/src/error/internal.rs
+++ b/src/error/internal.rs
@@ -2,7 +2,7 @@ use std::{cell::RefCell, fmt, io::Write as _};
 
 use actix_http::{
     body::BoxBody,
-    header::{self, IntoHeaderValue as _},
+    header::{self, TryIntoHeaderValue as _},
     StatusCode,
 };
 use bytes::{BufMut as _, BytesMut};

--- a/src/error/response_error.rs
+++ b/src/error/response_error.rs
@@ -8,7 +8,7 @@ use std::{
 
 use actix_http::{
     body::BoxBody,
-    header::{self, IntoHeaderValue},
+    header::{self, TryIntoHeaderValue},
     Response, StatusCode,
 };
 use bytes::BytesMut;

--- a/src/http/header/content_disposition.rs
+++ b/src/http/header/content_disposition.rs
@@ -14,7 +14,7 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 use std::fmt::{self, Write};
 
-use super::{ExtendedValue, Header, IntoHeaderValue, Writer};
+use super::{ExtendedValue, Header, TryIntoHeaderValue, Writer};
 use crate::http::header;
 
 /// Split at the index of the first `needle` if it exists or at the end.
@@ -454,7 +454,7 @@ impl ContentDisposition {
     }
 }
 
-impl IntoHeaderValue for ContentDisposition {
+impl TryIntoHeaderValue for ContentDisposition {
     type Error = header::InvalidHeaderValue;
 
     fn try_into_value(self) -> Result<header::HeaderValue, Self::Error> {

--- a/src/http/header/content_range.rs
+++ b/src/http/header/content_range.rs
@@ -3,7 +3,7 @@ use std::{
     str::FromStr,
 };
 
-use super::{HeaderValue, IntoHeaderValue, InvalidHeaderValue, Writer, CONTENT_RANGE};
+use super::{HeaderValue, InvalidHeaderValue, TryIntoHeaderValue, Writer, CONTENT_RANGE};
 use crate::error::ParseError;
 
 crate::http::header::common_header! {
@@ -196,7 +196,7 @@ impl Display for ContentRangeSpec {
     }
 }
 
-impl IntoHeaderValue for ContentRangeSpec {
+impl TryIntoHeaderValue for ContentRangeSpec {
     type Error = InvalidHeaderValue;
 
     fn try_into_value(self) -> Result<HeaderValue, Self::Error> {

--- a/src/http/header/entity.rs
+++ b/src/http/header/entity.rs
@@ -3,7 +3,7 @@ use std::{
     str::FromStr,
 };
 
-use super::{HeaderValue, IntoHeaderValue, InvalidHeaderValue, Writer};
+use super::{HeaderValue, InvalidHeaderValue, TryIntoHeaderValue, Writer};
 
 /// check that each char in the slice is either:
 /// 1. `%x21`, or
@@ -159,7 +159,7 @@ impl FromStr for EntityTag {
     }
 }
 
-impl IntoHeaderValue for EntityTag {
+impl TryIntoHeaderValue for EntityTag {
     type Error = InvalidHeaderValue;
 
     fn try_into_value(self) -> Result<HeaderValue, Self::Error> {

--- a/src/http/header/if_range.rs
+++ b/src/http/header/if_range.rs
@@ -1,8 +1,8 @@
 use std::fmt::{self, Display, Write};
 
 use super::{
-    from_one_raw_str, EntityTag, Header, HeaderName, HeaderValue, HttpDate, IntoHeaderValue,
-    InvalidHeaderValue, Writer,
+    from_one_raw_str, EntityTag, Header, HeaderName, HeaderValue, HttpDate, InvalidHeaderValue,
+    TryIntoHeaderValue, Writer,
 };
 use crate::error::ParseError;
 use crate::http::header;
@@ -96,7 +96,7 @@ impl Display for IfRange {
     }
 }
 
-impl IntoHeaderValue for IfRange {
+impl TryIntoHeaderValue for IfRange {
     type Error = InvalidHeaderValue;
 
     fn try_into_value(self) -> Result<HeaderValue, Self::Error> {

--- a/src/http/header/macros.rs
+++ b/src/http/header/macros.rs
@@ -125,7 +125,7 @@ macro_rules! common_header {
             }
         }
 
-        impl $crate::http::header::IntoHeaderValue for $id {
+        impl $crate::http::header::TryIntoHeaderValue for $id {
             type Error = $crate::http::header::InvalidHeaderValue;
 
             #[inline]
@@ -172,7 +172,7 @@ macro_rules! common_header {
             }
         }
 
-        impl $crate::http::header::IntoHeaderValue for $id {
+        impl $crate::http::header::TryIntoHeaderValue for $id {
             type Error = $crate::http::header::InvalidHeaderValue;
 
             #[inline]
@@ -211,7 +211,7 @@ macro_rules! common_header {
             }
         }
 
-        impl $crate::http::header::IntoHeaderValue for $id {
+        impl $crate::http::header::TryIntoHeaderValue for $id {
             type Error = $crate::http::header::InvalidHeaderValue;
 
             #[inline]
@@ -266,7 +266,7 @@ macro_rules! common_header {
             }
         }
 
-        impl $crate::http::header::IntoHeaderValue for $id {
+        impl $crate::http::header::TryIntoHeaderValue for $id {
             type Error = $crate::http::header::InvalidHeaderValue;
 
             #[inline]

--- a/src/http/header/range.rs
+++ b/src/http/header/range.rs
@@ -6,7 +6,7 @@ use std::{
 
 use actix_http::{error::ParseError, header, HttpMessage};
 
-use super::{Header, HeaderName, HeaderValue, IntoHeaderValue, InvalidHeaderValue, Writer};
+use super::{Header, HeaderName, HeaderValue, InvalidHeaderValue, TryIntoHeaderValue, Writer};
 
 /// `Range` header, defined
 /// in [RFC 7233 §3.1](https://datatracker.ietf.org/doc/html/rfc7233#section-3.1)
@@ -274,7 +274,7 @@ impl Header for Range {
     }
 }
 
-impl IntoHeaderValue for Range {
+impl TryIntoHeaderValue for Range {
     type Error = InvalidHeaderValue;
 
     fn try_into_value(self) -> Result<HeaderValue, Self::Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,6 @@ pub mod middleware;
 mod request;
 mod request_data;
 mod resource;
-mod responder;
 mod response;
 mod rmap;
 mod route;
@@ -109,12 +108,10 @@ pub use crate::error::{Error, ResponseError, Result};
 pub use crate::extract::FromRequest;
 pub use crate::request::HttpRequest;
 pub use crate::resource::Resource;
-pub use crate::responder::Responder;
-pub use crate::response::{HttpResponse, HttpResponseBuilder};
+pub use crate::response::{CustomizeResponder, HttpResponse, HttpResponseBuilder, Responder};
 pub use crate::route::Route;
 pub use crate::scope::Scope;
 pub use crate::server::HttpServer;
-// TODO: is exposing the error directly really needed
-pub use crate::types::{Either, EitherExtractError};
+pub use crate::types::Either;
 
 pub(crate) type BoxError = Box<dyn std::error::Error>;

--- a/src/middleware/default_headers.rs
+++ b/src/middleware/default_headers.rs
@@ -63,7 +63,7 @@ impl DefaultHeaders {
         // standard header terminology `insert` or `append` for this method would make the behavior
         // of this middleware less obvious since it only adds the headers if they are not present
 
-        match header.try_into_header_pair() {
+        match header.try_into_pair() {
             Ok((key, value)) => Rc::get_mut(&mut self.inner)
                 .expect("All default headers must be added before cloning.")
                 .headers

--- a/src/middleware/default_headers.rs
+++ b/src/middleware/default_headers.rs
@@ -75,7 +75,10 @@ impl DefaultHeaders {
     }
 
     #[doc(hidden)]
-    #[deprecated(since = "4.0.0", note = "Prefer `add`.")]
+    #[deprecated(
+        since = "4.0.0",
+        note = "Prefer `.add((key, value))`. Will be removed in v5."
+    )]
     pub fn header<K, V>(self, key: K, value: V) -> Self
     where
         HeaderName: TryFrom<K>,

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -33,7 +33,7 @@ mod tests {
         let _ = App::new()
             .wrap(Compat::new(Logger::default()))
             .wrap(Condition::new(true, DefaultHeaders::new()))
-            .wrap(DefaultHeaders::new().insert(("X-Test2", "X-Value2")))
+            .wrap(DefaultHeaders::new().add(("X-Test2", "X-Value2")))
             .wrap(ErrorHandlers::new().handler(StatusCode::FORBIDDEN, |res| {
                 Ok(ErrorHandlerResponse::Response(res))
             }))
@@ -46,7 +46,7 @@ mod tests {
             .wrap(ErrorHandlers::new().handler(StatusCode::FORBIDDEN, |res| {
                 Ok(ErrorHandlerResponse::Response(res))
             }))
-            .wrap(DefaultHeaders::new().insert(("X-Test2", "X-Value2")))
+            .wrap(DefaultHeaders::new().add(("X-Test2", "X-Value2")))
             .wrap(Condition::new(true, DefaultHeaders::new()))
             .wrap(Compat::new(Logger::default()));
 

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -33,7 +33,7 @@ mod tests {
         let _ = App::new()
             .wrap(Compat::new(Logger::default()))
             .wrap(Condition::new(true, DefaultHeaders::new()))
-            .wrap(DefaultHeaders::new().header("X-Test2", "X-Value2"))
+            .wrap(DefaultHeaders::new().insert(("X-Test2", "X-Value2")))
             .wrap(ErrorHandlers::new().handler(StatusCode::FORBIDDEN, |res| {
                 Ok(ErrorHandlerResponse::Response(res))
             }))
@@ -46,7 +46,7 @@ mod tests {
             .wrap(ErrorHandlers::new().handler(StatusCode::FORBIDDEN, |res| {
                 Ok(ErrorHandlerResponse::Response(res))
             }))
-            .wrap(DefaultHeaders::new().header("X-Test2", "X-Value2"))
+            .wrap(DefaultHeaders::new().insert(("X-Test2", "X-Value2")))
             .wrap(Condition::new(true, DefaultHeaders::new()))
             .wrap(Compat::new(Logger::default()));
 

--- a/src/request_data.rs
+++ b/src/request_data.rs
@@ -17,7 +17,7 @@ use crate::{dev::Payload, error::ErrorInternalServerError, Error, FromRequest, H
 /// # Mutating Request Data
 /// Note that since extractors must output owned data, only types that `impl Clone` can use this
 /// extractor. A clone is taken of the required request data and can, therefore, not be directly
-/// mutated in-place. To mutate request data, continue to use [`HttpRequest::extensions_mut`] or
+/// mutated in-place. To mutate request data, continue to use [`HttpRequest::req_data_mut`] or
 /// re-insert the cloned data back into the extensions map. A `DerefMut` impl is intentionally not
 /// provided to make this potential foot-gun more obvious.
 ///

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -525,7 +525,7 @@ mod tests {
                     .name("test")
                     .wrap(
                         DefaultHeaders::new()
-                            .insert((header::CONTENT_TYPE, HeaderValue::from_static("0001"))),
+                            .add((header::CONTENT_TYPE, HeaderValue::from_static("0001"))),
                     )
                     .route(web::get().to(HttpResponse::Ok)),
             ),

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -15,13 +15,12 @@ use crate::{
     dev::{ensure_leading_slash, AppService, ResourceDef},
     guard::Guard,
     handler::Handler,
-    responder::Responder,
     route::{Route, RouteService},
     service::{
         BoxedHttpService, BoxedHttpServiceFactory, HttpServiceFactory, ServiceRequest,
         ServiceResponse,
     },
-    BoxError, Error, FromRequest, HttpResponse,
+    BoxError, Error, FromRequest, HttpResponse, Responder,
 };
 
 /// *Resource* is an entry in resources table which corresponds to requested URL.
@@ -526,7 +525,7 @@ mod tests {
                     .name("test")
                     .wrap(
                         DefaultHeaders::new()
-                            .header(header::CONTENT_TYPE, HeaderValue::from_static("0001")),
+                            .insert((header::CONTENT_TYPE, HeaderValue::from_static("0001"))),
                     )
                     .route(web::get().to(HttpResponse::Ok)),
             ),

--- a/src/response/builder.rs
+++ b/src/response/builder.rs
@@ -9,7 +9,7 @@ use std::{
 use actix_http::{
     body::{BodyStream, BoxBody, MessageBody},
     error::HttpError,
-    header::{self, HeaderName, IntoHeaderPair, IntoHeaderValue},
+    header::{self, HeaderName, IntoHeaderValue, TryIntoHeaderPair},
     ConnectionType, Extensions, Response, ResponseHead, StatusCode,
 };
 use bytes::Bytes;
@@ -67,10 +67,7 @@ impl HttpResponseBuilder {
     ///     .insert_header(("X-TEST", "value"))
     ///     .finish();
     /// ```
-    pub fn insert_header<H>(&mut self, header: H) -> &mut Self
-    where
-        H: IntoHeaderPair,
-    {
+    pub fn insert_header(&mut self, header: impl TryIntoHeaderPair) -> &mut Self {
         if let Some(parts) = self.inner() {
             match header.try_into_header_pair() {
                 Ok((key, value)) => {
@@ -94,10 +91,7 @@ impl HttpResponseBuilder {
     ///     .append_header(("X-TEST", "value2"))
     ///     .finish();
     /// ```
-    pub fn append_header<H>(&mut self, header: H) -> &mut Self
-    where
-        H: IntoHeaderPair,
-    {
+    pub fn append_header(&mut self, header: impl TryIntoHeaderPair) -> &mut Self {
         if let Some(parts) = self.inner() {
             match header.try_into_header_pair() {
                 Ok((key, value)) => parts.headers.append(key, value),

--- a/src/response/builder.rs
+++ b/src/response/builder.rs
@@ -69,7 +69,7 @@ impl HttpResponseBuilder {
     /// ```
     pub fn insert_header(&mut self, header: impl TryIntoHeaderPair) -> &mut Self {
         if let Some(parts) = self.inner() {
-            match header.try_into_header_pair() {
+            match header.try_into_pair() {
                 Ok((key, value)) => {
                     parts.headers.insert(key, value);
                 }
@@ -93,7 +93,7 @@ impl HttpResponseBuilder {
     /// ```
     pub fn append_header(&mut self, header: impl TryIntoHeaderPair) -> &mut Self {
         if let Some(parts) = self.inner() {
-            match header.try_into_header_pair() {
+            match header.try_into_pair() {
                 Ok((key, value)) => parts.headers.append(key, value),
                 Err(e) => self.err = Some(e.into()),
             };

--- a/src/response/builder.rs
+++ b/src/response/builder.rs
@@ -9,7 +9,7 @@ use std::{
 use actix_http::{
     body::{BodyStream, BoxBody, MessageBody},
     error::HttpError,
-    header::{self, HeaderName, IntoHeaderValue, TryIntoHeaderPair},
+    header::{self, HeaderName, TryIntoHeaderPair, TryIntoHeaderValue},
     ConnectionType, Extensions, Response, ResponseHead, StatusCode,
 };
 use bytes::Bytes;
@@ -112,7 +112,7 @@ impl HttpResponseBuilder {
     where
         K: TryInto<HeaderName>,
         K::Error: Into<HttpError>,
-        V: IntoHeaderValue,
+        V: TryIntoHeaderValue,
     {
         if self.err.is_some() {
             return self;
@@ -137,7 +137,7 @@ impl HttpResponseBuilder {
     where
         K: TryInto<HeaderName>,
         K::Error: Into<HttpError>,
-        V: IntoHeaderValue,
+        V: TryIntoHeaderValue,
     {
         if self.err.is_some() {
             return self;
@@ -174,7 +174,7 @@ impl HttpResponseBuilder {
     #[inline]
     pub fn upgrade<V>(&mut self, value: V) -> &mut Self
     where
-        V: IntoHeaderValue,
+        V: TryIntoHeaderValue,
     {
         if let Some(parts) = self.inner() {
             parts.set_connection_type(ConnectionType::Upgrade);
@@ -212,7 +212,7 @@ impl HttpResponseBuilder {
     #[inline]
     pub fn content_type<V>(&mut self, value: V) -> &mut Self
     where
-        V: IntoHeaderValue,
+        V: TryIntoHeaderValue,
     {
         if let Some(parts) = self.inner() {
             match value.try_into_value() {

--- a/src/response/customize_responder.rs
+++ b/src/response/customize_responder.rs
@@ -1,0 +1,219 @@
+use actix_http::{
+    body::{EitherBody, MessageBody},
+    error::HttpError,
+    header::HeaderMap,
+    header::TryIntoHeaderPair,
+    StatusCode,
+};
+
+use crate::{BoxError, HttpRequest, HttpResponse, Responder};
+
+/// Allows overriding status code and headers for a responder.
+pub struct CustomizeResponder<R> {
+    inner: CustomizeResponderInner<R>,
+    error: Option<HttpError>,
+}
+
+struct CustomizeResponderInner<R> {
+    responder: R,
+    status: Option<StatusCode>,
+    override_headers: HeaderMap,
+    append_headers: HeaderMap,
+}
+
+impl<R: Responder> CustomizeResponder<R> {
+    pub(crate) fn new(responder: R) -> Self {
+        CustomizeResponder {
+            inner: CustomizeResponderInner {
+                responder,
+                status: None,
+                override_headers: HeaderMap::new(),
+                append_headers: HeaderMap::new(),
+            },
+            error: None,
+        }
+    }
+
+    /// Override a status code for the Responder's response.
+    ///
+    /// ```
+    /// use actix_web::{HttpRequest, Responder, http::StatusCode};
+    ///
+    /// fn index(req: HttpRequest) -> impl Responder {
+    ///     "Welcome!".with_status(StatusCode::OK)
+    /// }
+    /// ```
+    pub fn with_status(mut self, status: StatusCode) -> Self {
+        if let Some(inner) = self.inner() {
+            inner.status = Some(status);
+        }
+
+        self
+    }
+
+    /// Insert header to the final response.
+    ///
+    /// Overrides other headers with the same name.
+    ///
+    /// ```
+    /// use actix_web::{web, HttpRequest, Responder};
+    /// use serde::Serialize;
+    ///
+    /// #[derive(Serialize)]
+    /// struct MyObj {
+    ///     name: String,
+    /// }
+    ///
+    /// fn index(req: HttpRequest) -> impl Responder {
+    ///     web::Json(MyObj { name: "Name".to_string() })
+    ///         .with_header(("x-version", "1.2.3"))
+    ///         .with_header(("x-version", "1.2.3"))
+    /// }
+    /// ```
+    pub fn insert_header(mut self, header: impl TryIntoHeaderPair) -> Self {
+        if let Some(inner) = self.inner() {
+            match header.try_into_header_pair() {
+                Ok((key, value)) => {
+                    inner.override_headers.insert(key, value);
+                }
+                Err(err) => self.error = Some(err.into()),
+            };
+        }
+
+        self
+    }
+
+    pub fn append_header(mut self, header: impl TryIntoHeaderPair) -> Self {
+        if let Some(inner) = self.inner() {
+            match header.try_into_header_pair() {
+                Ok((key, value)) => {
+                    inner.append_headers.append(key, value);
+                }
+                Err(err) => self.error = Some(err.into()),
+            };
+        }
+
+        self
+    }
+
+    #[doc(hidden)]
+    #[deprecated(since = "4.0.0", note = "Renamed to `insert_header`.")]
+    pub fn with_header(self, header: impl TryIntoHeaderPair) -> Self
+    where
+        Self: Sized,
+    {
+        self.insert_header(header)
+    }
+
+    fn inner(&mut self) -> Option<&mut CustomizeResponderInner<R>> {
+        if self.error.is_some() {
+            None
+        } else {
+            Some(&mut self.inner)
+        }
+    }
+}
+
+impl<T> Responder for CustomizeResponder<T>
+where
+    T: Responder,
+    <T::Body as MessageBody>::Error: Into<BoxError>,
+{
+    type Body = EitherBody<T::Body>;
+
+    fn respond_to(self, req: &HttpRequest) -> HttpResponse<Self::Body> {
+        if let Some(err) = self.error {
+            return HttpResponse::from_error(err).map_into_right_body();
+        }
+
+        let mut res = self.inner.responder.respond_to(req);
+
+        if let Some(status) = self.inner.status {
+            *res.status_mut() = status;
+        }
+
+        for (k, v) in self.inner.override_headers {
+            res.headers_mut().insert(k, v);
+        }
+
+        for (k, v) in self.inner.append_headers {
+            res.headers_mut().append(k, v);
+        }
+
+        res.map_into_left_body()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+
+    use actix_http::body::to_bytes;
+
+    use super::*;
+    use crate::{
+        http::{
+            header::{HeaderValue, CONTENT_TYPE},
+            StatusCode,
+        },
+        test::TestRequest,
+    };
+
+    #[actix_rt::test]
+    async fn customize_responder() {
+        let req = TestRequest::default().to_http_request();
+        let res = "test"
+            .to_string()
+            .customize()
+            .with_status(StatusCode::BAD_REQUEST)
+            .respond_to(&req);
+
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(
+            to_bytes(res.into_body()).await.unwrap(),
+            Bytes::from_static(b"test"),
+        );
+
+        let res = "test"
+            .to_string()
+            .customize()
+            .insert_header(("content-type", "json"))
+            .respond_to(&req);
+
+        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(
+            res.headers().get(CONTENT_TYPE).unwrap(),
+            HeaderValue::from_static("json")
+        );
+        assert_eq!(
+            to_bytes(res.into_body()).await.unwrap(),
+            Bytes::from_static(b"test"),
+        );
+    }
+
+    #[actix_rt::test]
+    async fn tuple_responder_with_status_code() {
+        let req = TestRequest::default().to_http_request();
+        let res = ("test".to_string(), StatusCode::BAD_REQUEST).respond_to(&req);
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(
+            to_bytes(res.into_body()).await.unwrap(),
+            Bytes::from_static(b"test"),
+        );
+
+        let req = TestRequest::default().to_http_request();
+        let res = ("test".to_string(), StatusCode::OK)
+            .customize()
+            .insert_header((CONTENT_TYPE, mime::APPLICATION_JSON))
+            .respond_to(&req);
+        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(
+            res.headers().get(CONTENT_TYPE).unwrap(),
+            HeaderValue::from_static("application/json")
+        );
+        assert_eq!(
+            to_bytes(res.into_body()).await.unwrap(),
+            Bytes::from_static(b"test"),
+        );
+    }
+}

--- a/src/response/customize_responder.rs
+++ b/src/response/customize_responder.rs
@@ -79,7 +79,7 @@ impl<R: Responder> CustomizeResponder<R> {
     /// ```
     pub fn insert_header(mut self, header: impl TryIntoHeaderPair) -> Self {
         if let Some(inner) = self.inner() {
-            match header.try_into_header_pair() {
+            match header.try_into_pair() {
                 Ok((key, value)) => {
                     inner.override_headers.insert(key, value);
                 }
@@ -111,7 +111,7 @@ impl<R: Responder> CustomizeResponder<R> {
     /// ```
     pub fn append_header(mut self, header: impl TryIntoHeaderPair) -> Self {
         if let Some(inner) = self.inner() {
-            match header.try_into_header_pair() {
+            match header.try_into_pair() {
                 Ok((key, value)) => {
                     inner.append_headers.append(key, value);
                 }

--- a/src/response/mod.rs
+++ b/src/response/mod.rs
@@ -1,9 +1,13 @@
 mod builder;
+mod customize_responder;
 mod http_codes;
+mod responder;
 #[allow(clippy::module_inception)]
 mod response;
 
 pub use self::builder::HttpResponseBuilder;
+pub use self::customize_responder::CustomizeResponder;
+pub use self::responder::Responder;
 pub use self::response::HttpResponse;
 
 #[cfg(feature = "cookies")]

--- a/src/response/responder.rs
+++ b/src/response/responder.rs
@@ -21,24 +21,23 @@ pub trait Responder {
     /// Convert self to `HttpResponse`.
     fn respond_to(self, req: &HttpRequest) -> HttpResponse<Self::Body>;
 
-    /// Wraps responder in [`CustomizeResponder`] that allows modification of response details.
+    /// Wraps responder to allow alteration of its response.
     ///
-    /// See [`CustomizeResponder`] docs for more.
+    /// See [`CustomizeResponder`] docs for its capabilities.
     ///
     /// # Examples
     /// ```
-    /// use actix_web::{Responder, test};
-    ///
-    /// let request = test::TestRequest::default().to_http_request();
+    /// use actix_web::{Responder, http::StatusCode, test::TestRequest};
     ///
     /// let responder = "Hello world!"
     ///     .customize()
-    ///     .with_status(400)
-    ///     .insert_header(("x-hello", "world"))
+    ///     .with_status(StatusCode::BAD_REQUEST)
+    ///     .insert_header(("x-hello", "world"));
     ///
-    /// let response = res.respond_to(&req);
-    /// assert_eq!(res.status(), 400);
-    /// assert_eq!(res.headers().get("x-hello").unwrap(), "world");
+    /// let request = TestRequest::default().to_http_request();
+    /// let response = responder.respond_to(&request);
+    /// assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    /// assert_eq!(response.headers().get("x-hello").unwrap(), "world");
     /// ```
     #[inline]
     fn customize(self) -> CustomizeResponder<Self>

--- a/src/response/responder.rs
+++ b/src/response/responder.rs
@@ -48,7 +48,7 @@ pub trait Responder {
     }
 
     #[doc(hidden)]
-    #[deprecated(since = "4.0.0", note = "Prefer `.customize().insert_header()`.")]
+    #[deprecated(since = "4.0.0", note = "Prefer `.customize().insert_header(header)`.")]
     fn with_header(self, header: impl TryIntoHeaderPair) -> CustomizeResponder<Self>
     where
         Self: Sized,

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -935,7 +935,7 @@ mod tests {
                 web::scope("app")
                     .wrap(
                         DefaultHeaders::new()
-                            .header(header::CONTENT_TYPE, HeaderValue::from_static("0001")),
+                            .insert((header::CONTENT_TYPE, HeaderValue::from_static("0001"))),
                     )
                     .service(web::resource("/test").route(web::get().to(HttpResponse::Ok))),
             ),

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -935,7 +935,7 @@ mod tests {
                 web::scope("app")
                     .wrap(
                         DefaultHeaders::new()
-                            .insert((header::CONTENT_TYPE, HeaderValue::from_static("0001"))),
+                            .add((header::CONTENT_TYPE, HeaderValue::from_static("0001"))),
                     )
                     .service(web::resource("/test").route(web::get().to(HttpResponse::Ok))),
             ),

--- a/src/test.rs
+++ b/src/test.rs
@@ -4,8 +4,8 @@ use std::{borrow::Cow, net::SocketAddr, rc::Rc};
 
 pub use actix_http::test::TestBuffer;
 use actix_http::{
-    header::IntoHeaderPair, test::TestRequest as HttpTestRequest, Extensions, Method, Request,
-    StatusCode, Uri, Version,
+    header::TryIntoHeaderPair, test::TestRequest as HttpTestRequest, Extensions, Method,
+    Request, StatusCode, Uri, Version,
 };
 use actix_router::{Path, ResourceDef, Url};
 use actix_service::{IntoService, IntoServiceFactory, Service, ServiceFactory};
@@ -445,19 +445,13 @@ impl TestRequest {
     }
 
     /// Insert a header, replacing any that were set with an equivalent field name.
-    pub fn insert_header<H>(mut self, header: H) -> Self
-    where
-        H: IntoHeaderPair,
-    {
+    pub fn insert_header(mut self, header: impl TryIntoHeaderPair) -> Self {
         self.req.insert_header(header);
         self
     }
 
     /// Append a header, keeping any that were set with an equivalent field name.
-    pub fn append_header<H>(mut self, header: H) -> Self
-    where
-        H: IntoHeaderPair,
-    {
+    pub fn append_header(mut self, header: impl TryIntoHeaderPair) -> Self {
         self.req.append_header(header);
         self
     }

--- a/src/web.rs
+++ b/src/web.rs
@@ -8,7 +8,7 @@ pub use bytes::{Buf, BufMut, Bytes, BytesMut};
 
 use crate::{
     body::MessageBody, error::BlockingError, extract::FromRequest, handler::Handler,
-    resource::Resource, responder::Responder, route::Route, scope::Scope, service::WebService,
+    resource::Resource, route::Route, scope::Scope, service::WebService, Responder,
 };
 
 pub use crate::config::ServiceConfig;


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Feature/Fix


## PR Checklist
<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
- To prevent conflicts when migrating, this adds a new method to the Responder trait that wraps in a CustomizeResponder instead of renaming with_header to insert_header, like that which exists on HttpResponse. This is overall a nicer, more explicit API.
- Also alters the methods on DefaultHeaders middleware.
- Rename `IntoHeaderPair` to `TryIntoHeaderPair`.
- Rename `IntoHeaderValue` to `TryIntoHeaderValue`.
