### PR TITLE
allow any body type in Scope

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 # Changes
 
 ## Unreleased - 2021-xx-xx
+### Changed
+- no longer requires `Scope` service body type to be boxed. [#2523]
+
+[#2523]: https://github.com/actix/actix-web/pull/2523
 
 
 ## 4.0.0-beta.15 - 2021-12-17

--- a/src/middleware/compat.rs
+++ b/src/middleware/compat.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 
 /// Middleware for enabling any middleware to be used in [`Resource::wrap`](crate::Resource::wrap),
-/// [`Scope::wrap`](crate::Scope::wrap) and [`Condition`](super::Condition).
+/// and [`Condition`](super::Condition).
 ///
 /// # Examples
 /// ```

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -986,9 +986,9 @@ mod tests {
         );
     }
 
-    /// Any output body type should be accepted; test for `EitherBody`
     #[actix_rt::test]
     async fn test_middleware_body_type() {
+        // Compile test that Scope accepts any body type; test for `EitherBody`
         let srv = init_service(
             App::new().service(
                 web::scope("app")
@@ -1001,13 +1001,12 @@ mod tests {
         )
         .await;
 
-        // test if `is_complete_body()` is preserved across scope layer
+        // test if `MessageBody::try_into_bytes()` is preserved across scope layer
         use actix_http::body::MessageBody as _;
         let req = TestRequest::with_uri("/app/test").to_request();
         let resp = call_service(&srv, req).await;
-        let mut body = resp.into_body();
-        assert!(body.is_complete_body());
-        assert_eq!(body.take_complete_body(), b"hello".as_ref());
+        let body = resp.into_body();
+        assert_eq!(body.try_into_bytes().unwrap(), b"hello".as_ref());
     }
 
     #[actix_rt::test]


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Feature


## PR Checklist
<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Given that double boxing can be avoided with `MessageBody::boxed`, I think it is reasonable to implicitely box the response body type.

I understand that this is controversial to have, so I'm open to any opinion.


<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
