### PR TITLE
implement MessageBody for mut B

### DIFF
--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -1,6 +1,11 @@
 # Changes
 
 ## Unreleased - 2022-xx-xx
+### Added
+- Implement `MessageBody` for `&mut B` where `B: MessageBody + Unpin`. [#2868]
+- Implement `MessageBody` for `Pin<B>` where `B::Target: MessageBody`. [#2868]
+
+[#2868]: https://github.com/actix/actix-web/pull/2868
 
 
 ## 3.2.2 - 2022-09-11


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Feature


## PR Checklist
<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] ~~Documentation comments have been added / updated.~~
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
Add missing impl for MessageBody over `&mut B`. This should make it easier to read response bodies in middleware.

Also expands types accepted on `Pin<B>` impl.
