### PR TITLE
rework Handler trait

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -3,9 +3,8 @@ use std::future::Future;
 use actix_service::{boxed, fn_service};
 
 use crate::{
-    body::MessageBody,
     service::{BoxedHttpServiceFactory, ServiceRequest, ServiceResponse},
-    BoxError, FromRequest, HttpResponse, Responder,
+    FromRequest, HttpResponse, Responder,
 };
 
 /// The interface for request handlers.
@@ -92,8 +91,6 @@ where
     Args: FromRequest,
     R: Future,
     R::Output: Responder,
-    <R::Output as Responder>::Body: MessageBody,
-    <<R::Output as Responder>::Body as MessageBody>::Error: Into<BoxError>,
 {
     boxed::factory(fn_service(move |req: ServiceRequest| {
         let handler = handler.clone();

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -230,12 +230,11 @@ where
     /// # fn index(req: HttpRequest) -> HttpResponse { unimplemented!() }
     /// App::new().service(web::resource("/").route(web::route().to(index)));
     /// ```
-    pub fn to<F, Args, R>(mut self, handler: F) -> Self
+    pub fn to<F, Args>(mut self, handler: F) -> Self
     where
-        F: Handler<Args, R>,
+        F: Handler<Args>,
         Args: FromRequest + 'static,
-        R: Future + 'static,
-        R::Output: Responder + 'static,
+        F::Output: Responder + 'static,
     {
         self.routes.push(Route::new().to(handler));
         self

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -20,7 +20,7 @@ use crate::{
         BoxedHttpService, BoxedHttpServiceFactory, HttpServiceFactory, ServiceRequest,
         ServiceResponse,
     },
-    BoxError, Error, FromRequest, HttpResponse, Responder,
+    Error, FromRequest, HttpResponse, Responder,
 };
 
 /// A collection of [`Route`]s that respond to the same path pattern.
@@ -236,8 +236,6 @@ where
         Args: FromRequest + 'static,
         R: Future + 'static,
         R::Output: Responder + 'static,
-        <R::Output as Responder>::Body: MessageBody,
-        <<R::Output as Responder>::Body as MessageBody>::Error: Into<BoxError>,
     {
         self.routes.push(Route::new().to(handler));
         self

--- a/src/route.rs
+++ b/src/route.rs
@@ -8,11 +8,10 @@ use actix_service::{
 use futures_core::future::LocalBoxFuture;
 
 use crate::{
-    body::MessageBody,
     guard::{self, Guard},
     handler::{handler_service, Handler},
     service::{BoxedHttpServiceFactory, ServiceRequest, ServiceResponse},
-    BoxError, Error, FromRequest, HttpResponse, Responder,
+    Error, FromRequest, HttpResponse, Responder,
 };
 
 /// A request handler with [guards](guard).
@@ -182,8 +181,6 @@ impl Route {
         Args: FromRequest + 'static,
         R: Future + 'static,
         R::Output: Responder + 'static,
-        <R::Output as Responder>::Body: MessageBody,
-        <<R::Output as Responder>::Body as MessageBody>::Error: Into<BoxError>,
     {
         self.service = handler_service(handler);
         self

--- a/src/route.rs
+++ b/src/route.rs
@@ -1,4 +1,4 @@
-use std::{future::Future, mem, rc::Rc};
+use std::{mem, rc::Rc};
 
 use actix_http::Method;
 use actix_service::{
@@ -175,12 +175,11 @@ impl Route {
     ///     );
     /// }
     /// ```
-    pub fn to<F, Args, R>(mut self, handler: F) -> Self
+    pub fn to<F, Args>(mut self, handler: F) -> Self
     where
-        F: Handler<Args, R>,
+        F: Handler<Args>,
         Args: FromRequest + 'static,
-        R: Future + 'static,
-        R::Output: Responder + 'static,
+        F::Output: Responder + 'static,
     {
         self.service = handler_service(handler);
         self

--- a/src/web.rs
+++ b/src/web.rs
@@ -146,12 +146,11 @@ pub fn method(method: Method) -> Route {
 ///         web::to(index))
 /// );
 /// ```
-pub fn to<F, Args, R>(handler: F) -> Route
+pub fn to<F, Args>(handler: F) -> Route
 where
-    F: Handler<Args, R>,
+    F: Handler<Args>,
     Args: FromRequest + 'static,
-    R: Future + 'static,
-    R::Output: Responder + 'static,
+    F::Output: Responder + 'static,
 {
     Route::new().to(handler)
 }

--- a/src/web.rs
+++ b/src/web.rs
@@ -1,14 +1,14 @@
 //! Essentials helper functions and types for application registration.
 
-use std::{error::Error as StdError, future::Future};
+use std::future::Future;
 
 use actix_http::Method;
 use actix_router::IntoPatterns;
 pub use bytes::{Buf, BufMut, Bytes, BytesMut};
 
 use crate::{
-    body::MessageBody, error::BlockingError, extract::FromRequest, handler::Handler,
-    resource::Resource, route::Route, scope::Scope, service::WebService, Responder,
+    error::BlockingError, extract::FromRequest, handler::Handler, resource::Resource,
+    route::Route, scope::Scope, service::WebService, Responder,
 };
 
 pub use crate::config::ServiceConfig;
@@ -152,8 +152,6 @@ where
     Args: FromRequest + 'static,
     R: Future + 'static,
     R::Output: Responder + 'static,
-    <R::Output as Responder>::Body: MessageBody + 'static,
-    <<R::Output as Responder>::Body as MessageBody>::Error: Into<Box<dyn StdError + 'static>>,
 {
     Route::new().to(handler)
 }


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Refactor


## PR Checklist
<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Documentation comments have been added / updated.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
It is now parameterized over Args only. The output type is now an associated type, which is more sematically correct and is also consistent with `std::ops::Fn` and `Service`.

This also removes the `Responder` bound from the trait. This is in order to have more clear errors for handlers with invalid output: `Responder not implmented` vs `Handler not implemented`

We can also move the `Future` bound from the trait to `XX::to()`  for the same reason as above, but It is a less common mistake to miss the `async` keyword from handlers, so I'm not sure about this!

At this point I think it is better renamed to `AsyncFn`, which I think describes it better since it more general now.


<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
