### PR TITLE
Read remaining bytes when cleaning dropped payload #2764

### DIFF
--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -1,6 +1,8 @@
 # Changes
 
-## Unreleased - 2021-xx-xx
+## Unreleased - 2022-xx-xx
+### Fixed
+- Consume bytes from read buffer when `Payload` is dropped early. [#2764]
 
 
 ## 3.0.4 - 2022-03-09

--- a/actix-http/src/h1/dispatcher.rs
+++ b/actix-http/src/h1/dispatcher.rs
@@ -706,9 +706,6 @@ where
                     debug!("handler dropped payload early; attempt to clean connection");
                     // ...in which case poll request payload a few times
                     loop {
-                        if this.read_buf.is_empty() {
-                            Self::read_available_projected(&mut this, cx)?;
-                        }
                         match this.codec.decode(this.read_buf)? {
                             Some(msg) => {
                                 match msg {


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Bug Fix


## PR Checklist
<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Existing behavior did not completely read client data if a `Payload` was dropped without consuming all of its data. This calls `read_available()` before each `Payload` chunk is discarded. This does add a `read_available_projected()` so it can be called when only a pinned reference to the dispatcher is available.

<!-- If this PR fixes or closes an issue, reference it here. -->
Closes #2764