### PR TITLE
MessageBody::boxed

### DIFF
--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -28,8 +28,7 @@
 * `Request::take_req_data()`. [#2487]
 * `impl Clone` for `RequestHead`. [#2487]
 * New methods on `MessageBody` trait, `is_complete_body` and `take_complete_body`, both with default implementations, for optimisations on body types that are done in exactly one poll/chunk. [#2497]
-* New method on `MessageBody` trait, `boxed`, for optimisations on boxing body type. [#2520]
-* `BoxBody::new_raw`, which is less performant than `BoxBody::new` but is necessary for the default implmentation of `MessageBody::boxed`. [#2520]
+* New `boxed` method on `MessageBody` trait for wrapping body type. [#2520]
 
 ### Changed
 * Rename `body::BoxBody::{from_body => new}`. [#2468]

--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -28,6 +28,8 @@
 * `Request::take_req_data()`. [#2487]
 * `impl Clone` for `RequestHead`. [#2487]
 * New methods on `MessageBody` trait, `is_complete_body` and `take_complete_body`, both with default implementations, for optimisations on body types that are done in exactly one poll/chunk. [#2497]
+* New method on `MessageBody` trait, `boxed`, for optimisations on boxing body type. [#2520]
+* `BoxBody::new_raw`, which is less performant than `BoxBody::new` but is necessary for the default implmentation of `MessageBody::boxed`. [#2520]
 
 ### Changed
 * Rename `body::BoxBody::{from_body => new}`. [#2468]
@@ -56,6 +58,7 @@
 [#2488]: https://github.com/actix/actix-web/pull/2488
 [#2491]: https://github.com/actix/actix-web/pull/2491
 [#2497]: https://github.com/actix/actix-web/pull/2497
+[#2520]: https://github.com/actix/actix-web/pull/2520
 
 
 ## 3.0.0-beta.14 - 2021-11-30

--- a/actix-http/src/body/boxed.rs
+++ b/actix-http/src/body/boxed.rs
@@ -15,15 +15,11 @@ pub struct BoxBody(Pin<Box<dyn MessageBody<Error = Box<dyn StdError>>>>);
 
 impl BoxBody {
     /// Same as `MessageBody::boxed`.
+    ///
+    /// If the body type to wrap is unknown or generic it is better to use [`MessageBody::boxed`] to
+    /// avoid double boxing.
+    #[inline]
     pub fn new<B>(body: B) -> Self
-    where
-        B: MessageBody + 'static,
-    {
-        body.boxed()
-    }
-
-    /// Boxes a `MessageBody` and any errors it generates.
-    pub fn new_raw<B>(body: B) -> Self
     where
         B: MessageBody + 'static,
     {
@@ -32,6 +28,7 @@ impl BoxBody {
     }
 
     /// Returns a mutable pinned reference to the inner message body type.
+    #[inline]
     pub fn as_pin_mut(&mut self) -> Pin<&mut (dyn MessageBody<Error = Box<dyn StdError>>)> {
         self.0.as_mut()
     }
@@ -46,10 +43,12 @@ impl fmt::Debug for BoxBody {
 impl MessageBody for BoxBody {
     type Error = Error;
 
+    #[inline]
     fn size(&self) -> BodySize {
         self.0.size()
     }
 
+    #[inline]
     fn poll_next(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
@@ -60,10 +59,12 @@ impl MessageBody for BoxBody {
             .map_err(|err| Error::new_body().with_cause(err))
     }
 
+    #[inline]
     fn is_complete_body(&self) -> bool {
         self.0.is_complete_body()
     }
 
+    #[inline]
     fn take_complete_body(&mut self) -> Bytes {
         self.0.take_complete_body()
     }

--- a/actix-http/src/body/boxed.rs
+++ b/actix-http/src/body/boxed.rs
@@ -14,8 +14,16 @@ use crate::Error;
 pub struct BoxBody(Pin<Box<dyn MessageBody<Error = Box<dyn StdError>>>>);
 
 impl BoxBody {
-    /// Boxes a `MessageBody` and any errors it generates.
+    /// Same as `MessageBody::boxed`.
     pub fn new<B>(body: B) -> Self
+    where
+        B: MessageBody + 'static,
+    {
+        body.boxed()
+    }
+
+    /// Boxes a `MessageBody` and any errors it generates.
+    pub fn new_raw<B>(body: B) -> Self
     where
         B: MessageBody + 'static,
     {
@@ -58,6 +66,11 @@ impl MessageBody for BoxBody {
 
     fn take_complete_body(&mut self) -> Bytes {
         self.0.take_complete_body()
+    }
+
+    #[inline]
+    fn boxed(self) -> BoxBody {
+        self
     }
 }
 

--- a/actix-http/src/body/either.rs
+++ b/actix-http/src/body/either.rs
@@ -88,6 +88,14 @@ where
             EitherBody::Right { body } => body.take_complete_body(),
         }
     }
+
+    #[inline]
+    fn boxed(self) -> BoxBody {
+        match self {
+            EitherBody::Left { body } => body.boxed(),
+            EitherBody::Right { body } => body.boxed(),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/actix-http/src/body/message_body.rs
+++ b/actix-http/src/body/message_body.rs
@@ -79,14 +79,12 @@ pub trait MessageBody {
     }
 
     /// Converts this body into `BoxBody`.
-    ///
-    /// Implementation shouldn't call `BoxBody::new` on `self` as it would cause infinite
-    /// recursion.
+    #[inline]
     fn boxed(self) -> BoxBody
     where
         Self: Sized + 'static,
     {
-        BoxBody::new_raw(self)
+        BoxBody::new(self)
     }
 }
 
@@ -667,7 +665,7 @@ mod tests {
         assert_eq!(body.take_complete_body(), b"test".as_ref());
 
         // subsequent poll_next returns None
-        let waker = futures_util::task::noop_waker();
+        let waker = futures_task::noop_waker();
         let mut cx = Context::from_waker(&waker);
         assert!(Pin::new(&mut body).poll_next(&mut cx).map_err(drop) == Poll::Ready(None));
     }

--- a/actix-http/src/body/message_body.rs
+++ b/actix-http/src/body/message_body.rs
@@ -12,7 +12,7 @@ use bytes::{Bytes, BytesMut};
 use futures_core::ready;
 use pin_project_lite::pin_project;
 
-use super::BodySize;
+use super::{BodySize, BoxBody};
 
 /// An interface types that can converted to bytes and used as response bodies.
 // TODO: examples
@@ -76,6 +76,17 @@ pub trait MessageBody {
             check `is_complete_body` first",
             std::any::type_name::<Self>()
         );
+    }
+
+    /// Converts this body into `BoxBody`.
+    ///
+    /// Implementation shouldn't call `BoxBody::new` on `self` as it would cause infinite
+    /// recursion.
+    fn boxed(self) -> BoxBody
+    where
+        Self: Sized + 'static,
+    {
+        BoxBody::new_raw(self)
     }
 }
 

--- a/actix-http/src/response.rs
+++ b/actix-http/src/response.rs
@@ -194,7 +194,7 @@ impl<B> Response<B> {
     where
         B: MessageBody + 'static,
     {
-        self.map_body(|_, body| BoxBody::new(body))
+        self.map_body(|_, body| body.boxed())
     }
 
     /// Returns body, consuming this response.

--- a/awc/src/any_body.rs
+++ b/awc/src/any_body.rs
@@ -45,9 +45,7 @@ impl AnyBody {
     where
         B: MessageBody + 'static,
     {
-        Self::Body {
-            body: BoxBody::new(body),
-        }
+        Self::Body { body: body.boxed() }
     }
 
     /// Constructs new `AnyBody` instance from a slice of bytes by copying it.

--- a/src/response/response.rs
+++ b/src/response/response.rs
@@ -244,8 +244,7 @@ impl<B> HttpResponse<B> {
     where
         B: MessageBody + 'static,
     {
-        // TODO: avoid double boxing with down-casting, if it improves perf
-        self.map_body(|_, body| BoxBody::new(body))
+        self.map_body(|_, body| body.boxed())
     }
 
     /// Extract response body

--- a/src/service.rs
+++ b/src/service.rs
@@ -451,7 +451,7 @@ impl<B> ServiceResponse<B> {
     where
         B: MessageBody + 'static,
     {
-        self.map_body(|_, body| BoxBody::new(body))
+        self.map_body(|_, body| body.boxed())
     }
 }
 


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Feature


## PR Checklist
<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
`Either::right(Bytes::new().boxed()).boxed().boxed()` now allocate once.

The motivation behind this is not the perf as much as to enable zero-cost boxing to be more liberal with using boxed body.


<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
