### PR TITLE
use modern signatures for awc `send_*` and `header` methods

### DIFF
--- a/awc/CHANGES.md
+++ b/awc/CHANGES.md
@@ -1,6 +1,11 @@
 # Changes
 
 ## Unreleased - 2021-xx-xx
+- `*::send_json` and `*::send_form` methods now receive `impl Serialize`. [#2553]
+- `FrozenClientRequest::extra_header` now uses receives an `impl TryIntoHeaderPair`. [#2553]
+- Remove unnecessary `Unpin` bounds on `*::send_stream`. [#2553]
+
+[#2553]: https://github.com/actix/actix-web/pull/2553
 
 
 ## 3.0.0-beta.15 - 2021-12-27

--- a/awc/src/any_body.rs
+++ b/awc/src/any_body.rs
@@ -1,17 +1,13 @@
 use std::{
-    borrow::Cow,
     fmt, mem,
     pin::Pin,
     task::{Context, Poll},
 };
 
-use bytes::{Bytes, BytesMut};
-use futures_core::Stream;
+use bytes::Bytes;
 use pin_project_lite::pin_project;
 
-use actix_http::body::{BodySize, BodyStream, BoxBody, MessageBody, SizedStream};
-
-use crate::BoxError;
+use actix_http::body::{BodySize, BoxBody, MessageBody};
 
 pin_project! {
     /// Represents various types of HTTP message body.
@@ -157,91 +153,6 @@ impl<S: fmt::Debug> fmt::Debug for AnyBody<S> {
             AnyBody::Bytes { ref body } => write!(f, "AnyBody::Bytes({:?})", body),
             AnyBody::Body { ref body } => write!(f, "AnyBody::Message({:?})", body),
         }
-    }
-}
-
-impl<B> From<&'static str> for AnyBody<B> {
-    fn from(string: &'static str) -> Self {
-        Self::Bytes {
-            body: Bytes::from_static(string.as_ref()),
-        }
-    }
-}
-
-impl<B> From<&'static [u8]> for AnyBody<B> {
-    fn from(bytes: &'static [u8]) -> Self {
-        Self::Bytes {
-            body: Bytes::from_static(bytes),
-        }
-    }
-}
-
-impl<B> From<Vec<u8>> for AnyBody<B> {
-    fn from(vec: Vec<u8>) -> Self {
-        Self::Bytes {
-            body: Bytes::from(vec),
-        }
-    }
-}
-
-impl<B> From<String> for AnyBody<B> {
-    fn from(string: String) -> Self {
-        Self::Bytes {
-            body: Bytes::from(string),
-        }
-    }
-}
-
-impl<B> From<&'_ String> for AnyBody<B> {
-    fn from(string: &String) -> Self {
-        Self::Bytes {
-            body: Bytes::copy_from_slice(AsRef::<[u8]>::as_ref(&string)),
-        }
-    }
-}
-
-impl<B> From<Cow<'_, str>> for AnyBody<B> {
-    fn from(string: Cow<'_, str>) -> Self {
-        match string {
-            Cow::Owned(s) => Self::from(s),
-            Cow::Borrowed(s) => Self::Bytes {
-                body: Bytes::copy_from_slice(AsRef::<[u8]>::as_ref(s)),
-            },
-        }
-    }
-}
-
-impl<B> From<Bytes> for AnyBody<B> {
-    fn from(bytes: Bytes) -> Self {
-        Self::Bytes { body: bytes }
-    }
-}
-
-impl<B> From<BytesMut> for AnyBody<B> {
-    fn from(bytes: BytesMut) -> Self {
-        Self::Bytes {
-            body: bytes.freeze(),
-        }
-    }
-}
-
-impl<S, E> From<SizedStream<S>> for AnyBody
-where
-    S: Stream<Item = Result<Bytes, E>> + 'static,
-    E: Into<BoxError> + 'static,
-{
-    fn from(stream: SizedStream<S>) -> Self {
-        AnyBody::new_boxed(stream)
-    }
-}
-
-impl<S, E> From<BodyStream<S>> for AnyBody
-where
-    S: Stream<Item = Result<Bytes, E>> + 'static,
-    E: Into<BoxError> + 'static,
-{
-    fn from(stream: BodyStream<S>) -> Self {
-        AnyBody::new_boxed(stream)
     }
 }
 

--- a/awc/src/frozen.rs
+++ b/awc/src/frozen.rs
@@ -1,4 +1,4 @@
-use std::{convert::TryFrom, net, rc::Rc, time::Duration};
+use std::{net, rc::Rc, time::Duration};
 
 use bytes::Bytes;
 use futures_core::Stream;
@@ -7,7 +7,7 @@ use serde::Serialize;
 use actix_http::{
     body::MessageBody,
     error::HttpError,
-    header::{HeaderMap, HeaderName, TryIntoHeaderValue},
+    header::{HeaderMap, TryIntoHeaderPair},
     Method, RequestHead, Uri,
 };
 
@@ -18,6 +18,7 @@ use crate::{
 };
 
 /// `FrozenClientRequest` struct represents cloneable client request.
+///
 /// It could be used to send same request multiple times.
 #[derive(Clone)]
 pub struct FrozenClientRequest {
@@ -83,7 +84,7 @@ impl FrozenClientRequest {
     /// Send a streaming body.
     pub fn send_stream<S, E>(&self, stream: S) -> SendClientRequest
     where
-        S: Stream<Item = Result<Bytes, E>> + Unpin + 'static,
+        S: Stream<Item = Result<Bytes, E>> + 'static,
         E: Into<BoxError> + 'static,
     {
         RequestSender::Rc(self.head.clone(), None).send_stream(
@@ -105,20 +106,14 @@ impl FrozenClientRequest {
         )
     }
 
-    /// Create a `FrozenSendBuilder` with extra headers
+    /// Clones this `FrozenClientRequest`, returning a new one with extra headers added.
     pub fn extra_headers(&self, extra_headers: HeaderMap) -> FrozenSendBuilder {
         FrozenSendBuilder::new(self.clone(), extra_headers)
     }
 
-    /// Create a `FrozenSendBuilder` with an extra header
-    pub fn extra_header<K, V>(&self, key: K, value: V) -> FrozenSendBuilder
-    where
-        HeaderName: TryFrom<K>,
-        <HeaderName as TryFrom<K>>::Error: Into<HttpError>,
-        V: TryIntoHeaderValue,
-    {
-        self.extra_headers(HeaderMap::new())
-            .extra_header(key, value)
+    /// Clones this `FrozenClientRequest`, returning a new one with the extra header added.
+    pub fn extra_header(&self, header: impl TryIntoHeaderPair) -> FrozenSendBuilder {
+        self.extra_headers(HeaderMap::new()).extra_header(header)
     }
 }
 
@@ -139,29 +134,20 @@ impl FrozenSendBuilder {
     }
 
     /// Insert a header, it overrides existing header in `FrozenClientRequest`.
-    pub fn extra_header<K, V>(mut self, key: K, value: V) -> Self
-    where
-        HeaderName: TryFrom<K>,
-        <HeaderName as TryFrom<K>>::Error: Into<HttpError>,
-        V: TryIntoHeaderValue,
-    {
-        match HeaderName::try_from(key) {
-            Ok(key) => match value.try_into_value() {
-                Ok(value) => {
-                    self.extra_headers.insert(key, value);
-                }
-                Err(e) => self.err = Some(e.into()),
-            },
-            Err(e) => self.err = Some(e.into()),
+    pub fn extra_header(mut self, header: impl TryIntoHeaderPair) -> Self {
+        match header.try_into_pair() {
+            Ok((key, value)) => {
+                self.extra_headers.insert(key, value);
+            }
+
+            Err(err) => self.err = Some(err.into()),
         }
+
         self
     }
 
     /// Complete request construction and send a body.
-    pub fn send_body<B>(self, body: B) -> SendClientRequest
-    where
-        B: MessageBody + 'static,
-    {
+    pub fn send_body(self, body: impl MessageBody + 'static) -> SendClientRequest {
         if let Some(e) = self.err {
             return e.into();
         }
@@ -176,9 +162,9 @@ impl FrozenSendBuilder {
     }
 
     /// Complete request construction and send a json body.
-    pub fn send_json<T: Serialize>(self, value: &T) -> SendClientRequest {
-        if let Some(e) = self.err {
-            return e.into();
+    pub fn send_json(self, value: impl Serialize) -> SendClientRequest {
+        if let Some(err) = self.err {
+            return err.into();
         }
 
         RequestSender::Rc(self.req.head, Some(self.extra_headers)).send_json(
@@ -191,7 +177,7 @@ impl FrozenSendBuilder {
     }
 
     /// Complete request construction and send an urlencoded body.
-    pub fn send_form<T: Serialize>(self, value: &T) -> SendClientRequest {
+    pub fn send_form(self, value: impl Serialize) -> SendClientRequest {
         if let Some(e) = self.err {
             return e.into();
         }
@@ -208,7 +194,7 @@ impl FrozenSendBuilder {
     /// Complete request construction and send a streaming body.
     pub fn send_stream<S, E>(self, stream: S) -> SendClientRequest
     where
-        S: Stream<Item = Result<Bytes, E>> + Unpin + 'static,
+        S: Stream<Item = Result<Bytes, E>> + 'static,
         E: Into<BoxError> + 'static,
     {
         if let Some(e) = self.err {

--- a/awc/src/middleware/redirect.rs
+++ b/awc/src/middleware/redirect.rs
@@ -190,7 +190,9 @@ where
                         let body_new = if is_redirect {
                             // try to reuse body
                             match body {
-                                Some(ref bytes) => AnyBody::from(bytes.clone()),
+                                Some(ref bytes) => AnyBody::Bytes {
+                                    body: bytes.clone(),
+                                },
                                 // TODO: should this be AnyBody::Empty or AnyBody::None.
                                 _ => AnyBody::empty(),
                             }

--- a/awc/src/request.rs
+++ b/awc/src/request.rs
@@ -385,7 +385,7 @@ impl ClientRequest {
     /// Set an streaming body and generate `ClientRequest`.
     pub fn send_stream<S, E>(self, stream: S) -> SendClientRequest
     where
-        S: Stream<Item = Result<Bytes, E>> + Unpin + 'static,
+        S: Stream<Item = Result<Bytes, E>> + 'static,
         E: Into<BoxError> + 'static,
     {
         let slf = match self.prep_for_sending() {

--- a/awc/src/responses/response.rs
+++ b/awc/src/responses/response.rs
@@ -7,8 +7,8 @@ use std::{
 };
 
 use actix_http::{
-    error::PayloadError, header, header::HeaderMap, BoxedPayloadStream, Extensions,
-    HttpMessage, Payload, ResponseHead, StatusCode, Version,
+    error::PayloadError, header::HeaderMap, BoxedPayloadStream, Extensions, HttpMessage,
+    Payload, ResponseHead, StatusCode, Version,
 };
 use actix_rt::time::{sleep, Sleep};
 use bytes::Bytes;
@@ -119,12 +119,13 @@ impl<S> ClientResponse<S> {
 
         if self.extensions().get::<Cookies>().is_none() {
             let mut cookies = Vec::new();
-            for hdr in self.headers().get_all(&header::SET_COOKIE) {
+            for hdr in self.headers().get_all(&actix_http::header::SET_COOKIE) {
                 let s = std::str::from_utf8(hdr.as_bytes()).map_err(CookieParseError::from)?;
                 cookies.push(Cookie::parse_encoded(s)?.into_owned());
             }
             self.extensions_mut().insert(Cookies(cookies));
         }
+
         Ok(Ref::map(self.extensions(), |ext| {
             &ext.get::<Cookies>().unwrap().0
         }))


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Refactor


## PR Checklist
<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
Use `TryIntoHeaderPair` for header method in awc.