### PR TITLE
fix erroneous 500 responses when connection is unclean

### DIFF
--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -1,6 +1,10 @@
 # Changes
 
 ## Unreleased - 2022-xx-xx
+### Fixed
+- Dropping the payload early and causing unclean connections no longer causes erroneous 500 responses. [#2745]
+
+[#2745]: https://github.com/actix/actix-web/issues/2745
 
 
 ## 3.2.1 - 2022-07-02


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Fix


## PR Checklist
<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
The fix for #2624 tipped the scale too far the other way and caused 500 error responses to get queued. This moves the unclean connection detection to after the responses are queued and adds `Connection: close` headers.

Expect some minor perf drop (untested) but this is an important fix.

fixes #2695 
