### PR TITLE
Remove some unnecessary uses of `once_cell::sync::Lazy`

### DIFF
--- a/actix-http-test/Cargo.toml
+++ b/actix-http-test/Cargo.toml
@@ -40,7 +40,7 @@ awc = { version = "3", default-features = false }
 base64 = "0.13"
 bytes = "1"
 futures-core = { version = "0.3.7", default-features = false }
-http = "0.2.5"
+http = "0.2.8"
 log = "0.4"
 socket2 = "0.4"
 serde = "1.0"

--- a/actix-http/Cargo.toml
+++ b/actix-http/Cargo.toml
@@ -68,7 +68,7 @@ bytestring = "1"
 derive_more = "0.99.5"
 encoding_rs = "0.8"
 futures-core = { version = "0.3.7", default-features = false, features = ["alloc"] }
-http = "0.2.5"
+http = "0.2.8"
 httparse = "1.5.1"
 httpdate = "1.0.1"
 itoa = "1"

--- a/actix-router/Cargo.toml
+++ b/actix-router/Cargo.toml
@@ -21,14 +21,14 @@ default = ["http"]
 
 [dependencies]
 bytestring = ">=0.1.5, <2"
-http = { version = "0.2.3", optional = true }
+http = { version = "0.2.8", optional = true }
 regex = "1.5"
 serde = "1"
 tracing = { version = "0.1.30", default-features = false, features = ["log"] }
 
 [dev-dependencies]
 criterion = { version = "0.3", features = ["html_reports"] }
-http = "0.2.5"
+http = "0.2.8"
 serde = { version = "1", features = ["derive"] }
 percent-encoding = "2.1"
 

--- a/actix-web/src/middleware/compress.rs
+++ b/actix-web/src/middleware/compress.rs
@@ -220,32 +220,25 @@ static SUPPORTED_ENCODINGS_STRING: Lazy<String> = Lazy::new(|| {
     encoding.join(", ")
 });
 
-static SUPPORTED_ENCODINGS: Lazy<Vec<Encoding>> = Lazy::new(|| {
-    let mut encodings = vec![Encoding::identity()];
-
+static SUPPORTED_ENCODINGS: &[Encoding] = &[
+    Encoding::identity(),
     #[cfg(feature = "compress-brotli")]
     {
-        encodings.push(Encoding::brotli());
-    }
-
+        Encoding::brotli()
+    },
     #[cfg(feature = "compress-gzip")]
     {
-        encodings.push(Encoding::gzip());
-        encodings.push(Encoding::deflate());
-    }
-
+        Encoding::gzip()
+    },
+    #[cfg(feature = "compress-gzip")]
+    {
+        Encoding::deflate()
+    },
     #[cfg(feature = "compress-zstd")]
     {
-        encodings.push(Encoding::zstd());
-    }
-
-    assert!(
-        !encodings.is_empty(),
-        "encodings can not be empty unless __compress feature has been explicitly enabled by itself"
-    );
-
-    encodings
-});
+        Encoding::zstd()
+    },
+];
 
 // move cfg(feature) to prevents_double_compressing if more tests are added
 #[cfg(feature = "compress-gzip")]

--- a/awc/Cargo.toml
+++ b/awc/Cargo.toml
@@ -73,7 +73,7 @@ derive_more = "0.99.5"
 futures-core = { version = "0.3.7", default-features = false, features = ["alloc"] }
 futures-util = { version = "0.3.7", default-features = false, features = ["alloc", "sink"] }
 h2 = "0.3.9"
-http = "0.2.5"
+http = "0.2.8"
 itoa = "1"
 log =" 0.4"
 mime = "0.3"


### PR DESCRIPTION
## PR Type
Refactor


## PR Checklist
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview

To simplify the code as well as improve performance.

`http::header::HeaderName::from_static` has been made `const` recently, so it can be performed at compile time.
Dependency version is updated accordingly.

`SUPPORTED_ENCODINGS` is changed from `Vec<Encoding>` to `&[Encoding]` to be able to initialize it at compile time.
I also considered changing `SUPPORTED_ENCODINGS_STRING`, but could not find a non-convoluted way to do it, as `slice::join` is not `const`.

This is not a breaking change.