### PR TITLE
Improve the documentation for `default_service`

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -239,7 +239,7 @@ where
     /// Default service that is invoked when no matching resource could be found.
     ///
     /// You must use a [`Route`] as default service:
-    /// 
+    ///
     /// ```
     /// use actix_web::{web, App, HttpResponse};
     ///

--- a/src/app.rs
+++ b/src/app.rs
@@ -236,10 +236,10 @@ where
         self
     }
 
-    /// Default service to be used if no matching resource could be found.
+    /// Default service that is invoked when no matching resource could be found.
     ///
-    /// It is possible to use services like `Resource`, `Route`.
-    ///
+    /// You must use a [`Route`] as default service:
+    /// 
     /// ```
     /// use actix_web::{web, App, HttpResponse};
     ///
@@ -252,19 +252,6 @@ where
     ///         web::resource("/index.html").route(web::get().to(index)))
     ///     .default_service(
     ///         web::route().to(|| HttpResponse::NotFound()));
-    /// ```
-    ///
-    /// It is also possible to use static files as default service.
-    ///
-    /// ```
-    /// use actix_web::{web, App, HttpResponse};
-    ///
-    /// let app = App::new()
-    ///     .service(
-    ///         web::resource("/index.html").to(|| HttpResponse::Ok()))
-    ///     .default_service(
-    ///         web::to(|| HttpResponse::NotFound())
-    ///     );
     /// ```
     pub fn default_service<F, U>(mut self, svc: F) -> Self
     where

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -316,7 +316,7 @@ where
     /// You can pass a [`Route`] as default_service.
     ///
     /// If no default service is specified, a `405 Method Not Allowed` response will be returned to the caller.  
-    /// [`Resource`] does **not** inherit the default handler specified on the parent [`App`](crate::App) or [`Scope`](crate::web::Scope).
+    /// [`Resource`] does **not** inherit the default handler specified on the parent [`App`](crate::App) or [`Scope`](crate::Scope).
     pub fn default_service<F, U>(mut self, f: F) -> Self
     where
         F: IntoServiceFactory<U, ServiceRequest>,

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -312,9 +312,11 @@ where
         }
     }
 
-    /// Default service to be used if no matching route could be found.
-    /// By default *405* response get returned. Resource does not use
-    /// default handler from `App` or `Scope`.
+    /// Default service to be used if no matching route could be found.  
+    /// You can pass a [`Route`] as default_service.
+    /// 
+    /// If no default service is specified, a `405 Method Not Allowed` response will be returned to the caller.  
+    /// [`Resource`] does **not** inherit the default handler specified on the parent [`App`](crate::App) or [`Scope`](crate::web::Scope).
     pub fn default_service<F, U>(mut self, f: F) -> Self
     where
         F: IntoServiceFactory<U, ServiceRequest>,

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -314,7 +314,7 @@ where
 
     /// Default service to be used if no matching route could be found.  
     /// You can pass a [`Route`] as default_service.
-    /// 
+    ///
     /// If no default service is specified, a `405 Method Not Allowed` response will be returned to the caller.  
     /// [`Resource`] does **not** inherit the default handler specified on the parent [`App`](crate::App) or [`Scope`](crate::web::Scope).
     pub fn default_service<F, U>(mut self, f: F) -> Self

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -264,7 +264,8 @@ where
 
     /// Default service to be used if no matching route could be found.
     ///
-    /// If default resource is not registered, app's default resource is being used.
+    /// If a default service is not registered, it will fall back to the default service of
+    /// the parent [`App`](crate::App) (see [`App::default_service`](crate::App::default_service).
     pub fn default_service<F, U>(mut self, f: F) -> Self
     where
         F: IntoServiceFactory<U, ServiceRequest>,


### PR DESCRIPTION
## PR Type
Documentation


## PR Checklist
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
Clarify what can be passed to `default_service` - `Resource` is no longer an option in v4.
