### PR TITLE
[awc] change `client::Connect` to be public

### DIFF
--- a/awc/CHANGES.md
+++ b/awc/CHANGES.md
@@ -1,6 +1,8 @@
 # Changes
 
-## Unreleased - 2022-xx-xx
+## Unreleased - 2023-xx-xx
+### Changed
+- `client::Connect` is now public to allow tunneling connection with `client::Connector`.
 
 
 ## 3.1.0 - 2023-01-21

--- a/awc/src/lib.rs
+++ b/awc/src/lib.rs
@@ -139,7 +139,7 @@ pub mod http {
 }
 
 pub use self::builder::ClientBuilder;
-pub use self::client::{Client, Connector};
+pub use self::client::{Client, Connect, Connector};
 pub use self::connect::{BoxConnectorService, BoxedSocket, ConnectRequest, ConnectResponse};
 pub use self::frozen::{FrozenClientRequest, FrozenSendBuilder};
 pub use self::request::ClientRequest;


### PR DESCRIPTION
## PR Type
Feature 


## PR Checklist
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [ ] (Team) Label with affected crates and semver status.


## Overview

The `client::Connector` is not usable ATM in a public version and we are using this to tunnel http request in case of an upgrade in a proxy middleware for actix-web.

However this may not be the wanted behavior (and maybe client:Connector should only be public to the crate then)
