### PR TITLE
Fix actix-multipart field content_type() to return an Option

### DIFF
--- a/actix-multipart/CHANGES.md
+++ b/actix-multipart/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased - 2022-xx-xx
 - Minimum supported Rust version (MSRV) is now 1.59 due to transitive `time` dependency.
+- `Field::content_type()` now returns `Option<&mime::Mime>` [#2880]
 
 
 ## 0.4.0 - 2022-02-25

--- a/actix-multipart/CHANGES.md
+++ b/actix-multipart/CHANGES.md
@@ -4,6 +4,8 @@
 - Minimum supported Rust version (MSRV) is now 1.59 due to transitive `time` dependency.
 - `Field::content_type()` now returns `Option<&mime::Mime>` [#2880]
 
+[#2880]: https://github.com/actix/actix-web/pull/2880
+
 
 ## 0.4.0 - 2022-02-25
 - No significant changes since `0.4.0-beta.13`.


### PR DESCRIPTION
## PR Type
Bug Fix


## PR Checklist

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview

The [Field::content_type()](https://docs.rs/actix-multipart/latest/actix_multipart/struct.Field.html#method.content_type) is changed to return Option rather than implicitly using a default value.

This is necessary because the multipart spec does not define a universal default content type - the default content type depends on whether the field is "text" or a "file" (which is impossible to tell).

Closes https://github.com/actix/actix-web/issues/2880
