### PR TITLE
prepare actix-router release 0.5.0

### DIFF
--- a/actix-router/CHANGES.md
+++ b/actix-router/CHANGES.md
@@ -3,6 +3,77 @@
 ## Unreleased - 2021-xx-xx
 
 
+## 0.5.0 - 2022-02-22
+### Added
+- `Resource` is now implemented for `&mut Path<_>` and `RefMut<Path<_>>`. [#2568]
+- Add `Path::as_str`. [#2590]
+- Add `ResourceDef::set_name`. [#373][net#373]
+- Add `RouterBuilder::push`. [#2612]
+- Implement `IntoPatterns` for `bytestring::ByteString`. [#372][net#372]
+- Introduce `ResourceDef::join`. [#380][net#380]
+- Introduce `ResourceDef::pattern_iter` to get an iterator over all patterns in a multi-pattern resource. [#373][net#373]
+- Support `build_resource_path` on multi-pattern resources. [#2356]
+- Support multi-pattern prefixes and joins. [#2356]
+
+### Changed
+- `Quoter::requote` now returns `Option<Vec<u8>>`. [#2613]
+- `Resource` trait now uses an associated type, `Path`, instead of a generic parameter. [#2568]
+- `ResourceDef::pattern` now returns the first pattern in multi-pattern resources. [#2356]
+- `ResourceDef::resource_path_from_iter` now takes an `IntoIterator`. [#373][net#373]
+- Change signature of `ResourceDef::capture_match_info_fn` to remove `user_data` parameter. [#2612]
+- Deprecate `Path::path`. [#2590]
+- Disallow prefix routes with tail segments. [#379][net#379]
+- Enforce path separators on dynamic prefixes. [#378][net#378]
+- Prefix segments now always end with with a segment delimiter or end-of-input. [#2355]
+- Prefix segments with trailing slashes define a trailing empty segment. [#2355]
+- Re-work `IntoPatterns` trait, adding a `Patterns` enum. [#372][net#372]
+- Rename `Path::{len => segment_count}` to be more descriptive of it's purpose. [#370][net#370]
+- Rename `ResourceDef::{is_prefix_match => find_match}`. [#373][net#373]
+- Rename `ResourceDef::{match_path => capture_match_info}`. [#373][net#373]
+- Rename `ResourceDef::{match_path_checked => capture_match_info_fn}`. [#373][net#373]
+- Rename `ResourceDef::{resource_path => resource_path_from_iter}`. [#371][net#371]
+- Rename `ResourceDef::{resource_path_named => resource_path_from_map}`. [#371][net#371]
+- Rename `Router::{*_checked => *_fn}`. [#373][net#373]
+- Replace `Option<U>` with `U` in `Router` API. [#2612]
+- Return type of `ResourceDef::name` is now `Option<&str>`. [#373][net#373]
+- Return type of `ResourceDef::pattern` is now `Option<&str>`. [#373][net#373]
+- Minimum supported Rust version (MSRV) is now 1.54.
+
+### Fixed
+- `PathDeserializer` now decodes all percent encoded characters in dynamic segments. [#2566]
+- Fix `ResourceDef` `PartialEq` implementation. [#373][net#373]
+- Fix a bug in multi-patterns where static patterns are interpreted as regex. [#366][net#366]
+- Fix segment interpolation leaving `Path` in unintended state after matching. [#368][net#368]
+- Improve malformed path error message. [#384][net#384]
+- Relax bounds on `Router::recognize*` and `ResourceDef::capture_match_info`. [#2612]
+
+### Removed
+- `ResourceDef::name_mut`. [#373][net#373]
+- Unused `ResourceInfo`. [#2612]
+
+[#2355]: https://github.com/actix/actix-web/pull/2355
+[#2356]: https://github.com/actix/actix-web/pull/2356
+[#2566]: https://github.com/actix/actix-net/pull/2566
+[#2568]: https://github.com/actix/actix-web/pull/2568
+[#2590]: https://github.com/actix/actix-web/pull/2590
+[#2612]: https://github.com/actix/actix-web/pull/2612
+[#2613]: https://github.com/actix/actix-web/pull/2613
+[net#366]: https://github.com/actix/actix-net/pull/366
+[net#368]: https://github.com/actix/actix-net/pull/368
+[net#368]: https://github.com/actix/actix-net/pull/368
+[net#370]: https://github.com/actix/actix-net/pull/370
+[net#371]: https://github.com/actix/actix-net/pull/371
+[net#372]: https://github.com/actix/actix-net/pull/372
+[net#373]: https://github.com/actix/actix-net/pull/373
+[net#378]: https://github.com/actix/actix-net/pull/378
+[net#379]: https://github.com/actix/actix-net/pull/379
+[net#380]: https://github.com/actix/actix-net/pull/380
+[net#384]: https://github.com/actix/actix-net/pull/384
+
+
+<details>
+<summary>0.5.0 Pre-Releases</summary>
+
 ## 0.5.0-rc.3 - 2022-01-31
 - Remove unused `ResourceInfo`. [#2612]
 - Add `RouterBuilder::push`. [#2612]
@@ -41,10 +112,10 @@
 
 
 ## 0.5.0-beta.2 - 2021-09-09
-- Introduce `ResourceDef::join`. [#380]
-- Disallow prefix routes with tail segments. [#379]
-- Enforce path separators on dynamic prefixes. [#378]
-- Improve malformed path error message. [#384]
+- Introduce `ResourceDef::join`. [#380][net#380]
+- Disallow prefix routes with tail segments. [#379][net#379]
+- Enforce path separators on dynamic prefixes. [#378][net#378]
+- Improve malformed path error message. [#384][net#384]
 - Prefix segments now always end with with a segment delimiter or end-of-input. [#2355]
 - Prefix segments with trailing slashes define a trailing empty segment. [#2355]
 - Support multi-pattern prefixes and joins. [#2356]
@@ -52,52 +123,54 @@
 - Support `build_resource_path` on multi-pattern resources. [#2356]
 - Minimum supported Rust version (MSRV) is now 1.51.
 
-[#378]: https://github.com/actix/actix-net/pull/378
-[#379]: https://github.com/actix/actix-net/pull/379
-[#380]: https://github.com/actix/actix-net/pull/380
-[#384]: https://github.com/actix/actix-net/pull/384
+[net#378]: https://github.com/actix/actix-net/pull/378
+[net#379]: https://github.com/actix/actix-net/pull/379
+[net#380]: https://github.com/actix/actix-net/pull/380
+[net#384]: https://github.com/actix/actix-net/pull/384
 [#2355]: https://github.com/actix/actix-web/pull/2355
 [#2356]: https://github.com/actix/actix-web/pull/2356
 
 
 ## 0.5.0-beta.1 - 2021-07-20
-- Fix a bug in multi-patterns where static patterns are interpreted as regex. [#366]
-- Introduce `ResourceDef::pattern_iter` to get an iterator over all patterns in a multi-pattern resource. [#373]
-- Fix segment interpolation leaving `Path` in unintended state after matching. [#368]
-- Fix `ResourceDef` `PartialEq` implementation. [#373]
-- Re-work `IntoPatterns` trait, adding a `Patterns` enum. [#372]
-- Implement `IntoPatterns` for `bytestring::ByteString`. [#372]
-- Rename `Path::{len => segment_count}` to be more descriptive of it's purpose. [#370]
-- Rename `ResourceDef::{resource_path => resource_path_from_iter}`. [#371]
-- `ResourceDef::resource_path_from_iter` now takes an `IntoIterator`. [#373]
-- Rename `ResourceDef::{resource_path_named => resource_path_from_map}`. [#371]
-- Rename `ResourceDef::{is_prefix_match => find_match}`. [#373]
-- Rename `ResourceDef::{match_path => capture_match_info}`. [#373]
-- Rename `ResourceDef::{match_path_checked => capture_match_info_fn}`. [#373]
-- Remove `ResourceDef::name_mut` and introduce `ResourceDef::set_name`. [#373]
-- Rename `Router::{*_checked => *_fn}`. [#373]
-- Return type of `ResourceDef::name` is now `Option<&str>`. [#373]
-- Return type of `ResourceDef::pattern` is now `Option<&str>`. [#373]
+- Fix a bug in multi-patterns where static patterns are interpreted as regex. [#366][net#366]
+- Introduce `ResourceDef::pattern_iter` to get an iterator over all patterns in a multi-pattern resource. [#373][net#373]
+- Fix segment interpolation leaving `Path` in unintended state after matching. [#368][net#368]
+- Fix `ResourceDef` `PartialEq` implementation. [#373][net#373]
+- Re-work `IntoPatterns` trait, adding a `Patterns` enum. [#372][net#372]
+- Implement `IntoPatterns` for `bytestring::ByteString`. [#372][net#372]
+- Rename `Path::{len => segment_count}` to be more descriptive of it's purpose. [#370][net#370]
+- Rename `ResourceDef::{resource_path => resource_path_from_iter}`. [#371][net#371]
+- `ResourceDef::resource_path_from_iter` now takes an `IntoIterator`. [#373][net#373]
+- Rename `ResourceDef::{resource_path_named => resource_path_from_map}`. [#371][net#371]
+- Rename `ResourceDef::{is_prefix_match => find_match}`. [#373][net#373]
+- Rename `ResourceDef::{match_path => capture_match_info}`. [#373][net#373]
+- Rename `ResourceDef::{match_path_checked => capture_match_info_fn}`. [#373][net#373]
+- Remove `ResourceDef::name_mut` and introduce `ResourceDef::set_name`. [#373][net#373]
+- Rename `Router::{*_checked => *_fn}`. [#373][net#373]
+- Return type of `ResourceDef::name` is now `Option<&str>`. [#373][net#373]
+- Return type of `ResourceDef::pattern` is now `Option<&str>`. [#373][net#373]
 
-[#368]: https://github.com/actix/actix-net/pull/368
-[#366]: https://github.com/actix/actix-net/pull/366
-[#368]: https://github.com/actix/actix-net/pull/368
-[#370]: https://github.com/actix/actix-net/pull/370
-[#371]: https://github.com/actix/actix-net/pull/371
-[#372]: https://github.com/actix/actix-net/pull/372
-[#373]: https://github.com/actix/actix-net/pull/373
+[net#368]: https://github.com/actix/actix-net/pull/368
+[net#366]: https://github.com/actix/actix-net/pull/366
+[net#368]: https://github.com/actix/actix-net/pull/368
+[net#370]: https://github.com/actix/actix-net/pull/370
+[net#371]: https://github.com/actix/actix-net/pull/371
+[net#372]: https://github.com/actix/actix-net/pull/372
+[net#373]: https://github.com/actix/actix-net/pull/373
+
+</details>
 
 
 ## 0.4.0 - 2021-06-06
-- When matching path parameters, `%25` is now kept in the percent-encoded form; no longer decoded to `%`. [#357]
-- Path tail patterns now match new lines (`\n`) in request URL. [#360]
-- Fixed a safety bug where `Path` could return a malformed string after percent decoding. [#359]
-- Methods `Path::{add, add_static}` now take `impl Into<Cow<'static, str>>`. [#345]
+- When matching path parameters, `%25` is now kept in the percent-encoded form; no longer decoded to `%`. [#357][net#357]
+- Path tail patterns now match new lines (`\n`) in request URL. [#360][net#360]
+- Fixed a safety bug where `Path` could return a malformed string after percent decoding. [#359][net#359]
+- Methods `Path::{add, add_static}` now take `impl Into<Cow<'static, str>>`. [#345][net#345]
 
-[#345]: https://github.com/actix/actix-net/pull/345
-[#357]: https://github.com/actix/actix-net/pull/357
-[#359]: https://github.com/actix/actix-net/pull/359
-[#360]: https://github.com/actix/actix-net/pull/360
+[net#345]: https://github.com/actix/actix-net/pull/345
+[net#357]: https://github.com/actix/actix-net/pull/357
+[net#359]: https://github.com/actix/actix-net/pull/359
+[net#360]: https://github.com/actix/actix-net/pull/360
 
 
 ## 0.3.0 - 2019-12-31
@@ -105,15 +178,15 @@
 
 
 ## 0.2.7 - 2021-02-06
-- Add `Router::recognize_checked` [#247]
+- Add `Router::recognize_checked` [#247][net#247]
 
-[#247]: https://github.com/actix/actix-net/pull/247
+[net#247]: https://github.com/actix/actix-net/pull/247
 
 
 ## 0.2.6 - 2021-01-09
-- Use `bytestring` version range compatible with Bytes v1.0. [#246]
+- Use `bytestring` version range compatible with Bytes v1.0. [#246][net#246]
 
-[#246]: https://github.com/actix/actix-net/pull/246
+[net#246]: https://github.com/actix/actix-net/pull/246
 
 
 ## 0.2.5 - 2020-09-20

--- a/actix-router/Cargo.toml
+++ b/actix-router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-router"
-version = "0.5.0-rc.3"
+version = "0.5.0"
 authors = [
     "Nikolay Kim <fafhrd91@gmail.com>",
     "Ali MJ Al-Nasrawy <alimjalnasrawy@gmail.com>",

--- a/actix-web-codegen/Cargo.toml
+++ b/actix-web-codegen/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 proc-macro = true
 
 [dependencies]
-actix-router = "0.5.0-rc.3"
+actix-router = "0.5.0"
 proc-macro2 = "1"
 quote = "1"
 syn = { version = "1", features = ["full", "parsing"] }

--- a/actix-web/Cargo.toml
+++ b/actix-web/Cargo.toml
@@ -72,7 +72,7 @@ actix-utils = "3"
 actix-tls = { version = "3", default-features = false, optional = true }
 
 actix-http = { version = "3.0.0-rc.4", features = ["http2", "ws"] }
-actix-router = "0.5.0-rc.3"
+actix-router = "0.5.0"
 actix-web-codegen = { version = "0.5.0-rc.2", optional = true }
 
 ahash = "0.7"


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Release


## PR Checklist
<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] A changelog entry has been made for the appropriate packages.
- [x] (Team) Label with affected crates and semver status.


## Overview
It's quite possible that actix-router will get folded into actix-web itself soon but worth making a stable release of 0.5.0 anyway.

Thoughts on the changelog pre-release rollup? Was thinking about doing this for other crates too. (See the rich diff / view file to see effect.)