### PR TITLE
fix pending stream drop

### DIFF
--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -14,8 +14,10 @@
 
 ### Fixed
 - Avoid possibility of dispatcher getting stuck while back-pressuring I/O. [#2369]
+- Fix pending stream drop [#2830]
 
 [#2369]: https://github.com/actix/actix-web/pull/2369
+[#2830]: https://github.com/actix/actix-web/pull/2830
 
 
 ## 3.2.1 - 2022-07-02

--- a/actix-http/src/h1/dispatcher.rs
+++ b/actix-http/src/h1/dispatcher.rs
@@ -1197,7 +1197,8 @@ where
                     let state_is_none = inner_p.state.is_none();
 
                     // read half is closed; we do not process any responses
-                    if inner_p.flags.contains(Flags::READ_DISCONNECT) && state_is_none {
+                    // fix https://github.com/actix/actix-web/issues/1313
+                    if inner_p.flags.contains(Flags::READ_DISCONNECT) {
                         trace!("read half closed; start shutdown");
                         inner_p.flags.insert(Flags::SHUTDOWN);
                     }


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
But Fix

## PR Checklist
<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] ~Tests for the changes have been added / updated.~
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Fix the problem described in bug:
A Stream object in a pending state won't be dropped after the client disconnect https://github.com/actix/actix-web/issues/1313
When the disconnection events is triggered, no state check is needed.
The streaming process, due no access to TcpStream, don't have the necessary elements to change the state and this caused the stuck described in the bug.

<!-- If this PR fixes or closes an issue, reference it here. -->
Closes #1313 
