### PR TITLE
feat: add ability to specify log level for access logger

### DIFF
--- a/actix-web/CHANGES.md
+++ b/actix-web/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- Add `Logger::level` to change the log level.
+
 ### Changed
 
 - Updated `zstd` dependency to `0.13`.

--- a/actix-web/Cargo.toml
+++ b/actix-web/Cargo.toml
@@ -123,6 +123,7 @@ tls-openssl = { package = "openssl", version = "0.10.55" }
 tls-rustls = { package = "rustls", version = "0.21" }
 tokio = { version = "1.24.2", features = ["rt-multi-thread", "macros"] }
 zstd = "0.13"
+capture-logger = "0.1"
 
 [[test]]
 name = "test_server"

--- a/actix-web/src/middleware/logger.rs
+++ b/actix-web/src/middleware/logger.rs
@@ -147,6 +147,8 @@ impl Logger {
     ///
     /// # Examples
     /// ```
+    /// # use log::Level;
+    /// # use actix_web::middleware::Logger;
     /// Logger::default()
     ///     .level(Level::Debug);
     /// ```


### PR DESCRIPTION
Hi,

This add a new feature to the `Logger` middleware to set the level of the log.

# Example 
` Logger::default().level(Level::Debug);`

This would ideally go together with https://github.com/actix/actix-web/pull/3086 

## PR Checklist

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [ ] (Team) Label with affected crates and semver status.
