### PR TITLE
chore: update msrv to 1.68

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -2,8 +2,7 @@ name: Benchmark
 
 on:
   push:
-    branches:
-      - master
+    branches: [master]
 
 permissions:
   contents: read # to fetch code (actions/checkout)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           - { name: macOS, os: macos-latest, triple: x86_64-apple-darwin }
           - { name: Windows, os: windows-latest, triple: x86_64-pc-windows-msvc }
         version:
-          - 1.65.0 # MSRV
+          - 1.68.0 # MSRV
           - stable
 
     name: ${{ matrix.target.name }} / ${{ matrix.version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  merge_group:
+    types: [checks_requested]
   push:
     branches: [master]
 

--- a/actix-files/CHANGES.md
+++ b/actix-files/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## Unreleased - 2023-xx-xx
 
-- Minimum supported Rust version (MSRV) is now 1.65 due to transitive `time` dependency.
+- Minimum supported Rust version (MSRV) is now 1.68 due to transitive `time` dependency.
 
 ## 0.6.3 - 2023-01-21
 

--- a/actix-files/README.md
+++ b/actix-files/README.md
@@ -4,7 +4,7 @@
 
 [![crates.io](https://img.shields.io/crates/v/actix-files?label=latest)](https://crates.io/crates/actix-files)
 [![Documentation](https://docs.rs/actix-files/badge.svg?version=0.6.3)](https://docs.rs/actix-files/0.6.3)
-![Version](https://img.shields.io/badge/rustc-1.65+-ab6000.svg)
+![Version](https://img.shields.io/badge/rustc-1.68+-ab6000.svg)
 ![License](https://img.shields.io/crates/l/actix-files.svg)
 <br />
 [![dependency status](https://deps.rs/crate/actix-files/0.6.3/status.svg)](https://deps.rs/crate/actix-files/0.6.3)
@@ -15,4 +15,4 @@
 
 - [API Documentation](https://docs.rs/actix-files)
 - [Example Project](https://github.com/actix/examples/tree/master/basics/static-files)
-- Minimum Supported Rust Version (MSRV): 1.65
+- Minimum Supported Rust Version (MSRV): 1.68

--- a/actix-http-test/CHANGES.md
+++ b/actix-http-test/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## Unreleased - 2023-xx-xx
 
-- Minimum supported Rust version (MSRV) is now 1.65 due to transitive `time` dependency.
+- Minimum supported Rust version (MSRV) is now 1.68 due to transitive `time` dependency.
 
 ## 3.1.0 - 2023-01-21
 

--- a/actix-http-test/README.md
+++ b/actix-http-test/README.md
@@ -4,7 +4,7 @@
 
 [![crates.io](https://img.shields.io/crates/v/actix-http-test?label=latest)](https://crates.io/crates/actix-http-test)
 [![Documentation](https://docs.rs/actix-http-test/badge.svg?version=3.1.0)](https://docs.rs/actix-http-test/3.1.0)
-![Version](https://img.shields.io/badge/rustc-1.65+-ab6000.svg)
+![Version](https://img.shields.io/badge/rustc-1.68+-ab6000.svg)
 ![MIT or Apache 2.0 licensed](https://img.shields.io/crates/l/actix-http-test)
 <br>
 [![Dependency Status](https://deps.rs/crate/actix-http-test/3.1.0/status.svg)](https://deps.rs/crate/actix-http-test/3.1.0)
@@ -14,4 +14,4 @@
 ## Documentation & Resources
 
 - [API Documentation](https://docs.rs/actix-http-test)
-- Minimum Supported Rust Version (MSRV): 1.65
+- Minimum Supported Rust Version (MSRV): 1.68

--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -9,7 +9,7 @@
 
 ### Changed
 
-- Minimum supported Rust version (MSRV) is now 1.65 due to transitive `time` dependency.
+- Minimum supported Rust version (MSRV) is now 1.68 due to transitive `time` dependency.
 
 ## 3.3.1 - 2023-03-02
 

--- a/actix-http/README.md
+++ b/actix-http/README.md
@@ -4,7 +4,7 @@
 
 [![crates.io](https://img.shields.io/crates/v/actix-http?label=latest)](https://crates.io/crates/actix-http)
 [![Documentation](https://docs.rs/actix-http/badge.svg?version=3.3.1)](https://docs.rs/actix-http/3.3.1)
-![Version](https://img.shields.io/badge/rustc-1.65+-ab6000.svg)
+![Version](https://img.shields.io/badge/rustc-1.68+-ab6000.svg)
 ![MIT or Apache 2.0 licensed](https://img.shields.io/crates/l/actix-http.svg)
 <br />
 [![dependency status](https://deps.rs/crate/actix-http/3.3.1/status.svg)](https://deps.rs/crate/actix-http/3.3.1)
@@ -14,7 +14,7 @@
 ## Documentation & Resources
 
 - [API Documentation](https://docs.rs/actix-http)
-- Minimum Supported Rust Version (MSRV): 1.65
+- Minimum Supported Rust Version (MSRV): 1.68
 
 ## Example
 

--- a/actix-multipart-derive/CHANGES.md
+++ b/actix-multipart-derive/CHANGES.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Update `syn` dependency to `2`.
-- Minimum supported Rust version (MSRV) is now 1.65 due to transitive `time` dependency.
+- Minimum supported Rust version (MSRV) is now 1.68 due to transitive `time` dependency.
 
 ## 0.6.0 - 2023-02-26
 

--- a/actix-multipart-derive/README.md
+++ b/actix-multipart-derive/README.md
@@ -4,7 +4,7 @@
 
 [![crates.io](https://img.shields.io/crates/v/actix-multipart-derive?label=latest)](https://crates.io/crates/actix-multipart-derive)
 [![Documentation](https://docs.rs/actix-multipart-derive/badge.svg?version=0.5.0)](https://docs.rs/actix-multipart-derive/0.5.0)
-![Version](https://img.shields.io/badge/rustc-1.65+-ab6000.svg)
+![Version](https://img.shields.io/badge/rustc-1.68+-ab6000.svg)
 ![MIT or Apache 2.0 licensed](https://img.shields.io/crates/l/actix-multipart-derive.svg)
 <br />
 [![dependency status](https://deps.rs/crate/actix-multipart-derive/0.5.0/status.svg)](https://deps.rs/crate/actix-multipart-derive/0.5.0)
@@ -14,4 +14,4 @@
 ## Documentation & Resources
 
 - [API Documentation](https://docs.rs/actix-multipart-derive)
-- Minimum Supported Rust Version (MSRV): 1.65
+- Minimum Supported Rust Version (MSRV): 1.68

--- a/actix-multipart-derive/tests/trybuild.rs
+++ b/actix-multipart-derive/tests/trybuild.rs
@@ -1,4 +1,4 @@
-#[rustversion::stable(1.65)] // MSRV
+#[rustversion::stable(1.68)] // MSRV
 #[test]
 fn compile_macros() {
     let t = trybuild::TestCases::new();

--- a/actix-multipart/CHANGES.md
+++ b/actix-multipart/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## Unreleased - 2023-xx-xx
 
-- Minimum supported Rust version (MSRV) is now 1.65 due to transitive `time` dependency.
+- Minimum supported Rust version (MSRV) is now 1.68 due to transitive `time` dependency.
 
 ## 0.6.0 - 2023-02-26
 

--- a/actix-multipart/README.md
+++ b/actix-multipart/README.md
@@ -4,7 +4,7 @@
 
 [![crates.io](https://img.shields.io/crates/v/actix-multipart?label=latest)](https://crates.io/crates/actix-multipart)
 [![Documentation](https://docs.rs/actix-multipart/badge.svg?version=0.6.0)](https://docs.rs/actix-multipart/0.6.0)
-![Version](https://img.shields.io/badge/rustc-1.65+-ab6000.svg)
+![Version](https://img.shields.io/badge/rustc-1.68+-ab6000.svg)
 ![MIT or Apache 2.0 licensed](https://img.shields.io/crates/l/actix-multipart.svg)
 <br />
 [![dependency status](https://deps.rs/crate/actix-multipart/0.6.0/status.svg)](https://deps.rs/crate/actix-multipart/0.6.0)
@@ -14,4 +14,4 @@
 ## Documentation & Resources
 
 - [API Documentation](https://docs.rs/actix-multipart)
-- Minimum Supported Rust Version (MSRV): 1.65
+- Minimum Supported Rust Version (MSRV): 1.68

--- a/actix-router/CHANGES.md
+++ b/actix-router/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## Unreleased - 2023-xx-xx
 
-- Minimum supported Rust version (MSRV) is now 1.65 due to transitive `time` dependency.
+- Minimum supported Rust version (MSRV) is now 1.68 due to transitive `time` dependency.
 
 ## 0.5.1 - 2022-09-19
 

--- a/actix-router/src/resource.rs
+++ b/actix-router/src/resource.rs
@@ -501,7 +501,12 @@ impl ResourceDef {
         let patterns = self
             .pattern_iter()
             .flat_map(move |this| other.pattern_iter().map(move |other| (this, other)))
-            .map(|(this, other)| [this, other].join(""))
+            .map(|(this, other)| {
+                let mut pattern = String::with_capacity(this.len() + other.len());
+                pattern.push_str(this);
+                pattern.push_str(other);
+                pattern
+            })
             .collect::<Vec<_>>();
 
         match patterns.len() {

--- a/actix-test/CHANGES.md
+++ b/actix-test/CHANGES.md
@@ -3,7 +3,7 @@
 ## Unreleased - 2023-xx-xx
 
 - Add `TestServerConfig::workers()` setter method.
-- Minimum supported Rust version (MSRV) is now 1.65 due to transitive `time` dependency.
+- Minimum supported Rust version (MSRV) is now 1.68 due to transitive `time` dependency.
 
 ## 0.1.1 - 2023-02-26
 

--- a/actix-web-actors/CHANGES.md
+++ b/actix-web-actors/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## Unreleased - 2023-xx-xx
 
-- Minimum supported Rust version (MSRV) is now 1.65 due to transitive `time` dependency.
+- Minimum supported Rust version (MSRV) is now 1.68 due to transitive `time` dependency.
 
 ## 4.2.0 - 2023-01-21
 

--- a/actix-web-actors/README.md
+++ b/actix-web-actors/README.md
@@ -4,7 +4,7 @@
 
 [![crates.io](https://img.shields.io/crates/v/actix-web-actors?label=latest)](https://crates.io/crates/actix-web-actors)
 [![Documentation](https://docs.rs/actix-web-actors/badge.svg?version=4.2.0)](https://docs.rs/actix-web-actors/4.2.0)
-![Version](https://img.shields.io/badge/rustc-1.65+-ab6000.svg)
+![Version](https://img.shields.io/badge/rustc-1.68+-ab6000.svg)
 ![License](https://img.shields.io/crates/l/actix-web-actors.svg)
 <br />
 [![dependency status](https://deps.rs/crate/actix-web-actors/4.2.0/status.svg)](https://deps.rs/crate/actix-web-actors/4.2.0)
@@ -14,4 +14,4 @@
 ## Documentation & Resources
 
 - [API Documentation](https://docs.rs/actix-web-actors)
-- Minimum Supported Rust Version (MSRV): 1.65
+- Minimum Supported Rust Version (MSRV): 1.68

--- a/actix-web-codegen/CHANGES.md
+++ b/actix-web-codegen/CHANGES.md
@@ -3,7 +3,7 @@
 ## Unreleased - 2023-xx-xx
 
 - Update `syn` dependency to `2`.
-- Minimum supported Rust version (MSRV) is now 1.65 due to transitive `time` dependency.
+- Minimum supported Rust version (MSRV) is now 1.68 due to transitive `time` dependency.
 
 ## 4.2.0 - 2023-02-26
 

--- a/actix-web-codegen/README.md
+++ b/actix-web-codegen/README.md
@@ -4,7 +4,7 @@
 
 [![crates.io](https://img.shields.io/crates/v/actix-web-codegen?label=latest)](https://crates.io/crates/actix-web-codegen)
 [![Documentation](https://docs.rs/actix-web-codegen/badge.svg?version=4.2.0)](https://docs.rs/actix-web-codegen/4.2.0)
-![Version](https://img.shields.io/badge/rustc-1.65+-ab6000.svg)
+![Version](https://img.shields.io/badge/rustc-1.68+-ab6000.svg)
 ![License](https://img.shields.io/crates/l/actix-web-codegen.svg)
 <br />
 [![dependency status](https://deps.rs/crate/actix-web-codegen/4.2.0/status.svg)](https://deps.rs/crate/actix-web-codegen/4.2.0)
@@ -14,7 +14,7 @@
 ## Documentation & Resources
 
 - [API Documentation](https://docs.rs/actix-web-codegen)
-- Minimum Supported Rust Version (MSRV): 1.65
+- Minimum Supported Rust Version (MSRV): 1.68
 
 ## Compile Testing
 

--- a/actix-web-codegen/tests/trybuild.rs
+++ b/actix-web-codegen/tests/trybuild.rs
@@ -1,4 +1,4 @@
-#[rustversion::stable(1.65)] // MSRV
+#[rustversion::stable(1.68)] // MSRV
 #[test]
 fn compile_macros() {
     let t = trybuild::TestCases::new();

--- a/actix-web/CHANGES.md
+++ b/actix-web/CHANGES.md
@@ -15,7 +15,7 @@
 - Handler functions can now receive up to 16 extractor parameters.
 - The `Compress` middleware no longer compresses image or video content.
 - Hide sensitive header values in `HttpRequest`'s `Debug` output.
-- Minimum supported Rust version (MSRV) is now 1.65 due to transitive `time` dependency.
+- Minimum supported Rust version (MSRV) is now 1.68 due to transitive `time` dependency.
 
 ## 4.3.1 - 2023-02-26
 

--- a/actix-web/README.md
+++ b/actix-web/README.md
@@ -5,7 +5,7 @@
   </p>
   <p>
 
-[![crates.io](https://img.shields.io/crates/v/actix-web?label=latest)](https://crates.io/crates/actix-web) [![Documentation](https://docs.rs/actix-web/badge.svg?version=4.3.1)](https://docs.rs/actix-web/4.3.1) ![MSRV](https://img.shields.io/badge/rustc-1.65+-ab6000.svg) ![MIT or Apache 2.0 licensed](https://img.shields.io/crates/l/actix-web.svg) [![Dependency Status](https://deps.rs/crate/actix-web/4.3.1/status.svg)](https://deps.rs/crate/actix-web/4.3.1) <br /> [![CI](https://github.com/actix/actix-web/actions/workflows/ci.yml/badge.svg)](https://github.com/actix/actix-web/actions/workflows/ci.yml) [![codecov](https://codecov.io/gh/actix/actix-web/branch/master/graph/badge.svg)](https://codecov.io/gh/actix/actix-web) ![downloads](https://img.shields.io/crates/d/actix-web.svg) [![Chat on Discord](https://img.shields.io/discord/771444961383153695?label=chat&logo=discord)](https://discord.gg/NWpN5mmg3x)
+[![crates.io](https://img.shields.io/crates/v/actix-web?label=latest)](https://crates.io/crates/actix-web) [![Documentation](https://docs.rs/actix-web/badge.svg?version=4.3.1)](https://docs.rs/actix-web/4.3.1) ![MSRV](https://img.shields.io/badge/rustc-1.68+-ab6000.svg) ![MIT or Apache 2.0 licensed](https://img.shields.io/crates/l/actix-web.svg) [![Dependency Status](https://deps.rs/crate/actix-web/4.3.1/status.svg)](https://deps.rs/crate/actix-web/4.3.1) <br /> [![CI](https://github.com/actix/actix-web/actions/workflows/ci.yml/badge.svg)](https://github.com/actix/actix-web/actions/workflows/ci.yml) [![codecov](https://codecov.io/gh/actix/actix-web/branch/master/graph/badge.svg)](https://codecov.io/gh/actix/actix-web) ![downloads](https://img.shields.io/crates/d/actix-web.svg) [![Chat on Discord](https://img.shields.io/discord/771444961383153695?label=chat&logo=discord)](https://discord.gg/NWpN5mmg3x)
 
   </p>
 </div>
@@ -24,7 +24,7 @@
 - SSL support using OpenSSL or Rustls
 - Middlewares ([Logger, Session, CORS, etc](https://actix.rs/docs/middleware/))
 - Integrates with the [`awc` HTTP client](https://docs.rs/awc/)
-- Runs on stable Rust 1.65+
+- Runs on stable Rust 1.68+
 
 ## Documentation
 

--- a/awc/CHANGES.md
+++ b/awc/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## Unreleased - 2023-xx-xx
 
-- Minimum supported Rust version (MSRV) is now 1.65 due to transitive `time` dependency.
+- Minimum supported Rust version (MSRV) is now 1.68 due to transitive `time` dependency.
 
 ## 3.1.1 - 2023-02-26
 

--- a/awc/README.md
+++ b/awc/README.md
@@ -12,7 +12,7 @@
 
 - [API Documentation](https://docs.rs/awc)
 - [Example Project](https://github.com/actix/examples/tree/master/https-tls/awc-https)
-- Minimum Supported Rust Version (MSRV): 1.65
+- Minimum Supported Rust Version (MSRV): 1.68
 
 ## Example
 


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type

<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->

MSRV

## PR Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] ~Tests for the changes have been added / updated.~
- [x] ~Documentation comments have been added / updated.~
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.

## Overview

MSRV 1.68 due to another time bump + 1

released March 2023