### PR TITLE
Implement `MessageBody` for `Cow<'static, {[u8], str}>`

### DIFF
--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased - 2022-xx-xx
 ### Added
+- Implement `MessageBody` for `Cow<'static, str>` and `Cow<'static, [u8]>`. [#2959]
 - Implement `MessageBody` for `&mut B` where `B: MessageBody + Unpin`. [#2868]
 - Implement `MessageBody` for `Pin<B>` where `B::Target: MessageBody`. [#2868]
 - Automatic h2c detection via new service finalizer `HttpService::tcp_auto_h2c()`. [#2957]
@@ -17,6 +18,7 @@
 ### Performance
 - Improve overall performance of operations on `Extensions`. [#2890]
 
+[#2959]: https://github.com/actix/actix-web/pull/2959
 [#2868]: https://github.com/actix/actix-web/pull/2868
 [#2890]: https://github.com/actix/actix-web/pull/2890
 [#2957]: https://github.com/actix/actix-web/pull/2957


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Feature


## PR Checklist
<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] ~Tests for the changes have been added / updated.~
- [x] ~Documentation comments have been added / updated.~
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
This is extends flexibility in the same vein as implementations for `&'static [u8]`, `Vet<u8>`, `&'static str`, and `String`. It can be used to simplify code that conditionally caches message bodies.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
