### PR TITLE
Guard against broken intra-doc links in CI

### DIFF
--- a/.github/workflows/clippy-fmt.yml
+++ b/.github/workflows/clippy-fmt.yml
@@ -5,6 +5,24 @@ on:
     types: [opened, synchronize, reopened]
 
 jobs:
+  lint-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          components: rustdoc
+      - name: Check for broken intra-doc links
+        uses: actions-rs/cargo@v1
+        env:
+          RUSTDOCFLAGS: "-D warnings"
+        with:
+          command: doc
+          args: --no-deps --all-features --examples --workspace
+
   fmt:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/clippy-fmt.yml
+++ b/.github/workflows/clippy-fmt.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           toolchain: stable
           profile: minimal
-          components: rustdoc
+          components: rust-docs
       - name: Check for broken intra-doc links
         uses: actions-rs/cargo@v1
         env:

--- a/.github/workflows/clippy-fmt.yml
+++ b/.github/workflows/clippy-fmt.yml
@@ -21,7 +21,7 @@ jobs:
           RUSTDOCFLAGS: "-D warnings"
         with:
           command: doc
-          args: --no-deps --all-features --examples --workspace
+          args: --no-deps --all-features --workspace
 
   fmt:
     runs-on: ubuntu-latest

--- a/actix-files/src/named.rs
+++ b/actix-files/src/named.rs
@@ -301,7 +301,7 @@ impl NamedFile {
 
     /// Set content encoding for serving this file
     ///
-    /// Must be used with [`actix_web::middleware::Compress`] to take effect.
+    /// Must be used with `actix_web::middleware::Compress` to take effect.
     #[inline]
     pub fn set_content_encoding(mut self, enc: ContentEncoding) -> Self {
         self.encoding = Some(enc);

--- a/actix-files/src/named.rs
+++ b/actix-files/src/named.rs
@@ -209,6 +209,7 @@ impl NamedFile {
         Self::from_file(file, path)
     }
 
+    #[allow(rustdoc::broken_intra_doc_links)]
     /// Attempts to open a file asynchronously in read-only mode.
     ///
     /// When the `experimental-io-uring` crate feature is enabled, this will be async.


### PR DESCRIPTION
## PR Type
CI improvement


## PR Checklist
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
Docs are not built for PRs (as far as I can see) and a PR with broken intra-doc links would still result in a green CI run. This check catches that category of issues.
Example: [this commit](https://github.com/actix/actix-web/pull/2614/commits/9780f1193637c05f3bd78225817e6101dd56a07f) had a broken intra-doc link but it still managed to pass CI checks.