### PR TITLE
fix non-empty body of http2 HEAD response

### DIFF
--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -1,6 +1,9 @@
 # Changes
 
 ## Unreleased - 2022-xx-xx
+### Fixed
+- Fix non-empty body of http2 HEAD response.
+
 ### Added
 - Implement `MessageBody` for `&mut B` where `B: MessageBody + Unpin`. [#2868]
 - Implement `MessageBody` for `Pin<B>` where `B::Target: MessageBody`. [#2868]

--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -1,9 +1,6 @@
 # Changes
 
 ## Unreleased - 2022-xx-xx
-### Fixed
-- Fix non-empty body of http2 HEAD response.
-
 ### Added
 - Implement `MessageBody` for `Cow<'static, str>` and `Cow<'static, [u8]>`. [#2959]
 - Implement `MessageBody` for `&mut B` where `B: MessageBody + Unpin`. [#2868]
@@ -20,17 +17,20 @@
   - `X_FORWARDED_HOST`
   - `X_FORWARDED_PROTO`
 
+### Fixed
+- Fix non-empty body of HTTP/2 HEAD responses. [#2920]
+
 ### Performance
 - Improve overall performance of operations on `Extensions`. [#2890]
 
 [#2959]: https://github.com/actix/actix-web/pull/2959
 [#2868]: https://github.com/actix/actix-web/pull/2868
 [#2890]: https://github.com/actix/actix-web/pull/2890
+[#2920]: https://github.com/actix/actix-web/pull/2920
 [#2957]: https://github.com/actix/actix-web/pull/2957
 [#2955]: https://github.com/actix/actix-web/pull/2955
 [#2956]: https://github.com/actix/actix-web/pull/2956
 [#2968]: https://github.com/actix/actix-web/pull/2968
-
 
 ## 3.2.2 - 2022-09-11
 ### Changed

--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -32,6 +32,7 @@
 [#2956]: https://github.com/actix/actix-web/pull/2956
 [#2968]: https://github.com/actix/actix-web/pull/2968
 
+
 ## 3.2.2 - 2022-09-11
 ### Changed
 - Minimum supported Rust version (MSRV) is now 1.59 due to transitive `time` dependency.

--- a/actix-http/src/h2/dispatcher.rs
+++ b/actix-http/src/h2/dispatcher.rs
@@ -19,6 +19,7 @@ use h2::{
     server::{Connection, SendResponse},
     Ping, PingPong,
 };
+use http::Method;
 use pin_project_lite::pin_project;
 use tracing::{error, trace, warn};
 
@@ -118,6 +119,7 @@ where
                     let payload = crate::h2::Payload::new(body);
                     let pl = Payload::H2 { payload };
                     let mut req = Request::with_payload(pl);
+                    let head_req = parts.method == Method::HEAD;
 
                     let head = req.head_mut();
                     head.uri = parts.uri;
@@ -135,10 +137,10 @@ where
                     actix_rt::spawn(async move {
                         // resolve service call and send response.
                         let res = match fut.await {
-                            Ok(res) => handle_response(res.into(), tx, config).await,
+                            Ok(res) => handle_response(res.into(), tx, config, head_req).await,
                             Err(err) => {
                                 let res: Response<BoxBody> = err.into();
-                                handle_response(res, tx, config).await
+                                handle_response(res, tx, config, head_req).await
                             }
                         };
 
@@ -206,6 +208,7 @@ async fn handle_response<B>(
     res: Response<B>,
     mut tx: SendResponse<Bytes>,
     config: ServiceConfig,
+    head_req: bool,
 ) -> Result<(), DispatchError>
 where
     B: MessageBody,
@@ -215,7 +218,7 @@ where
     // prepare response.
     let mut size = body.size();
     let res = prepare_response(config, res.head(), &mut size);
-    let eof = size.is_eof();
+    let eof = size.is_eof() || head_req;
 
     // send response head and return on eof.
     let mut stream = tx

--- a/awc/src/client/h2proto.rs
+++ b/awc/src/client/h2proto.rs
@@ -126,7 +126,15 @@ where
     };
 
     let (parts, body) = resp.into_parts();
-    let payload = if head_req { Payload::None } else { body.into() };
+    let payload = if cfg!(test) {
+        body.into()
+    } else {
+        if head_req {
+            Payload::None
+        } else {
+            body.into()
+        }
+    };
 
     let mut head = ResponseHead::new(parts.status);
     head.version = parts.version;

--- a/awc/src/client/h2proto.rs
+++ b/awc/src/client/h2proto.rs
@@ -126,15 +126,7 @@ where
     };
 
     let (parts, body) = resp.into_parts();
-    let payload = if cfg!(test) {
-        body.into()
-    } else {
-        if head_req {
-            Payload::None
-        } else {
-            body.into()
-        }
-    };
+    let payload = if head_req { Payload::None } else { body.into() };
 
     let mut head = ResponseHead::new(parts.status);
     head.version = parts.version;


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Fix


## PR Checklist
<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
The body of http2 HEAD response was non-empty, test ```h2_head_empty``` works because awc drop the body in the client.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
