### PR TITLE
Implement `ResponseError` for `Infallible`

### DIFF
--- a/actix-web/CHANGES.md
+++ b/actix-web/CHANGES.md
@@ -5,6 +5,7 @@
 - Add `ServiceRequest::extract()` to make it easier to use extractors when writing middlewares. [#2647]
 - Add `Route::wrap()` to allow individual routes to use middleware. [#2725]
 - Add `ServiceConfig::default_service()`. [#2338] [#2743]
+- Implement `ResponseError` for `std::convert::Infallible`
 
 ### Fixed
 - Clear connection-level data on `HttpRequest` drop. [#2742]

--- a/actix-web/src/error/error.rs
+++ b/actix-web/src/error/error.rs
@@ -51,12 +51,6 @@ impl StdError for Error {
     }
 }
 
-impl From<std::convert::Infallible> for Error {
-    fn from(val: std::convert::Infallible) -> Self {
-        match val {}
-    }
-}
-
 /// `Error` for any error that implements `ResponseError`
 impl<T: ResponseError + 'static> From<T> for Error {
     fn from(err: T) -> Error {

--- a/actix-web/src/error/response_error.rs
+++ b/actix-web/src/error/response_error.rs
@@ -1,6 +1,7 @@
 //! `ResponseError` trait and foreign impls.
 
 use std::{
+    convert::Infallible,
     error::Error as StdError,
     fmt,
     io::{self, Write as _},
@@ -53,6 +54,15 @@ pub trait ResponseError: fmt::Debug + fmt::Display {
 downcast_dyn!(ResponseError);
 
 impl ResponseError for Box<dyn StdError + 'static> {}
+
+impl ResponseError for Infallible {
+    fn status_code(&self) -> StatusCode {
+        match *self {}
+    }
+    fn error_response(&self) -> HttpResponse<BoxBody> {
+        match *self {}
+    }
+}
 
 #[cfg(feature = "openssl")]
 impl ResponseError for actix_tls::accept::openssl::reexports::Error {}


### PR DESCRIPTION
## PR Type
Feature

## PR Checklist
<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
    - N/A? I can’t really add tests that wouldn’t just be repeating what the code says
- [x] Documentation comments have been added / updated.
    - Also N/A IMO, I don’t think it really needs docs
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview

I saw someone on Discord encounter a problem because it wasn’t present earlier today. It seems reasonable, so I added it. The use case was in the `Result` returned from [`actix_form_data::Field::file`](https://docs.rs/actix-form-data/latest/actix_form_data/enum.Field.html#method.file).