### PR TITLE
simplify MessageBody::complete_body interface

### DIFF
--- a/actix-http/src/body/either.rs
+++ b/actix-http/src/body/either.rs
@@ -74,18 +74,14 @@ where
     }
 
     #[inline]
-    fn is_complete_body(&self) -> bool {
+    fn try_into_bytes(self) -> Result<Bytes, Self> {
         match self {
-            EitherBody::Left { body } => body.is_complete_body(),
-            EitherBody::Right { body } => body.is_complete_body(),
-        }
-    }
-
-    #[inline]
-    fn take_complete_body(&mut self) -> Bytes {
-        match self {
-            EitherBody::Left { body } => body.take_complete_body(),
-            EitherBody::Right { body } => body.take_complete_body(),
+            EitherBody::Left { body } => body
+                .try_into_bytes()
+                .map_err(|body| EitherBody::Left { body }),
+            EitherBody::Right { body } => body
+                .try_into_bytes()
+                .map_err(|body| EitherBody::Right { body }),
         }
     }
 

--- a/actix-http/src/body/none.rs
+++ b/actix-http/src/body/none.rs
@@ -40,4 +40,9 @@ impl MessageBody for None {
     ) -> Poll<Option<Result<Bytes, Self::Error>>> {
         Poll::Ready(Option::None)
     }
+
+    #[inline]
+    fn try_into_bytes(self) -> Result<Bytes, Self> {
+        Ok(Bytes::new())
+    }
 }

--- a/actix-http/src/body/none.rs
+++ b/actix-http/src/body/none.rs
@@ -40,14 +40,4 @@ impl MessageBody for None {
     ) -> Poll<Option<Result<Bytes, Self::Error>>> {
         Poll::Ready(Option::None)
     }
-
-    #[inline]
-    fn is_complete_body(&self) -> bool {
-        true
-    }
-
-    #[inline]
-    fn take_complete_body(&mut self) -> Bytes {
-        Bytes::new()
-    }
 }

--- a/actix-http/src/encoding/encoder.rs
+++ b/actix-http/src/encoding/encoder.rs
@@ -136,6 +136,7 @@ where
         Self: Sized,
     {
         match self {
+            EncoderBody::None => Ok(Bytes::new()),
             EncoderBody::Full { body } => Ok(body),
             _ => Err(self),
         }

--- a/actix-http/src/h1/dispatcher.rs
+++ b/actix-http/src/h1/dispatcher.rs
@@ -22,7 +22,7 @@ use crate::{
     config::ServiceConfig,
     error::{DispatchError, ParseError, PayloadError},
     service::HttpFlow,
-    Extensions, OnConnectData, Request, Response, StatusCode,
+    Error, Extensions, OnConnectData, Request, Response, StatusCode,
 };
 
 use super::{
@@ -458,7 +458,9 @@ where
                             }
 
                             Poll::Ready(Some(Err(err))) => {
-                                return Err(DispatchError::Service(err.into()))
+                                return Err(DispatchError::Service(
+                                    Error::new_body().with_cause(err).into(),
+                                ))
                             }
 
                             Poll::Pending => return Ok(PollResponse::DoNothing),

--- a/src/dev.rs
+++ b/src/dev.rs
@@ -139,4 +139,12 @@ impl crate::body::MessageBody for AnyBody {
             AnyBody::Boxed { body } => body.as_pin_mut().poll_next(cx),
         }
     }
+
+    fn try_into_bytes(self) -> Result<crate::web::Bytes, Self> {
+        match self {
+            AnyBody::None => Ok(crate::web::Bytes::new()),
+            AnyBody::Full { body } => Ok(body),
+            _ => Err(self),
+        }
+    }
 }


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Feature


## PR Checklist
<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
This tries to make MessageBody interface for take_complete_body less strict, more fail-safe and hence usable directly.

The idea is to store Bytes in boxed body so that `take_body` no longer needs to be object-safe.

@robjtede I'd appreciate your input at this point before finishing it.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
