### PR TITLE
Update tokio-uring to 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,5 +43,5 @@ awc = { path = "awc" }
 # actix-tls = { path = "../actix-net/actix-tls" }
 # actix-server = { path = "../actix-net/actix-server" }
 
-actix-server = { git = "https://github.com/actix/actix-net" }
-actix-rt = { git = "https://github.com/actix/actix-net" }
+actix-server = { git = "https://github.com/asonix/actix-net", branch = "asonix/tokio-uring-04" }
+actix-rt = { git = "https://github.com/asonix/actix-net", branch = "asonix/tokio-uring-04" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,3 +42,6 @@ awc = { path = "awc" }
 # actix-utils = { path = "../actix-net/actix-utils" }
 # actix-tls = { path = "../actix-net/actix-tls" }
 # actix-server = { path = "../actix-net/actix-server" }
+
+actix-server = { git = "https://github.com/actix/actix-net" }
+actix-rt = { git = "https://github.com/actix/actix-net" }

--- a/actix-files/CHANGES.md
+++ b/actix-files/CHANGES.md
@@ -3,8 +3,10 @@
 ## Unreleased - 2022-xx-xx
 - XHTML files now use `Content-Disposition: inline` instead of `attachment`. [#2903]
 - Minimum supported Rust version (MSRV) is now 1.59 due to transitive `time` dependency.
+- Update tokio-uring to 0.4
 
 [#2903]: https://github.com/actix/actix-web/pull/2903
+[#????]: pending
 
 ## 0.6.2 - 2022-07-23
 - Allow partial range responses for video content to start streaming sooner. [#2817]

--- a/actix-files/CHANGES.md
+++ b/actix-files/CHANGES.md
@@ -6,7 +6,7 @@
 - Update tokio-uring to 0.4
 
 [#2903]: https://github.com/actix/actix-web/pull/2903
-[#????]: pending
+[#2934]: https://github.com/actix/actix-web/pull/2934
 
 ## 0.6.2 - 2022-07-23
 - Allow partial range responses for video content to start streaming sooner. [#2817]

--- a/actix-files/Cargo.toml
+++ b/actix-files/Cargo.toml
@@ -40,8 +40,8 @@ v_htmlescape= "0.15"
 
 # experimental-io-uring
 [target.'cfg(target_os = "linux")'.dependencies]
-tokio-uring = { version = "0.3", optional = true, features = ["bytes"] }
-actix-server = { version = "2.1", optional = true } # ensure matching tokio-uring versions
+tokio-uring = { version = "0.4", optional = true, features = ["bytes"] }
+actix-server = { version = "2.1", optional = true, features = ["io-uring"] } # ensure matching tokio-uring versions
 
 [dev-dependencies]
 actix-rt = "2.7"


### PR DESCRIPTION
## PR Type
Dependency update


## PR Checklist
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [ ] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
update tokio-uring to 0.4
