### PR TITLE
Replace deprecated twoway with memchr

### DIFF
--- a/actix-multipart/Cargo.toml
+++ b/actix-multipart/Cargo.toml
@@ -24,7 +24,7 @@ httparse = "1.3"
 local-waker = "0.1"
 log = "0.4"
 mime = "0.3"
-twoway = "0.2"
+memchr = "2.5"
 
 [dev-dependencies]
 actix-rt = "2.2"

--- a/actix-multipart/src/server.rs
+++ b/actix-multipart/src/server.rs
@@ -606,7 +606,7 @@ impl InnerField {
         }
 
         loop {
-            return if let Some(idx) = twoway::find_bytes(&payload.buf[pos..], b"\r") {
+            return if let Some(idx) = memchr::memmem::find(&payload.buf[pos..], b"\r") {
                 let cur = pos + idx;
 
                 // check if we have enough data for boundary detection
@@ -827,7 +827,7 @@ impl PayloadBuffer {
 
     /// Read until specified ending
     fn read_until(&mut self, line: &[u8]) -> Result<Option<Bytes>, MultipartError> {
-        let res = twoway::find_bytes(&self.buf, line)
+        let res = memchr::memmem::find(&self.buf, line)
             .map(|idx| self.buf.split_to(idx + line.len()).freeze());
 
         if res.is_none() && self.eof {


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Refactor


## PR Checklist
<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] ~~Tests for the changes have been added / updated.~~
- [x] ~~Documentation comments have been added / updated.~~
- [x] ~~A changelog entry has been made for the appropriate packages.~~
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

This PR replaces the depecated `twoway` package with `memchr` as suggested.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->

Closes #2907
