### PR TITLE
never return port in `realip_remote_addr`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@
 - The `Not` guard is now generic over the type of guard it wraps. [#2552]
 
 ### Fixed
+- Rename `ConnectionInfo::{remote_addr => peer_addr}`, deprecating the old name. [#2554]
+- `ConnectionInfo::peer_addr` will not return the port number. [#2554]
 - `ConnectionInfo::realip_remote_addr` will not return the port number if sourcing the IP from the peer's socket address. [#2554]
 
 [#2552]: https://github.com/actix/actix-web/pull/2552

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,11 @@
 - Some guards now return `impl Guard` and their concrete types are made private: `guard::{Header}` and all the method guards. [#2552]
 - The `Not` guard is now generic over the type of guard it wraps. [#2552]
 
+### Fixed
+- `ConnectionInfo::realip_remote_addr` will not return the port number if sourcing the IP from the peer's socket address. [#2554]
+
 [#2552]: https://github.com/actix/actix-web/pull/2552
+[#2554]: https://github.com/actix/actix-web/pull/2554
 
 
 ## 4.0.0-beta.16 - 2021-12-27

--- a/src/config.rs
+++ b/src/config.rs
@@ -128,7 +128,7 @@ impl AppConfig {
 
     /// Server host name.
     ///
-    /// Host name is used by application router as a hostname for url generation.
+    /// Host name is used by application router as a hostname for URL generation.
     /// Check [ConnectionInfo](super::dev::ConnectionInfo::host())
     /// documentation for more information.
     ///
@@ -137,7 +137,7 @@ impl AppConfig {
         &self.host
     }
 
-    /// Returns true if connection is secure(https)
+    /// Returns true if connection is secure (ie. running over `https:`).
     pub fn secure(&self) -> bool {
         self.secure
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -137,7 +137,7 @@ impl AppConfig {
         &self.host
     }
 
-    /// Returns true if connection is secure (ie. running over `https:`).
+    /// Returns true if connection is secure (i.e., running over `https:`).
     pub fn secure(&self) -> bool {
         self.secure
     }

--- a/src/info.rs
+++ b/src/info.rs
@@ -449,12 +449,12 @@ mod tests {
     async fn remote_address() {
         let req = TestRequest::default().to_http_request();
         let res = ConnectionInfo::extract(&req).await.unwrap();
-        assert!(res.remote_addr().is_none());
+        assert!(res.peer_addr().is_none());
 
         let addr = "127.0.0.1:8080".parse().unwrap();
         let req = TestRequest::default().peer_addr(addr).to_http_request();
         let conn_info = ConnectionInfo::extract(&req).await.unwrap();
-        assert_eq!(conn_info.remote_addr().unwrap(), "127.0.0.1");
+        assert_eq!(conn_info.peer_addr().unwrap(), "127.0.0.1");
     }
 
     #[actix_rt::test]

--- a/src/middleware/logger.rs
+++ b/src/middleware/logger.rs
@@ -547,7 +547,7 @@ impl FormatText {
                 *self = FormatText::Str(s.to_string());
             }
             FormatText::RemoteAddr => {
-                let s = if let Some(peer) = req.connection_info().remote_addr() {
+                let s = if let Some(peer) = req.connection_info().peer_addr() {
                     FormatText::Str((*peer).to_string())
                 } else {
                     FormatText::Str("-".to_string())

--- a/src/request.rs
+++ b/src/request.rs
@@ -228,23 +228,28 @@ impl HttpRequest {
         self.app_state().rmap()
     }
 
-    /// Peer socket address.
+    /// Returns peer socket address.
     ///
     /// Peer address is the directly connected peer's socket address. If a proxy is used in front of
     /// the Actix Web server, then it would be address of this proxy.
     ///
-    /// To get client connection information `.connection_info()` should be used.
+    /// For expanded client connection information, use [`connection_info`] instead.
     ///
-    /// Will only return None when called in unit tests.
+    /// Will only return None when called in unit tests unless [`TestRequest::peer_addr`] is used.
+    ///
+    /// [`TestRequest::peer_addr`]: crate::test::TestRequest::peer_addr
+    /// [`connection_info`]: Self::connection_info
     #[inline]
     pub fn peer_addr(&self) -> Option<net::SocketAddr> {
         self.head().peer_addr
     }
 
-    /// Get *ConnectionInfo* for the current request.
+    /// Returns connection info for the current request.
     ///
-    /// This method panics if request's extensions container is already
-    /// borrowed.
+    /// The return type, [`ConnectionInfo`], can also be used as an extractor.
+    ///
+    /// # Panics
+    /// Panics if request's extensions container is already borrowed.
     #[inline]
     pub fn connection_info(&self) -> Ref<'_, ConnectionInfo> {
         if !self.extensions().contains::<ConnectionInfo>() {
@@ -252,7 +257,7 @@ impl HttpRequest {
             self.extensions_mut().insert(info);
         }
 
-        Ref::map(self.extensions(), |e| e.get().unwrap())
+        Ref::map(self.extensions(), |data| data.get().unwrap())
     }
 
     /// App config


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Fix


## PR Checklist
<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
Normalizes `realip_remote_addr` so that a port is never included.

Closes #2528 