### PR TITLE
Add fallible versions of test_utils helpers to actix-test

### DIFF
--- a/actix-web/CHANGES.md
+++ b/actix-web/CHANGES.md
@@ -7,6 +7,7 @@
 - Add `Logger::custom_response_replace()`. [#2631]
 - Add rudimentary redirection service at `web::redirect()` / `web::Redirect`. [#1961]
 - Add `guard::Acceptable` for matching against `Accept` header mime types. [#2265]
+- Add fallible versions of test helpers: `try_call_service`, `try_call_and_read_body_json`, `try_read_body`, and `try_read_body_json`. [#2961]
 
 ### Fixed
 - Add `Allow` header to `Resource`'s default responses when no routes are matched. [#2949]
@@ -17,7 +18,7 @@
 [#2784]: https://github.com/actix/actix-web/pull/2784
 [#2867]: https://github.com/actix/actix-web/pull/2867
 [#2949]: https://github.com/actix/actix-web/pull/2949
-
+[#2961]: https://github.com/actix/actix-web/pull/2961
 
 ## 4.2.1 - 2022-09-12
 ### Fixed

--- a/actix-web/src/test/mod.rs
+++ b/actix-web/src/test/mod.rs
@@ -10,12 +10,16 @@
 //! # Calling Test Service
 //! - [`TestRequest`]
 //! - [`call_service`]
+//! - [`try_call_service`]
 //! - [`call_and_read_body`]
 //! - [`call_and_read_body_json`]
+//! - [`try_call_and_read_body_json`]
 //!
 //! # Reading Response Payloads
 //! - [`read_body`]
+//! - [`try_read_body`]
 //! - [`read_body_json`]
+//! - [`try_read_body_json`]
 
 // TODO: more docs on generally how testing works with these parts
 
@@ -31,7 +35,8 @@ pub use self::test_services::{default_service, ok_service, simple_service, statu
 #[allow(deprecated)]
 pub use self::test_utils::{
     call_and_read_body, call_and_read_body_json, call_service, init_service, read_body,
-    read_body_json, read_response, read_response_json,
+    read_body_json, read_response, read_response_json, try_call_and_read_body_json,
+    try_call_service, try_read_body, try_read_body_json,
 };
 
 #[cfg(test)]


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Feature


## PR Checklist
<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Add fallible versions of `test_utils` helpers for calling test services and reading response payloads. Existing non-fallible call into their fallible counterparts and use `unwrap`.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
Resolves #2952 