### PR TITLE
Expose inner value of Path

### DIFF
--- a/actix-web/src/types/path.rs
+++ b/actix-web/src/types/path.rs
@@ -29,8 +29,7 @@ use crate::{
 /// // {name}  - deserialize a String
 /// // {count} - deserialize a u32
 /// #[get("/{name}/{count}/index.html")]
-/// async fn index(path: web::Path<(String, u32)>) -> String {
-///     let (name, count) = path.into_inner();
+/// async fn index(web::Path((name, count)): web::Path<(String, u32)>) -> String {
 ///     format!("Welcome {}! {}", name, count)
 /// }
 /// ```
@@ -54,7 +53,7 @@ use crate::{
 /// }
 /// ```
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Deref, DerefMut, AsRef, Display, From)]
-pub struct Path<T>(T);
+pub struct Path<T>(pub T);
 
 impl<T> Path<T> {
     /// Unwrap into inner `T` value.


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Feature


## PR Checklist
<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [ ] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
The inner value is already exposed via the `into_inner` function, so we may as well expose it directly to improve ergonomics. I have updated the doc example to illustrate this.

Note that this aligns the implementation with that of Query, Json, Header, and Form.
