### PR TITLE
Allow a path as a guard in route handler macro

### DIFF
--- a/actix-web-codegen/CHANGES.md
+++ b/actix-web-codegen/CHANGES.md
@@ -1,7 +1,8 @@
 # Changes
 
 ## Unreleased - 2021-xx-xx
-
+### Fixed
+- Allow a path as a guard in route handler macro, such as `get`, `post`, as the `actix-web` document says
 
 ## 4.0.0 - 2022-02-24
 - Version aligned with `actix-web` and will remain in sync going forward.

--- a/actix-web-codegen/CHANGES.md
+++ b/actix-web-codegen/CHANGES.md
@@ -1,8 +1,10 @@
 # Changes
 
 ## Unreleased - 2021-xx-xx
-### Fixed
-- Allow a path as a guard in route handler macro, such as `get`, `post`, as the `actix-web` document says
+- Fix support for guard paths in route handler macros. [#2771]
+
+[#2771] https://github.com/actix/actix-web/pull/2771
+
 
 ## 4.0.0 - 2022-02-24
 - Version aligned with `actix-web` and will remain in sync going forward.

--- a/actix-web-codegen/src/route.rs
+++ b/actix-web-codegen/src/route.rs
@@ -4,7 +4,7 @@ use actix_router::ResourceDef;
 use proc_macro::TokenStream;
 use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::{format_ident, quote, ToTokens, TokenStreamExt};
-use syn::{parse_macro_input, AttributeArgs, Ident, LitStr, NestedMeta};
+use syn::{parse_macro_input, AttributeArgs, Ident, LitStr, NestedMeta, Path};
 
 enum ResourceType {
     Async,
@@ -77,7 +77,7 @@ impl TryFrom<&syn::LitStr> for MethodType {
 struct Args {
     path: syn::LitStr,
     resource_name: Option<syn::LitStr>,
-    guards: Vec<Ident>,
+    guards: Vec<Path>,
     wrappers: Vec<syn::Type>,
     methods: HashSet<MethodType>,
 }
@@ -121,7 +121,7 @@ impl Args {
                         }
                     } else if nv.path.is_ident("guard") {
                         if let syn::Lit::Str(lit) = nv.lit {
-                            guards.push(Ident::new(&lit.value(), Span::call_site()));
+                            guards.push(lit.parse::<Path>()?);
                         } else {
                             return Err(syn::Error::new_spanned(
                                 nv.lit,


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Bug Fix


## PR Checklist
<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [ ] (Team) Label with affected crates and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
`actix-web` document says route handler macros(`#[get]`, `#[post]`, etc.) accept any valid expression as a guard. But currently it doesn't.

This PR fixes the behavior as the doc says.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
Closes #2706