### PR TITLE
clear conn_data on HttpRequest drop

### DIFF
--- a/actix-http/benches/uninit-headers.rs
+++ b/actix-http/benches/uninit-headers.rs
@@ -114,7 +114,7 @@ mod _original {
     use std::mem::MaybeUninit;
 
     pub fn parse_headers(src: &mut BytesMut) -> usize {
-        #![allow(clippy::uninit_assumed_init)]
+        #![allow(invalid_value, clippy::uninit_assumed_init)]
 
         let mut headers: [HeaderIndex; MAX_HEADERS] =
             unsafe { MaybeUninit::uninit().assume_init() };

--- a/actix-web/CHANGES.md
+++ b/actix-web/CHANGES.md
@@ -1,9 +1,14 @@
 # Changelog
 
 ## Unreleased - 2021-xx-xx
+### Added
 - Add `ServiceRequest::extract` to make it easier to use extractors when writing middlewares. [#2647]
 
+### Fixed
+- Clear connection-level data on `HttpRequest` drop. [#2742]
+
 [#2647]: https://github.com/actix/actix-web/pull/2647
+[#2742]: https://github.com/actix/actix-web/pull/2742
 
 
 ## 4.0.1 - 2022-02-25

--- a/actix-web/src/test/test_request.rs
+++ b/actix-web/src/test/test_request.rs
@@ -53,7 +53,7 @@ use crate::cookie::{Cookie, CookieJar};
 ///     assert_eq!(resp.status(), StatusCode::OK);
 ///
 ///     let req = test::TestRequest::default().to_http_request();
-///     let resp = index(req).await;
+///     let resp = handler(req).await;
 ///     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
 /// }
 /// ```


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Fix


## PR Checklist
<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] ~~Tests for the changes have been added / updated.~~
  - Tested using repro from #2740 
- [x] ~~Documentation comments have been added / updated.~~
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
Currently conn data is cleared too late.

fixes #2740