### PR TITLE
Add http2 optional feature

### DIFF
--- a/actix-multipart/Cargo.toml
+++ b/actix-multipart/Cargo.toml
@@ -40,7 +40,7 @@ serde_json = "1"
 serde_plain = "1"
 # TODO(MSRV 1.60): replace with dep: prefix
 tempfile-dep = { package = "tempfile", version = "3.4", optional = true }
-tokio = { version = "1.24.2", features = ["sync"] }
+tokio = { version = "1.24.2", features = ["io-util", "sync"] }
 
 [dev-dependencies]
 actix-http = "3"

--- a/actix-web/CHANGES.md
+++ b/actix-web/CHANGES.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Add `HttpServer::{bind,listen}_auto_h2c()` method.
+- Add `HttpServer::{bind, listen}_auto_h2c()` method behind new `http2` crate feature.
 - Add `Resource::{get, post, etc...}` methods for more concisely adding routes that don't need additional guards.
 
 ### Changed

--- a/actix-web/Cargo.toml
+++ b/actix-web/Cargo.toml
@@ -28,7 +28,7 @@ name = "actix_web"
 path = "src/lib.rs"
 
 [features]
-default = ["macros", "compress-brotli", "compress-gzip", "compress-zstd", "cookies"]
+default = ["macros", "compress-brotli", "compress-gzip", "compress-zstd", "cookies", "http2"]
 
 # Brotli algorithm content-encoding support
 compress-brotli = ["actix-http/compress-brotli", "__compress"]
@@ -46,11 +46,13 @@ cookies = ["cookie"]
 # Secure & signed cookies
 secure-cookies = ["cookies", "cookie/secure"]
 
+http2 = ["actix-http/http2"]
+
 # TLS via OpenSSL
-openssl = ["actix-http/openssl", "actix-tls/accept", "actix-tls/openssl"]
+openssl = ["http2", "actix-http/openssl", "actix-tls/accept", "actix-tls/openssl"]
 
 # TLS via Rustls
-rustls = ["actix-http/rustls", "actix-tls/accept", "actix-tls/rustls"]
+rustls = ["http2", "actix-http/rustls", "actix-tls/accept", "actix-tls/rustls"]
 
 # Internal (PRIVATE!) features used to aid testing and checking feature status.
 # Don't rely on these whatsoever. They may disappear at anytime.
@@ -68,7 +70,7 @@ actix-service = "2"
 actix-utils = "3"
 actix-tls = { version = "3", default-features = false, optional = true }
 
-actix-http = { version = "3.3", features = ["http2", "ws"] }
+actix-http = { version = "3.3", features = ["ws"] }
 actix-router = "0.5"
 actix-web-codegen = { version = "4.2", optional = true }
 

--- a/actix-web/src/rmap.rs
+++ b/actix-web/src/rmap.rs
@@ -81,7 +81,7 @@ impl ResourceMap {
                 "`pattern` and `nested` mismatch"
             );
             // parents absorb references to the named resources of children
-            self.named.extend(new_node.named.clone().into_iter());
+            self.named.extend(new_node.named.clone());
             self.nodes.as_mut().unwrap().push(new_node);
         } else {
             let new_node = Rc::new(ResourceMap {

--- a/actix-web/src/server.rs
+++ b/actix-web/src/server.rs
@@ -356,6 +356,7 @@ where
 
     /// Resolves socket address(es) and binds server to created listener(s) for plaintext HTTP/1.x
     /// or HTTP/2 connections.
+    #[cfg(feature = "http2")]
     pub fn bind_auto_h2c<A: net::ToSocketAddrs>(mut self, addrs: A) -> io::Result<Self> {
         let sockets = bind_addrs(addrs, self.backlog)?;
 
@@ -453,6 +454,7 @@ where
     }
 
     /// Binds to existing listener for accepting incoming plaintext HTTP/1.x or HTTP/2 connections.
+    #[cfg(feature = "http2")]
     pub fn listen_auto_h2c(mut self, lst: net::TcpListener) -> io::Result<Self> {
         let cfg = self.config.clone();
         let factory = self.factory.clone();


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type

<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->

Feature

## PR Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [X] Tests for the changes have been added / updated.
  - There are currently no test cases for this in actix-web as far as i could tell.
- [X] Documentation comments have been added / updated.
  - Since these methods are new features in 4.3.1, I don't know that they need any new documentation changes.
- [x] A changelog entry has been made for the appropriate packages.
- [X] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.

## Overview

<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->

Closes https://github.com/actix/actix-web/issues/3071 

Adds a new default feature flag for http2 and puts the new auto_h2c methods behind this feature. This allows users to remove http2 support for binary size savings.

In my minimum sized application, the size difference was 20% savings when removing http2, but I did not do exhaustive testing of several applications.