### PR TITLE
soft-deprecate `NormalizePath::default` in v3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 # Changes
 
 ## Unreleased - 2020-xx-xx
+
+
+## 3.3.3 - 2021-12-18
 ### Changed
 * Soft-deprecate `NormalizePath::default()`, noting upcoming behavior change in v4. [#2529]
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 # Changes
 
 ## Unreleased - 2020-xx-xx
+### Changed
+* Soft-deprecate `NormalizePath::default()`, noting upcoming behavior change in v4. [#2529]
+
+[#2529]: https://github.com/actix/actix-web/pull/2529
 
 
 ## 3.3.2 - 2020-12-01

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-web"
-version = "3.3.2"
+version = "3.3.3"
 authors = ["Nikolay Kim <fafhrd91@gmail.com>"]
 description = "Actix Web is a powerful, pragmatic, and extremely fast web framework for Rust"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@
   <p>
 
 [![crates.io](https://img.shields.io/crates/v/actix-web?label=latest)](https://crates.io/crates/actix-web)
-[![Documentation](https://docs.rs/actix-web/badge.svg?version=3.3.2)](https://docs.rs/actix-web/3.3.2)
+[![Documentation](https://docs.rs/actix-web/badge.svg?version=3.3.3)](https://docs.rs/actix-web/3.3.3)
 [![Version](https://img.shields.io/badge/rustc-1.42+-ab6000.svg)](https://blog.rust-lang.org/2020/03/12/Rust-1.42.html)
 ![License](https://img.shields.io/crates/l/actix-web.svg)
-[![Dependency Status](https://deps.rs/crate/actix-web/3.3.2/status.svg)](https://deps.rs/crate/actix-web/3.3.2)
+[![Dependency Status](https://deps.rs/crate/actix-web/3.3.3/status.svg)](https://deps.rs/crate/actix-web/3.3.3)
 <br />
 [![Build Status](https://travis-ci.org/actix/actix-web.svg?branch=master)](https://travis-ci.org/actix/actix-web) 
 [![codecov](https://codecov.io/gh/actix/actix-web/branch/master/graph/badge.svg)](https://codecov.io/gh/actix/actix-web) 

--- a/actix-http/src/error.rs
+++ b/actix-http/src/error.rs
@@ -55,7 +55,7 @@ impl Error {
 
     /// Similar to `as_response_error` but downcasts.
     pub fn as_error<T: ResponseError + 'static>(&self) -> Option<&T> {
-        ResponseError::downcast_ref(self.cause.as_ref())
+        <dyn ResponseError>::downcast_ref(self.cause.as_ref())
     }
 }
 

--- a/src/middleware/normalize.rs
+++ b/src/middleware/normalize.rs
@@ -31,7 +31,7 @@ impl Default for TrailingSlash {
     }
 }
 
-#[derive(Default, Clone, Copy)]
+#[derive(Clone, Copy)]
 /// `Middleware` to normalize request's URI in place
 ///
 /// Performs following:
@@ -55,6 +55,18 @@ impl Default for TrailingSlash {
 /// ```
 
 pub struct NormalizePath(TrailingSlash);
+
+impl Default for NormalizePath {
+    fn default() -> Self {
+        log::warn!(
+            "`NormalizePath::default()` is deprecated. The default trailing slash behavior will \
+            change in v4 from `Always` to `Trim`. Update your call to `NormalizePath::new(...)` to \
+            avoid inaccessible routes when upgrading."
+        );
+
+        Self(TrailingSlash::default())
+    }
+}
 
 impl NormalizePath {
     /// Create new `NormalizePath` middleware with the specified trailing slash style.


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Deprecation backport


## PR Checklist
<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
As a transition step for v4, add warning to v3 `NormalizePath` middleware noting change in behavior.

Closes #2343
