### PR TITLE
Allow using `Option<Middleware>` to enable/disable a middlware

### DIFF
--- a/actix-web/CHANGES.md
+++ b/actix-web/CHANGES.md
@@ -18,6 +18,7 @@
 - Add `Route::wrap()` to allow individual routes to use middleware. [#2725]
 - Add `ServiceConfig::default_service()`. [#2338] [#2743]
 - Implement `ResponseError` for `std::convert::Infallible`
+- Add `Condition::from_option()` to allow creating a conditional middleware from an `Option`. [#2623]
 
 ### Changed
 - Minimum supported Rust version (MSRV) is now 1.56 due to transitive `hashbrown` dependency.


### PR DESCRIPTION

<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Feature


## PR Checklist
<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

Currently, there is `Condition`, which accepts a boolean (to enable/disable) and an instance to
the actual middleware. The downside of that is, that such a middlware needs to be constructed in
any case. Even if the middleware is used or not.

However, the middleware is not used when it is disabled. Only the type seems required. So this
`Optional` middleware allows passing in an `Option` instead of boolean and instance. If the option
"is some" it is enabled. Otherwise not.


<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->

Improves #934