### PR TITLE
ci(windows): use choco to install openssl (#3003

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         target:
           - { name: Linux, os: ubuntu-latest, triple: x86_64-unknown-linux-gnu }
           - { name: macOS, os: macos-latest, triple: x86_64-apple-darwin }
-          - { name: Windows, os: windows-2022, triple: x86_64-pc-windows-msvc }
+          - { name: Windows, os: windows-latest, triple: x86_64-pc-windows-msvc }
         version:
           - 1.59.0 # MSRV
           - stable
@@ -28,20 +28,16 @@ jobs:
     env:
       CI: 1
       CARGO_INCREMENTAL: 0
-      VCPKGRS_DYNAMIC: 1
 
     steps:
       - uses: actions/checkout@v3
 
-      # install OpenSSL on Windows
-      # TODO: GitHub actions docs state that OpenSSL is
-      # already installed on these Windows machines somewhere
-      - name: Set vcpkg root
-        if: matrix.target.triple == 'x86_64-pc-windows-msvc'
-        run: echo "VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" | Out-File -FilePath $env:GITHUB_ENV -Append
       - name: Install OpenSSL
-        if: matrix.target.triple == 'x86_64-pc-windows-msvc'
-        run: vcpkg install openssl:x64-windows
+        if: matrix.target.os == 'windows-latest'
+        run: choco install openssl
+      - name: Set OpenSSL dir in env
+        if: matrix.target.os == 'windows-latest'
+        run: echo 'OPENSSL_DIR=C:\Program Files\OpenSSL-Win64' | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Install ${{ matrix.version }}
         uses: actions-rs/toolchain@v1


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type

<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->

CI

## PR Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you com -->

- [x] (Team) Label with affected crates and semver status.

## Overview

Use choco to install OpenSSL on Windows runners. It's 10x faster than vcpkg.