### PR TITLE
fix xhtml pages' `content-disposition`

### DIFF
--- a/actix-files/CHANGES.md
+++ b/actix-files/CHANGES.md
@@ -1,7 +1,7 @@
 # Changes
 
 ## Unreleased - 2022-xx-xx
-- Fix xhtml pages' `content-disposition` [#2903].
+- XHTML files now use `Content-Disposition: inline` instead of `attachment`. [#2903]
 - Minimum supported Rust version (MSRV) is now 1.59 due to transitive `time` dependency.
 
 [#2903]: https://github.com/actix/actix-web/pull/2903

--- a/actix-files/CHANGES.md
+++ b/actix-files/CHANGES.md
@@ -1,8 +1,10 @@
 # Changes
 
 ## Unreleased - 2022-xx-xx
+- Fix xhtml pages' `content-disposition` [#2903].
 - Minimum supported Rust version (MSRV) is now 1.59 due to transitive `time` dependency.
 
+[#2903]: https://github.com/actix/actix-web/pull/2903
 
 ## 0.6.2 - 2022-07-23
 - Allow partial range responses for video content to start streaming sooner. [#2817]

--- a/actix-files/src/named.rs
+++ b/actix-files/src/named.rs
@@ -133,6 +133,7 @@ impl NamedFile {
                 mime::APPLICATION => match ct.subtype() {
                     mime::JAVASCRIPT | mime::JSON => DispositionType::Inline,
                     name if name == "wasm" => DispositionType::Inline,
+                    name if name == "xhtml" => DispositionType::Inline,
                     _ => DispositionType::Attachment,
                 },
                 _ => DispositionType::Attachment,

--- a/actix-files/src/named.rs
+++ b/actix-files/src/named.rs
@@ -132,8 +132,7 @@ impl NamedFile {
                 mime::IMAGE | mime::TEXT | mime::AUDIO | mime::VIDEO => DispositionType::Inline,
                 mime::APPLICATION => match ct.subtype() {
                     mime::JAVASCRIPT | mime::JSON => DispositionType::Inline,
-                    name if name == "wasm" => DispositionType::Inline,
-                    name if name == "xhtml" => DispositionType::Inline,
+                    name if name == "wasm" || name == "xhtml" => DispositionType::Inline,
                     _ => DispositionType::Attachment,
                 },
                 _ => DispositionType::Attachment,


### PR DESCRIPTION
## PR Type

Bug Fix

## PR Checklist

- [x] ~(Is this needed?) Tests for the changes have been added / updated.~
- [x] ~(Is this needed?) Documentation comments have been added / updated.~
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.

## Overview

Currently a `index.xhtml` will starts download dialog in browser due to the `content-disposition: attachment`. This PR change it to `inline`.

It's a tiny fix, but still a breaking change? Do we promised this behaviour (the crate `mime_guess`)?