### PR TITLE
move blocking error to web

### DIFF
--- a/actix-files/src/chunked.rs
+++ b/actix-files/src/chunked.rs
@@ -81,7 +81,7 @@ async fn chunked_read_file_callback(
 ) -> Result<(File, Bytes), Error> {
     use io::{Read as _, Seek as _};
 
-    let res = actix_web::rt::task::spawn_blocking(move || {
+    let res = actix_web::web::block(move || {
         let mut buf = Vec::with_capacity(max_bytes);
 
         file.seek(io::SeekFrom::Start(offset))?;
@@ -94,8 +94,7 @@ async fn chunked_read_file_callback(
             Ok((file, Bytes::from(buf)))
         }
     })
-    .await
-    .map_err(|_| actix_web::error::BlockingError)??;
+    .await??;
 
     Ok(res)
 }

--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -1,6 +1,10 @@
 # Changes
 
 ## Unreleased - 2021-xx-xx
+### Removed
+- `error::BlockingError` [#????]
+
+[#????]: https://github.com/actix/actix-web/pull/????
 
 
 ## 3.0.0-rc.4 - 2022-02-22

--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -2,9 +2,9 @@
 
 ## Unreleased - 2021-xx-xx
 ### Removed
-- `error::BlockingError` [#????]
+- `error::BlockingError` [#2660]
 
-[#????]: https://github.com/actix/actix-web/pull/????
+[#2660]: https://github.com/actix/actix-web/pull/2660
 
 
 ## 3.0.0-rc.4 - 2022-02-22

--- a/actix-http/src/error.rs
+++ b/actix-http/src/error.rs
@@ -51,7 +51,7 @@ impl Error {
         Self::new(Kind::SendResponse)
     }
 
-    #[allow(unused)] // reserved for future use (TODO: remove allow when being used)
+    #[allow(unused)] // available for future use
     pub(crate) fn new_io() -> Self {
         Self::new(Kind::Io)
     }
@@ -252,12 +252,6 @@ impl From<ParseError> for Response<BoxBody> {
     }
 }
 
-/// A set of errors that can occur running blocking tasks in thread pool.
-#[derive(Debug, Display, Error)]
-#[display(fmt = "Blocking thread pool is gone")]
-// TODO: non-exhaustive
-pub struct BlockingError;
-
 /// A set of errors that can occur during payload parsing.
 #[derive(Debug, Display)]
 #[non_exhaustive]
@@ -295,13 +289,13 @@ impl std::error::Error for PayloadError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             PayloadError::Incomplete(None) => None,
-            PayloadError::Incomplete(Some(err)) => Some(err as &dyn std::error::Error),
+            PayloadError::Incomplete(Some(err)) => Some(err),
             PayloadError::EncodingCorrupted => None,
             PayloadError::Overflow => None,
             PayloadError::UnknownLength => None,
             #[cfg(feature = "http2")]
-            PayloadError::Http2Payload(err) => Some(err as &dyn std::error::Error),
-            PayloadError::Io(err) => Some(err as &dyn std::error::Error),
+            PayloadError::Http2Payload(err) => Some(err),
+            PayloadError::Io(err) => Some(err),
         }
     }
 }
@@ -322,15 +316,6 @@ impl From<Option<io::Error>> for PayloadError {
 impl From<io::Error> for PayloadError {
     fn from(err: io::Error) -> Self {
         PayloadError::Incomplete(Some(err))
-    }
-}
-
-impl From<BlockingError> for PayloadError {
-    fn from(_: BlockingError) -> Self {
-        PayloadError::Io(io::Error::new(
-            io::ErrorKind::Other,
-            "Operation is canceled",
-        ))
     }
 }
 

--- a/actix-http/tests/test_server.rs
+++ b/actix-http/tests/test_server.rs
@@ -850,7 +850,8 @@ async fn not_modified_spec_h1() {
         Some(&header::HeaderValue::from_static("4")),
     );
     // server does not prevent payload from being sent but clients may choose not to read it
-    // TODO: this is probably a bug, especially since CL header can differ in length from the body
+    // TODO: this is probably a bug in the client, especially since CL header can differ in length
+    // from the body
     assert!(!srv.load_body(res).await.unwrap().is_empty());
 
     // TODO: add stream response tests

--- a/actix-web/CHANGES.md
+++ b/actix-web/CHANGES.md
@@ -1,6 +1,7 @@
 # Changes
 
 ## Unreleased - 2021-xx-xx
+### Changed
 - Rename `test::{simple_service => status_service}`. [#2659]
 
 [#2659]: https://github.com/actix/actix-web/pull/2659

--- a/actix-web/src/error/error.rs
+++ b/actix-web/src/error/error.rs
@@ -47,7 +47,6 @@ impl fmt::Debug for Error {
 
 impl StdError for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        // TODO: populate if replacement for Box<dyn Error> is found
         None
     }
 }

--- a/actix-web/src/error/mod.rs
+++ b/actix-web/src/error/mod.rs
@@ -6,7 +6,7 @@
 //
 // See <https://github.com/rust-lang/rust/issues/83375>
 pub use actix_http::error::{
-    BlockingError, ContentTypeError, DispatchError, HttpError, ParseError, PayloadError,
+    ContentTypeError, DispatchError, HttpError, ParseError, PayloadError,
 };
 
 use derive_more::{Display, Error, From};
@@ -32,6 +32,14 @@ pub(crate) use macros::{downcast_dyn, downcast_get_type_id};
 ///
 /// This type alias is generally used to avoid writing out `actix_http::Error` directly.
 pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// An error representing a problem running a blocking task on a thread pool.
+#[derive(Debug, Display, Error)]
+#[display(fmt = "Blocking thread pool is shut down unexpectedly")]
+#[non_exhaustive]
+pub struct BlockingError;
+
+impl ResponseError for crate::error::BlockingError {}
 
 /// Errors which can occur when attempting to generate resource uri.
 #[derive(Debug, PartialEq, Display, Error, From)]

--- a/actix-web/src/http/mod.rs
+++ b/actix-web/src/http/mod.rs
@@ -2,5 +2,4 @@
 
 pub mod header;
 
-// TODO: figure out how best to expose http::Error vs actix_http::Error
 pub use actix_http::{uri, ConnectionType, Error, KeepAlive, Method, StatusCode, Uri, Version};


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Refactor


## PR Checklist
<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
Move `BlockingError` to `actix-web` and alter its previous uses in `actix-http` to use generic `io::Error`s.
