### PR TITLE
Add support for audio files streaming

### DIFF
--- a/actix-files/CHANGES.md
+++ b/actix-files/CHANGES.md
@@ -1,7 +1,10 @@
 # Changes
 
 ## Unreleased - 2021-xx-xx
-- Add support for streaming audio files by setting the `content-disposition` header `inline` instead of `attachement`
+- Add support for streaming audio files by setting the `content-disposition` header `inline` instead of `attachement`. [#2645]
+
+[#2645]: https://github.com/actix/actix-web/pull/2645
+
 
 ## 0.6.0 - 2022-02-25
 - No significant changes since `0.6.0-beta.16`.

--- a/actix-files/CHANGES.md
+++ b/actix-files/CHANGES.md
@@ -1,7 +1,7 @@
 # Changes
 
 ## Unreleased - 2021-xx-xx
-
+- Add support for streaming audio files by setting the `content-disposition` header `inline` instead of `attachement`
 
 ## 0.6.0-beta.16 - 2022-01-31
 - No significant changes since `0.6.0-beta.15`.

--- a/actix-files/src/named.rs
+++ b/actix-files/src/named.rs
@@ -128,7 +128,7 @@ impl NamedFile {
             let ct = from_path(&path).first_or_octet_stream();
 
             let disposition = match ct.type_() {
-                mime::IMAGE | mime::TEXT | mime::VIDEO => DispositionType::Inline,
+                mime::IMAGE | mime::TEXT | mime::AUDIO | mime::VIDEO => DispositionType::Inline,
                 mime::APPLICATION => match ct.subtype() {
                     mime::JAVASCRIPT | mime::JSON => DispositionType::Inline,
                     name if name == "wasm" => DispositionType::Inline,


### PR DESCRIPTION
## PR Type
Bug fix

## PR Checklist

- [x] ~~Tests for the changes have been added / updated.~~
- [x] ~~Documentation comments have been added / updated.~~
- [X] A changelog entry has been made for the appropriate packages.
- [X] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.

## Overview
Add support for audio files streaming by setting the `content-disposition` header `inline` instead of `attachement` in `actix-files`.
No API change, less-than-a-line update.

Closes #2644 