### PR TITLE
update derive_more dependency to 0.99.8

### DIFF
--- a/actix-web/Cargo.toml
+++ b/actix-web/Cargo.toml
@@ -80,7 +80,7 @@ bytes = "1"
 bytestring = "1"
 cfg-if = "1"
 cookie = { version = "0.16", features = ["percent-encode"], optional = true }
-derive_more = "0.99.5"
+derive_more = "0.99.8"
 encoding_rs = "0.8"
 futures-core = { version = "0.3.7", default-features = false }
 futures-util = { version = "0.3.7", default-features = false }


### PR DESCRIPTION
## PR Type

Bug Fix

## PR Checklist

- [x] ~~Tests for the changes have been added / updated.~~
- [x] ~~Documentation comments have been added / updated.~~
- [x] ~~A changelog entry has been made for the appropriate packages.~~
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.

## Overview

actix-web does not compile with derive_more versions below this.

This should be an uncontroversial change. It seems clear that everyone using actix-web is actually pulling in >=0.99.8 because otherwise actix-web does not compile.