### PR TITLE
Improve documentation for `actix-web-actors`

### DIFF
--- a/actix-web-actors/CHANGES.md
+++ b/actix-web-actors/CHANGES.md
@@ -2,9 +2,6 @@
 
 ## Unreleased - 2022-xx-xx
 - Minimum supported Rust version (MSRV) is now 1.57 due to transitive `time` dependency.
-- Improve crate documentation. [#2788]
-
-[#2788]: https://github.com/actix/actix-web/pull/2788
 
 
 ## 4.1.0 - 2022-03-02

--- a/actix-web-actors/CHANGES.md
+++ b/actix-web-actors/CHANGES.md
@@ -6,6 +6,7 @@
 
 [#2788]: https://github.com/actix/actix-web/pull/2788
 
+
 ## 4.1.0 - 2022-03-02
 - Add support for `actix` version `0.13`. [#2675]
 

--- a/actix-web-actors/CHANGES.md
+++ b/actix-web-actors/CHANGES.md
@@ -2,7 +2,9 @@
 
 ## Unreleased - 2022-xx-xx
 - Minimum supported Rust version (MSRV) is now 1.57 due to transitive `time` dependency.
+- Improve crate documentation. [#2788]
 
+[#2788]: https://github.com/actix/actix-web/pull/2788
 
 ## 4.1.0 - 2022-03-02
 - Add support for `actix` version `0.13`. [#2675]

--- a/actix-web-actors/Cargo.toml
+++ b/actix-web-actors/Cargo.toml
@@ -29,6 +29,9 @@ tokio = { version = "1.13.1", features = ["sync"] }
 actix-rt = "2.2"
 actix-test = "0.1.0-beta.13"
 awc = { version = "3", default-features = false }
+actix-web = { version = "4", features = ["macros"] }
+
+mime = "0.3"
 
 env_logger = "0.9"
 futures-util = { version = "0.3.7", default-features = false }

--- a/actix-web-actors/src/context.rs
+++ b/actix-web-actors/src/context.rs
@@ -14,31 +14,31 @@ use futures_core::Stream;
 use tokio::sync::oneshot::Sender;
 
 /// Execution context for HTTP actors
-/// 
+///
 /// # Example
-/// 
+///
 /// A demonstration of [server-sent events](https://developer.mozilla.org/docs/Web/API/Server-sent_events) using actors:
-/// 
+///
 /// ```no_run
 /// use std::time::Duration;
-/// 
+///
 /// use actix::{Actor, AsyncContext};
 /// use actix_web::{get, http::header, App, HttpResponse, HttpServer};
 /// use actix_web_actors::HttpContext;
 /// use bytes::Bytes;
-/// 
+///
 /// struct MyActor {
 ///     count: usize,
 /// }
-/// 
+///
 /// impl Actor for MyActor {
 ///     type Context = HttpContext<Self>;
-/// 
+///
 ///     fn started(&mut self, ctx: &mut Self::Context) {
 ///         ctx.run_later(Duration::from_millis(100), Self::write);
 ///     }
 /// }
-/// 
+///
 /// impl MyActor {
 ///     fn write(&mut self, ctx: &mut HttpContext<Self>) {
 ///         self.count += 1;
@@ -50,14 +50,14 @@ use tokio::sync::oneshot::Sender;
 ///         }
 ///     }
 /// }
-/// 
+///
 /// #[get("/")]
 /// async fn index() -> HttpResponse {
 ///     HttpResponse::Ok()
 ///         .insert_header(header::ContentType(mime::TEXT_EVENT_STREAM))
 ///         .streaming(HttpContext::create(MyActor { count: 0 }))
 /// }
-/// 
+///
 /// #[actix_web::main]
 /// async fn main() -> std::io::Result<()> {
 ///     HttpServer::new(|| App::new().service(index))

--- a/actix-web-actors/src/lib.rs
+++ b/actix-web-actors/src/lib.rs
@@ -1,4 +1,59 @@
 //! Actix actors support for Actix Web.
+//! 
+//! # Examples
+//! 
+//! ```no_run
+//! use actix::{Actor, StreamHandler};
+//! use actix_web::{get, web, App, Error, HttpRequest, HttpResponse, HttpServer};
+//! use actix_web_actors::ws;
+//! 
+//! /// Define Websocket actor
+//! struct MyWs;
+//! 
+//! impl Actor for MyWs {
+//!     type Context = ws::WebsocketContext<Self>;
+//! }
+//! 
+//! /// Handler for ws::Message message
+//! impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for MyWs {
+//!     fn handle(&mut self, msg: Result<ws::Message, ws::ProtocolError>, ctx: &mut Self::Context) {
+//!         match msg {
+//!             Ok(ws::Message::Ping(msg)) => ctx.pong(&msg),
+//!             Ok(ws::Message::Text(text)) => ctx.text(text),
+//!             Ok(ws::Message::Binary(bin)) => ctx.binary(bin),
+//!             _ => (),
+//!         }
+//!     }
+//! }
+//! 
+//! #[get("/ws")]
+//! async fn index(req: HttpRequest, stream: web::Payload) -> Result<HttpResponse, Error> {
+//!     ws::start(MyWs, &req, stream)
+//! }
+//! 
+//! #[actix_web::main]
+//! async fn main() -> std::io::Result<()> {
+//!     HttpServer::new(|| App::new().service(index))
+//!         .bind(("127.0.0.1", 8080))?
+//!         .run()
+//!         .await
+//! }
+//! ```
+//! 
+//! # Documentation & Community Resources
+//! In addition to this API documentation, several other resources are available:
+//!
+//! * [Website & User Guide](https://actix.rs/)
+//! * [Documentation for `actix_web`](actix_web)
+//! * [Examples Repository](https://github.com/actix/examples)
+//! * [Community Chat on Discord](https://discord.gg/NWpN5mmg3x)
+//!
+//! To get started navigating the API docs, you may consider looking at the following pages first:
+//!
+//! * [`ws`]: This module provides actor support for WebSockets.
+//!
+//! * [`HttpContext`]: This struct provides actor support for streaming HTTP responses.
+//! 
 
 #![deny(rust_2018_idioms, nonstandard_style)]
 #![warn(future_incompatible)]

--- a/actix-web-actors/src/lib.rs
+++ b/actix-web-actors/src/lib.rs
@@ -1,19 +1,19 @@
 //! Actix actors support for Actix Web.
-//! 
+//!
 //! # Examples
-//! 
+//!
 //! ```no_run
 //! use actix::{Actor, StreamHandler};
 //! use actix_web::{get, web, App, Error, HttpRequest, HttpResponse, HttpServer};
 //! use actix_web_actors::ws;
-//! 
+//!
 //! /// Define Websocket actor
 //! struct MyWs;
-//! 
+//!
 //! impl Actor for MyWs {
 //!     type Context = ws::WebsocketContext<Self>;
 //! }
-//! 
+//!
 //! /// Handler for ws::Message message
 //! impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for MyWs {
 //!     fn handle(&mut self, msg: Result<ws::Message, ws::ProtocolError>, ctx: &mut Self::Context) {
@@ -25,12 +25,12 @@
 //!         }
 //!     }
 //! }
-//! 
+//!
 //! #[get("/ws")]
 //! async fn index(req: HttpRequest, stream: web::Payload) -> Result<HttpResponse, Error> {
 //!     ws::start(MyWs, &req, stream)
 //! }
-//! 
+//!
 //! #[actix_web::main]
 //! async fn main() -> std::io::Result<()> {
 //!     HttpServer::new(|| App::new().service(index))
@@ -39,7 +39,7 @@
 //!         .await
 //! }
 //! ```
-//! 
+//!
 //! # Documentation & Community Resources
 //! In addition to this API documentation, several other resources are available:
 //!
@@ -53,7 +53,7 @@
 //! * [`ws`]: This module provides actor support for WebSockets.
 //!
 //! * [`HttpContext`]: This struct provides actor support for streaming HTTP responses.
-//! 
+//!
 
 #![deny(rust_2018_idioms, nonstandard_style)]
 #![warn(future_incompatible)]

--- a/actix-web-actors/src/ws.rs
+++ b/actix-web-actors/src/ws.rs
@@ -1,19 +1,19 @@
 //! Websocket integration.
-//! 
+//!
 //! # Examples
-//! 
+//!
 //! ```no_run
 //! use actix::{Actor, StreamHandler};
 //! use actix_web::{get, web, App, Error, HttpRequest, HttpResponse, HttpServer};
 //! use actix_web_actors::ws;
-//! 
+//!
 //! /// Define Websocket actor
 //! struct MyWs;
-//! 
+//!
 //! impl Actor for MyWs {
 //!     type Context = ws::WebsocketContext<Self>;
 //! }
-//! 
+//!
 //! /// Handler for ws::Message message
 //! impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for MyWs {
 //!     fn handle(&mut self, msg: Result<ws::Message, ws::ProtocolError>, ctx: &mut Self::Context) {
@@ -25,14 +25,14 @@
 //!         }
 //!     }
 //! }
-//! 
+//!
 //! #[get("/ws")]
 //! async fn websocket(req: HttpRequest, stream: web::Payload) -> Result<HttpResponse, Error> {
 //!     ws::start(MyWs, &req, stream)
 //! }
-//! 
+//!
 //! const MAX_FRAME_SIZE: usize = 16_384; // 16KiB
-//! 
+//!
 //! #[get("/custom-ws")]
 //! async fn custom_websocket(req: HttpRequest, stream: web::Payload) -> Result<HttpResponse, Error> {
 //!     // Create a Websocket session with a specific max frame size, and protocols.
@@ -41,7 +41,7 @@
 //!         .protocols(&["A", "B"])
 //!         .start()
 //! }
-//! 
+//!
 //! #[actix_web::main]
 //! async fn main() -> std::io::Result<()> {
 //!     HttpServer::new(|| {
@@ -54,7 +54,7 @@
 //!         .await
 //! }
 //! ```
-//! 
+//!
 
 use std::{
     collections::VecDeque,
@@ -101,25 +101,25 @@ use tokio::sync::oneshot;
 /// # use actix::{Actor, StreamHandler};
 /// # use actix_web::{get, web, App, Error, HttpRequest, HttpResponse, HttpServer};
 /// # use actix_web_actors::ws;
-/// # 
+/// #
 /// # struct MyWs;
-/// # 
+/// #
 /// # impl Actor for MyWs {
 /// #     type Context = ws::WebsocketContext<Self>;
 /// # }
-/// # 
+/// #
 /// # /// Handler for ws::Message message
 /// # impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for MyWs {
 /// #     fn handle(&mut self, msg: Result<ws::Message, ws::ProtocolError>, ctx: &mut Self::Context) {}
 /// # }
-/// # 
+/// #
 /// #[get("/ws")]
 /// async fn websocket(req: HttpRequest, stream: web::Payload) -> Result<HttpResponse, Error> {
 ///     ws::WsResponseBuilder::new(MyWs, &req, stream).start()
 /// }
-/// 
+///
 /// const MAX_FRAME_SIZE: usize = 16_384; // 16KiB
-/// 
+///
 /// #[get("/custom-ws")]
 /// async fn custom_websocket(req: HttpRequest, stream: web::Payload) -> Result<HttpResponse, Error> {
 ///     // Create a Websocket session with a specific max frame size, codec, and protocols.
@@ -130,7 +130,7 @@ use tokio::sync::oneshot;
 ///         .protocols(&["A", "B"])
 ///         .start()
 /// }
-/// # 
+/// #
 /// # #[actix_web::main]
 /// # async fn main() -> std::io::Result<()> {
 /// #     HttpServer::new(|| {

--- a/actix-web-actors/src/ws.rs
+++ b/actix-web-actors/src/ws.rs
@@ -97,20 +97,51 @@ use tokio::sync::oneshot;
 ///
 /// # Examples
 ///
-/// Create a Websocket session response with default configuration.
-/// ```ignore
-/// WsResponseBuilder::new(WsActor, &req, stream).start()
-/// ```
-///
-/// Create a Websocket session with a specific max frame size, [`Codec`], and protocols.
-/// ```ignore
+/// ```no_run
+/// # use actix::{Actor, StreamHandler};
+/// # use actix_web::{get, web, App, Error, HttpRequest, HttpResponse, HttpServer};
+/// # use actix_web_actors::ws;
+/// # 
+/// # struct MyWs;
+/// # 
+/// # impl Actor for MyWs {
+/// #     type Context = ws::WebsocketContext<Self>;
+/// # }
+/// # 
+/// # /// Handler for ws::Message message
+/// # impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for MyWs {
+/// #     fn handle(&mut self, msg: Result<ws::Message, ws::ProtocolError>, ctx: &mut Self::Context) {}
+/// # }
+/// # 
+/// #[get("/ws")]
+/// async fn websocket(req: HttpRequest, stream: web::Payload) -> Result<HttpResponse, Error> {
+///     ws::WsResponseBuilder::new(MyWs, &req, stream).start()
+/// }
+/// 
 /// const MAX_FRAME_SIZE: usize = 16_384; // 16KiB
-///
-/// ws::WsResponseBuilder::new(WsActor, &req, stream)
-///     .codec(Codec::new())
-///     .protocols(&["A", "B"])
-///     .frame_size(MAX_FRAME_SIZE)
-///     .start()
+/// 
+/// #[get("/custom-ws")]
+/// async fn custom_websocket(req: HttpRequest, stream: web::Payload) -> Result<HttpResponse, Error> {
+///     // Create a Websocket session with a specific max frame size, codec, and protocols.
+///     ws::WsResponseBuilder::new(MyWs, &req, stream)
+///         .codec(actix_http::ws::Codec::new())
+///         // This will overwrite the codec's max frame-size
+///         .frame_size(MAX_FRAME_SIZE)
+///         .protocols(&["A", "B"])
+///         .start()
+/// }
+/// # 
+/// # #[actix_web::main]
+/// # async fn main() -> std::io::Result<()> {
+/// #     HttpServer::new(|| {
+/// #             App::new()
+/// #                 .service(websocket)
+/// #                 .service(custom_websocket)
+/// #         })
+/// #         .bind(("127.0.0.1", 8080))?
+/// #         .run()
+/// #         .await
+/// # }
 /// ```
 pub struct WsResponseBuilder<'a, A, T>
 where


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Documentation update


## PR Checklist
<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

The documentation for `actix-web-actors` didn't provide any examples on how to use the library. The examples are either on the actix.rs website or in the examples repository. While the examples are good, the documentation should still provide at least basic examples on how to use major structs/modules.

I've added:

* An example ([Websocket example on actix.rx](https://actix.rs/docs/websockets/)) and links (like for actix-web) to documentation and other resources.
* An example (same as on the crate-level) to the `ws` module.
* An example to the `WsResponseBuilder` struct (previously it only included a minimal example with no context).
* An example to `HttpContext`.

I'm not sure about the duplicate example in the `ws` module and on crate-level. I feel like there sould be an example in both locations, maybe even the example from `HttpContext` but I'd like to avoid duplicate examples.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
