### PR TITLE
http: Replace header::map::GetAll with std::slice::Iter

### DIFF
--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -1,6 +1,10 @@
 # Changes
 
 ## Unreleased - 2021-xx-xx
+### Removed
+* `header::map::GetAll` iterator, its `Iterator::size_hint` method was wrongly implemented. Replaced with `std::slice::Iter`. [#2527]
+
+[#2527]: https://github.com/actix/actix-web/pull/2527
 
 
 ## 3.0.0-beta.16 - 2021-12-17

--- a/src/response/response.rs
+++ b/src/response/response.rs
@@ -313,7 +313,7 @@ impl Future for HttpResponse<BoxBody> {
 
 #[cfg(feature = "cookies")]
 pub struct CookieIter<'a> {
-    iter: header::map::GetAll<'a>,
+    iter: std::slice::Iter<'a, HeaderValue>,
 }
 
 #[cfg(feature = "cookies")]


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Bug Fix / Refactor


## PR Checklist
<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
The `Iterator::size_hint` implementation of `GetAll` was wrong, this PR removes `GetAll` completely and replaces it with a more flexible iterator from `std`.

This is a breaking change!


<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
