### PR TITLE
Add ConditionOption middleware

### DIFF
--- a/actix-web/src/middleware/condition_option.rs
+++ b/actix-web/src/middleware/condition_option.rs
@@ -1,0 +1,60 @@
+//! For middleware documentation, see [`ConditionOption`].
+
+use futures_core::future::LocalBoxFuture;
+use futures_util::future::FutureExt as _;
+
+use crate::{
+    body::EitherBody,
+    dev::{Service, ServiceResponse, Transform},
+    middleware::condition::ConditionMiddleware,
+};
+
+/// Middleware for conditionally enabling other middleware in an [`Option`].
+///
+/// Uses [`Condition`](crate::middleware::condition::Condition) under the hood.
+///
+/// # Example
+/// ```
+/// use actix_web::middleware::{ConditionOption, NormalizePath};
+/// use actix_web::App;
+///
+/// let normalize: ConditionOption<_> = Some(NormalizePath::default()).into();
+/// let app = App::new()
+///     .wrap(normalize);
+/// ```
+pub struct ConditionOption<T>(Option<T>);
+
+impl<T> From<Option<T>> for ConditionOption<T> {
+    fn from(value: Option<T>) -> Self {
+        Self(value)
+    }
+}
+
+impl<S, T, Req, BE, BD, Err> Transform<S, Req> for ConditionOption<T>
+where
+    S: Service<Req, Response = ServiceResponse<BD>, Error = Err> + 'static,
+    T: Transform<S, Req, Response = ServiceResponse<BE>, Error = Err>,
+    T::Future: 'static,
+    T::InitError: 'static,
+    T::Transform: 'static,
+{
+    type Response = ServiceResponse<EitherBody<BE, BD>>;
+    type Error = Err;
+    type Transform = ConditionMiddleware<T::Transform, S>;
+    type InitError = T::InitError;
+    type Future = LocalBoxFuture<'static, Result<Self::Transform, Self::InitError>>;
+
+    fn new_transform(&self, service: S) -> Self::Future {
+        match &self.0 {
+            Some(transformer) => {
+                let fut = transformer.new_transform(service);
+                async move {
+                    let wrapped_svc = fut.await?;
+                    Ok(ConditionMiddleware::Enable(wrapped_svc))
+                }
+                .boxed_local()
+            }
+            None => async move { Ok(ConditionMiddleware::Disable(service)) }.boxed_local(),
+        }
+    }
+}

--- a/actix-web/src/middleware/mod.rs
+++ b/actix-web/src/middleware/mod.rs
@@ -2,6 +2,7 @@
 
 mod compat;
 mod condition;
+mod condition_option;
 mod default_headers;
 mod err_handlers;
 mod logger;
@@ -11,6 +12,7 @@ mod normalize;
 
 pub use self::compat::Compat;
 pub use self::condition::Condition;
+pub use self::condition_option::ConditionOption;
 pub use self::default_headers::DefaultHeaders;
 pub use self::err_handlers::{ErrorHandlerResponse, ErrorHandlers};
 pub use self::logger::Logger;


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Feature


## PR Checklist
<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [X] Tests for the changes have been added / updated.
- [X] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [X] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
I'm interested in conditionally applying a middleware. But with `Condition`, I find strange that the middleware has to be created even if the condition is false.

One simple, quite idiomatic improvement would have been to use a lambda to lazily generate the middleware.

But there's a more idiomatic way to do, using `Option`!

As `Transform` is defined in another crate, a newtype is required, which I called `ConditionOption`. Sadly it has to be mentioned for `wrap` to work.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
