### PR TITLE
Fix minor typo in Markdown

### DIFF
--- a/actix-web/src/response/responder.rs
+++ b/actix-web/src/response/responder.rs
@@ -21,7 +21,7 @@ use crate::{Error, HttpRequest, HttpResponse};
 /// - `HttpResponse` and `HttpResponseBuilder`
 /// - `Option<R>` where `R: Responder`
 /// - `Result<R, E>` where `R: Responder` and [`E: ResponseError`](crate::ResponseError)
-/// - `(R, StatusCode) where `R: Responder`
+/// - `(R, StatusCode)` where `R: Responder`
 /// - `&'static str`, `String`, `&'_ String`, `Cow<'_, str>`, [`ByteString`](bytestring::ByteString)
 /// - `&'static [u8]`, `Vec<u8>`, `Bytes`, `BytesMut`
 /// - [`Json<T>`](crate::web::Json) and [`Form<T>`](crate::web::Form) where `T: Serialize`


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Bug Fix


## PR Checklist
<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [X] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [ ] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.


## Overview
Fixes a minor typo in the Markdown for `Responder` where a closing backtick was missed.
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->


<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
