### PR TITLE
Lower MSRV to 1.51.0

### DIFF
--- a/actix-http/src/header/shared/quality_item.rs
+++ b/actix-http/src/header/shared/quality_item.rs
@@ -99,8 +99,7 @@ impl<T: str::FromStr> str::FromStr for QualityItem<T> {
         let mut raw_item = q_item_str;
         let mut quality = Quality::MAX;
 
-        let parts = q_item_str
-            .rsplit_once(';')
+        let parts = str_rsplit_once(q_item_str, ';')
             .map(|(item, q_attr)| (item.trim(), q_attr.trim()));
 
         if let Some((val, q_attr)) = parts {
@@ -139,6 +138,14 @@ impl<T: str::FromStr> str::FromStr for QualityItem<T> {
 
         Ok(QualityItem::new(item, quality))
     }
+}
+
+// `str::rsplit_once` is stabilized in 1.52.0
+fn str_rsplit_once(s: &str, delimiter: char) -> Option<(&str, &str)> {
+    let mut rsplit = s.rsplitn(2, delimiter);
+    let suffix = rsplit.next()?;
+    let prefix = rsplit.next()?;
+    Some((prefix, suffix))
 }
 
 #[cfg(test)]

--- a/actix-http/src/header/shared/quality_item.rs
+++ b/actix-http/src/header/shared/quality_item.rs
@@ -99,8 +99,8 @@ impl<T: str::FromStr> str::FromStr for QualityItem<T> {
         let mut raw_item = q_item_str;
         let mut quality = Quality::MAX;
 
-        let parts = str_rsplit_once(q_item_str, ';')
-            .map(|(item, q_attr)| (item.trim(), q_attr.trim()));
+        let parts =
+            str_rsplit_once(q_item_str, ';').map(|(item, q_attr)| (item.trim(), q_attr.trim()));
 
         if let Some((val, q_attr)) = parts {
             // example for item with q-factor:

--- a/src/error/internal.rs
+++ b/src/error/internal.rs
@@ -117,8 +117,17 @@ where
 }
 
 macro_rules! error_helper {
+    // Workaround for 1.52.0 compat. It's not great but any use of `concat!` must be done prior
+    // to insertion in a doc comment.
     ($name:ident, $status:ident) => {
-        #[doc = concat!("Helper function that wraps any error and generates a `", stringify!($status), "` response.")]
+        error_helper!(
+            $name,
+            $status,
+            concat!("Helper function that wraps any error and generates a `", stringify!($status), "` response.")
+        );
+    };
+    ($name:ident, $status:ident, $doc:expr) => {
+        #[doc = $doc]
         #[allow(non_snake_case)]
         pub fn $name<T>(err: T) -> Error
         where

--- a/src/error/internal.rs
+++ b/src/error/internal.rs
@@ -123,7 +123,11 @@ macro_rules! error_helper {
         error_helper!(
             $name,
             $status,
-            concat!("Helper function that wraps any error and generates a `", stringify!($status), "` response.")
+            concat!(
+                "Helper function that wraps any error and generates a `",
+                stringify!($status),
+                "` response."
+            )
         );
     };
     ($name:ident, $status:ident, $doc:expr) => {

--- a/src/guard.rs
+++ b/src/guard.rs
@@ -295,8 +295,16 @@ macro_rules! method_guard {
         method_guard!(
             $method_fn,
             $method_const,
-            concat!("Creates a guard that matches the `", stringify!($method_const), "` request method."),
-            concat!("The route in this example will only respond to `", stringify!($method_const), "` requests."),
+            concat!(
+                "Creates a guard that matches the `",
+                stringify!($method_const),
+                "` request method."
+            ),
+            concat!(
+                "The route in this example will only respond to `",
+                stringify!($method_const),
+                "` requests."
+            ),
             concat!("    .guard(guard::", stringify!($method_fn), "())")
         );
     };

--- a/src/guard.rs
+++ b/src/guard.rs
@@ -289,16 +289,27 @@ impl Guard for MethodGuard {
 }
 
 macro_rules! method_guard {
+    // Workaround for 1.52.0 compat. It's not great but any use of `concat!` must be done prior
+    // to insertion in a doc comment.
     ($method_fn:ident, $method_const:ident) => {
-        #[doc = concat!("Creates a guard that matches the `", stringify!($method_const), "` request method.")]
+        method_guard!(
+            $method_fn,
+            $method_const,
+            concat!("Creates a guard that matches the `", stringify!($method_const), "` request method."),
+            concat!("The route in this example will only respond to `", stringify!($method_const), "` requests."),
+            concat!("    .guard(guard::", stringify!($method_fn), "())")
+        );
+    };
+    ($method_fn:ident, $method_const:ident, $doc1:expr, $doc2:expr, $doc3:expr) => {
+        #[doc = $doc1]
         ///
         /// # Examples
-        #[doc = concat!("The route in this example will only respond to `", stringify!($method_const), "` requests.")]
+        #[doc = $doc2]
         /// ```
         /// use actix_web::{guard, web, HttpResponse};
         ///
         /// web::route()
-        #[doc = concat!("    .guard(guard::", stringify!($method_fn), "())")]
+        #[doc = $doc3]
         ///     .to(|| HttpResponse::Ok());
         /// ```
         #[allow(non_snake_case)]

--- a/src/http/header/range.rs
+++ b/src/http/header/range.rs
@@ -217,7 +217,7 @@ impl FromStr for Range {
     type Err = ParseError;
 
     fn from_str(s: &str) -> Result<Range, ParseError> {
-        let (unit, val) = s.split_once('=').ok_or(ParseError::Header)?;
+        let (unit, val) = str_split_once(s, '=').ok_or(ParseError::Header)?;
 
         match (unit, val) {
             ("bytes", ranges) => {
@@ -242,7 +242,7 @@ impl FromStr for ByteRangeSpec {
     type Err = ParseError;
 
     fn from_str(s: &str) -> Result<ByteRangeSpec, ParseError> {
-        let (start, end) = s.split_once('-').ok_or(ParseError::Header)?;
+        let (start, end) = str_split_once(s, '-').ok_or(ParseError::Header)?;
 
         match (start, end) {
             ("", end) => end
@@ -293,6 +293,14 @@ fn from_comma_delimited<T: FromStr>(s: &str) -> Vec<T> {
         })
         .filter_map(|x| x.parse().ok())
         .collect()
+}
+
+// `str::split_once` is stabilized in 1.52.0
+fn str_split_once(str: &str, delimiter: char) -> Option<(&str, &str)> {
+    let mut splitn = str.splitn(2, delimiter);
+    let prefix = splitn.next()?;
+    let suffix = splitn.next()?;
+    Some((prefix, suffix))
 }
 
 #[cfg(test)]

--- a/src/web.rs
+++ b/src/web.rs
@@ -83,7 +83,6 @@ pub fn route() -> Route {
     Route::new()
 }
 
-
 macro_rules! method_route {
     // Workaround for 1.52.0 compat. It's not great but any use of `concat!` must be done prior
     // to insertion in a doc comment.
@@ -91,9 +90,21 @@ macro_rules! method_route {
         method_route!(
             $method_fn,
             $method_const,
-            concat!(" Creates a new route with `", stringify!($method_const), "` method guard."),
-            concat!(" In this example, one `", stringify!($method_const), " /{project_id}` route is set up:"),
-            concat!("         .route(web::", stringify!($method_fn), "().to(|| HttpResponse::Ok()))")
+            concat!(
+                " Creates a new route with `",
+                stringify!($method_const),
+                "` method guard."
+            ),
+            concat!(
+                " In this example, one `",
+                stringify!($method_const),
+                " /{project_id}` route is set up:"
+            ),
+            concat!(
+                "         .route(web::",
+                stringify!($method_fn),
+                "().to(|| HttpResponse::Ok()))"
+            )
         );
     };
     ($method_fn:ident, $method_const:ident, $doc1:expr, $doc2:expr, $doc3:expr) => {
@@ -113,7 +124,7 @@ macro_rules! method_route {
         pub fn $method_fn() -> Route {
             method(Method::$method_const)
         }
-    }
+    };
 }
 
 method_route!(get, GET);

--- a/src/web.rs
+++ b/src/web.rs
@@ -83,25 +83,37 @@ pub fn route() -> Route {
     Route::new()
 }
 
+
 macro_rules! method_route {
+    // Workaround for 1.52.0 compat. It's not great but any use of `concat!` must be done prior
+    // to insertion in a doc comment.
     ($method_fn:ident, $method_const:ident) => {
-        #[doc = concat!(" Creates a new route with `", stringify!($method_const), "` method guard.")]
+        method_route!(
+            $method_fn,
+            $method_const,
+            concat!(" Creates a new route with `", stringify!($method_const), "` method guard."),
+            concat!(" In this example, one `", stringify!($method_const), " /{project_id}` route is set up:"),
+            concat!("         .route(web::", stringify!($method_fn), "().to(|| HttpResponse::Ok()))")
+        );
+    };
+    ($method_fn:ident, $method_const:ident, $doc1:expr, $doc2:expr, $doc3:expr) => {
+        #[doc = $doc1]
         ///
         /// # Examples
-        #[doc = concat!(" In this example, one `", stringify!($method_const), " /{project_id}` route is set up:")]
+        #[doc = $doc2]
         /// ```
         /// use actix_web::{web, App, HttpResponse};
         ///
         /// let app = App::new().service(
         ///     web::resource("/{project_id}")
-        #[doc = concat!("         .route(web::", stringify!($method_fn), "().to(|| HttpResponse::Ok()))")]
+        #[doc = $doc3]
         ///
         /// );
         /// ```
         pub fn $method_fn() -> Route {
             method(Method::$method_const)
         }
-    };
+    }
 }
 
 method_route!(get, GET);


### PR DESCRIPTION
Replace use of `str::split_once`, `str::rsplit_once`, and `concat!` inside doc comments, to enable 1.51 compat

<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Other


## PR Checklist
<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [X] Tests for the changes have been added / updated.
- [X] Documentation comments have been added / updated.
- [X] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Hi, as previously discussed in https://github.com/actix/actix-net/pull/434 we here at Moixa are stuck on `1.51.0` and currently stuck on old versions of the various actix beta crates. This fork (and PR) reverts the MSRV to 1.51.0, and not before that due to use of cargo's resolver feature.

I haven't quite finished the supporting changes such as the changelog, CI, and label changes since this PR is more substantial than the `actix-net` one and impacts the crate more significantly (but still invisibly from the outside) with the doc comments being more cumbersome to write and edit so I wanted to see what you thought about upstreaming it here first before doing that stuff.

I have generated the documentation and couldn't see any changes at all as I'd hope, and the new functions are already covered by the existing tests.