### PR TITLE
fix(docs): update `TestRequest` example in `actix-http`

### DIFF
--- a/actix-http/src/test.rs
+++ b/actix-http/src/test.rs
@@ -21,26 +21,31 @@ use crate::{
 
 /// Test `Request` builder
 ///
-/// ```ignore
-/// # use http::{header, StatusCode};
-/// # use actix_web::*;
-/// use actix_web::test::TestRequest;
+/// ```
+/// use actix_web::http::{header, StatusCode};
+/// use actix_web::{test, HttpRequest, HttpResponse};
 ///
-/// fn index(req: &HttpRequest) -> Response {
+/// async fn index(req: HttpRequest) -> HttpResponse {
 ///     if let Some(hdr) = req.headers().get(header::CONTENT_TYPE) {
-///         Response::Ok().into()
+///         HttpResponse::Ok().into()
 ///     } else {
-///         Response::BadRequest().into()
+///         HttpResponse::BadRequest().into()
 ///     }
 /// }
 ///
-/// let resp = TestRequest::default().insert_header("content-type", "text/plain")
-///     .run(&index)
-///     .unwrap();
-/// assert_eq!(resp.status(), StatusCode::OK);
+/// #[actix_web::test]
+/// async fn test_index() {
+///     let req = test::TestRequest::default()
+///         .insert_header(("content-type", "text/plain"))
+///         .to_http_request();
 ///
-/// let resp = TestRequest::default().run(&index).unwrap();
-/// assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+///     let resp = index(req).await;
+///     assert_eq!(resp.status(), StatusCode::OK);
+///
+///     let req = test::TestRequest::default().to_http_request();
+///     let resp = index(req).await;
+///     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+/// }
 /// ```
 pub struct TestRequest(Option<Inner>);
 


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Fix (example)

## PR Checklist
<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] ~~A changelog entry has been made for the appropriate packages.~~
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.

## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

Request builder example in [`actix_http::test::TestRequest`](https://docs.rs/actix-http/3.0.4/actix_http/test/struct.TestRequest.html) is outdated and also marked as `ignore` so it wasn't checked during doctests.

This PR updates this example and removes the `ignore` attribute.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
