### PR TITLE
Fix typo in error string for i32 parse in router deserialization

### DIFF
--- a/actix-router/CHANGES.md
+++ b/actix-router/CHANGES.md
@@ -1,6 +1,7 @@
 # Changes
 
 ## Unreleased - 2022-xx-xx
+- Fix typo in error string in `Deserializer::deserialize_i32` implementation for `Value`. [#2876]
 - Minimum supported Rust version (MSRV) is now 1.59 due to transitive `time` dependency.
 
 

--- a/actix-router/CHANGES.md
+++ b/actix-router/CHANGES.md
@@ -4,6 +4,8 @@
 - Fix typo in error string in `Deserializer::deserialize_i32` implementation for `Value`. [#2876]
 - Minimum supported Rust version (MSRV) is now 1.59 due to transitive `time` dependency.
 
+[#2876]: https://github.com/actix/actix-web/pull/2876
+
 
 ## 0.5.0 - 2022-02-22
 ### Added

--- a/actix-router/src/de.rs
+++ b/actix-router/src/de.rs
@@ -293,7 +293,7 @@ impl<'de> Deserializer<'de> for Value<'de> {
     parse_value!(deserialize_bool, visit_bool, "bool");
     parse_value!(deserialize_i8, visit_i8, "i8");
     parse_value!(deserialize_i16, visit_i16, "i16");
-    parse_value!(deserialize_i32, visit_i32, "i16");
+    parse_value!(deserialize_i32, visit_i32, "i32");
     parse_value!(deserialize_i64, visit_i64, "i64");
     parse_value!(deserialize_u8, visit_u8, "u8");
     parse_value!(deserialize_u16, visit_u16, "u16");


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Bug Fix

## PR Checklist
<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] ~~Tests for the changes have been added / updated.~~
- [x] ~~Documentation comments have been added / updated.~~
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.

## Overview
Very minor bug, as described in the title.