### PR TITLE
Improve documentation for FromRequest::Future

### DIFF
--- a/actix-web/src/extract.rs
+++ b/actix-web/src/extract.rs
@@ -67,6 +67,10 @@ pub trait FromRequest: Sized {
     type Error: Into<Error>;
 
     /// Future that resolves to a Self.
+    ///
+    /// To refer to the type of an async function or block here, you have two options.
+    /// The first is to use a boxed future such as `futures::future::BoxFuture`. This works on stable and nightly.
+    /// The second is to use `impl Future`, which requires `#![feature(type_alias_impl_trait)]` so only works on nightly.
     type Future: Future<Output = Result<Self, Self::Error>>;
 
     /// Create a Self from request parts asynchronously.

--- a/actix-web/src/extract.rs
+++ b/actix-web/src/extract.rs
@@ -68,9 +68,13 @@ pub trait FromRequest: Sized {
 
     /// Future that resolves to a Self.
     ///
-    /// To refer to the type of an async function or block here, you have two options.
-    /// The first is to use a boxed future such as `futures::future::BoxFuture`. This works on stable and nightly.
-    /// The second is to use `impl Future`, which requires `#![feature(type_alias_impl_trait)]` so only works on nightly.
+    /// To use an async function or block here, you can a boxed future such as `futures::future::LocalBoxFuture`.
+    /// This is an alias for a pinned Box, so you can create it with the following syntax:
+    /// ```
+    /// Box::pin(async {
+    ///     ...
+    /// })
+    /// ```
     type Future: Future<Output = Result<Self, Self::Error>>;
 
     /// Create a Self from request parts asynchronously.

--- a/actix-web/src/extract.rs
+++ b/actix-web/src/extract.rs
@@ -66,21 +66,29 @@ pub trait FromRequest: Sized {
     /// The associated error which can be returned.
     type Error: Into<Error>;
 
-    /// Future that resolves to a Self.
+    /// Future that resolves to a `Self`.
     ///
-    /// To use an async function or block here, you can a boxed future such as `futures::future::LocalBoxFuture`.
-    /// This is an alias for a pinned Box, so you can create it with the following syntax:
-    /// ```
-    /// Box::pin(async {
-    ///     ...
-    /// })
+    /// To use an async function or block, the futures must be boxed. The following snippet will be
+    /// common when creating async/await extractors (that do not consume the body).
+    ///
+    /// ```ignore
+    /// type Future = Pin<Box<dyn Future<Output = Result<Self, Self::Error>>>>;
+    /// // or
+    /// type Future = futures_util::future::LocalBoxFuture<'static, Result<Self, Self::Error>>;
+    ///
+    /// fn from_request(req: HttpRequest, ...) -> Self::Future {
+    ///     let req = req.clone();
+    ///     Box::pin(async move {
+    ///         ...
+    ///     })
+    /// }
     /// ```
     type Future: Future<Output = Result<Self, Self::Error>>;
 
-    /// Create a Self from request parts asynchronously.
+    /// Create a `Self` from request parts asynchronously.
     fn from_request(req: &HttpRequest, payload: &mut Payload) -> Self::Future;
 
-    /// Create a Self from request head asynchronously.
+    /// Create a `Self` from request head asynchronously.
     ///
     /// This method is short for `T::from_request(req, &mut Payload::None)`.
     fn extract(req: &HttpRequest) -> Self::Future {


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Other: Documentation


## PR Checklist
<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [N/A] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [N/A] A changelog entry has been made for the appropriate packages.
- [X] Format code with the latest stable rustfmt.
- [N/A] (Team) Label with affected crates and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Improve documentation for the `Future` associated type of the `FromRequest` trait. I was confused by this and made [a Rust forum post](https://users.rust-lang.org/t/actix-web-fromrequest-where-future-ready/74280/3) where I got some help so I thought it would make sense to add this to the documentation.

No breaking changes.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
