### PR TITLE
various fixes to MessageBody::complete_body

### DIFF
--- a/actix-http/src/body/boxed.rs
+++ b/actix-http/src/body/boxed.rs
@@ -57,27 +57,7 @@ impl MessageBody for BoxBody {
     }
 
     fn take_complete_body(&mut self) -> Bytes {
-        debug_assert!(
-            self.is_complete_body(),
-            "boxed type does not allow taking complete body; caller should make sure to \
-            call `is_complete_body` first",
-        );
-
-        // we do not have DerefMut access to call take_complete_body directly but since
-        // is_complete_body is true we should expect the entire bytes chunk in one poll_next
-
-        let waker = futures_util::task::noop_waker();
-        let mut cx = Context::from_waker(&waker);
-
-        match self.as_pin_mut().poll_next(&mut cx) {
-            Poll::Ready(Some(Ok(data))) => data,
-            _ => {
-                panic!(
-                    "boxed type indicated it allows taking complete body but failed to \
-                    return Bytes when polled",
-                );
-            }
-        }
+        self.0.take_complete_body()
     }
 }
 

--- a/actix-http/src/body/message_body.rs
+++ b/actix-http/src/body/message_body.rs
@@ -134,7 +134,7 @@ mod foreign_impls {
 
     impl<B> MessageBody for Box<B>
     where
-        B: MessageBody + Unpin,
+        B: MessageBody + Unpin + ?Sized,
     {
         type Error = B::Error;
 

--- a/actix-http/src/body/none.rs
+++ b/actix-http/src/body/none.rs
@@ -40,14 +40,4 @@ impl MessageBody for None {
     ) -> Poll<Option<Result<Bytes, Self::Error>>> {
         Poll::Ready(Option::None)
     }
-
-    #[inline]
-    fn is_complete_body(&self) -> bool {
-        true
-    }
-
-    #[inline]
-    fn take_complete_body(&mut self) -> Bytes {
-        Bytes::new()
-    }
 }

--- a/actix-http/src/body/none.rs
+++ b/actix-http/src/body/none.rs
@@ -40,4 +40,14 @@ impl MessageBody for None {
     ) -> Poll<Option<Result<Bytes, Self::Error>>> {
         Poll::Ready(Option::None)
     }
+
+    #[inline]
+    fn is_complete_body(&self) -> bool {
+        true
+    }
+
+    #[inline]
+    fn take_complete_body(&mut self) -> Bytes {
+        Bytes::new()
+    }
 }


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Bug Fix


## PR Checklist
<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
1. `BoxBody.is_complete_body()` was always `false`, because of absent impl in `MapErr`
2. `None` shouldn't return bytes::new()
3. fix `impl MessageBody for Pin<Box<B>>`


<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
