### PR TITLE
awc: correctly handle redirections that begins with `//`

### DIFF
--- a/awc/CHANGES.md
+++ b/awc/CHANGES.md
@@ -5,7 +5,10 @@
 - Minimum supported Rust version (MSRV) is now 1.57 due to transitive `time` dependency.
 
 ### Fixed
-- Fixed handling of redirection requests that begin with `//`. [#XXXX]
+- Fixed handling of redirection requests that begin with `//`. [#2840]
+
+[#2840]: https://github.com/actix/actix-web/pull/2840
+
 
 ## 3.0.0 - 2022-03-07
 ### Dependencies

--- a/awc/CHANGES.md
+++ b/awc/CHANGES.md
@@ -4,6 +4,8 @@
 ### Changed
 - Minimum supported Rust version (MSRV) is now 1.57 due to transitive `time` dependency.
 
+### Fixed
+- Fixed handling of redirection requests that begin with `//`. [#XXXX]
 
 ## 3.0.0 - 2022-03-07
 ### Dependencies


### PR DESCRIPTION
## PR Type
Bug Fix


## PR Checklist

- [X] Tests for the changes have been added / updated.
- [X] Documentation comments have been added / updated.
- [X] A changelog entry has been made for the appropriate packages.
- [X] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview

Before this pull request, `awc` will not correctly handle any redirection that begins with `//`.

For instance, `Location: //example.com/a` will be interpreted as a path. When the originating host is, say `https://example2.com`, most user-agents will navigate to `https://example.com/a` while `awc` will incorrectly go to `https://example2.com//example.com/a`.

See https://www.rfc-editor.org/rfc/rfc3986#section-3.3 for the designated behaviour.