### PR TITLE
Fix deprecated notice about client_shutdown

### DIFF
--- a/actix-web/src/server.rs
+++ b/actix-web/src/server.rs
@@ -226,7 +226,7 @@ where
     }
 
     #[doc(hidden)]
-    #[deprecated(since = "4.0.0", note = "Renamed to `client_request_timeout`.")]
+    #[deprecated(since = "4.0.0", note = "Renamed to `client_disconnect_timeout`.")]
     pub fn client_shutdown(self, dur: u64) -> Self {
         self.client_disconnect_timeout(Duration::from_millis(dur))
     }


### PR DESCRIPTION
## PR Type
Other


## PR Checklist
- [x] Documentation comments have been added / updated.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
Fixing a deprecation notice for the `#client_shutdown` method.
