### PR TITLE
Do not encode zero-sized response bodies

### DIFF
--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -6,6 +6,10 @@
 
 - Updated `zstd` dependency to `0.13`.
 
+### Fixed
+
+- Do not encode zero-sized response bodies
+
 ## 3.4.0
 
 ### Added

--- a/actix-http/src/encoding/encoder.rs
+++ b/actix-http/src/encoding/encoder.rs
@@ -52,7 +52,7 @@ impl<B: MessageBody> Encoder<B> {
 
     pub fn response(encoding: ContentEncoding, head: &mut ResponseHead, body: B) -> Self {
         // no need to compress an empty body
-        if matches!(body.size(), BodySize::None) {
+        if matches!(body.size(), BodySize::None | BodySize::Sized(0)) {
             return Self::none();
         }
 


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type

<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->

Bug Fix

## PR Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.

## Overview

While debugging [unleash-edge#341](https://github.com/Unleash/unleash-edge/issues/341), I noticed a that when a client requests compression, the Compress middleware uses `actix_http::encoding::Encoder` to encode the response body. If the response body is empty (as a result of using `()` or `Bytes::new()` or something like `HttpResponse::NotModified().finish()`), the resulting "compressed" response is is no longer empty.

This does not happen if `actix_web::body::None` is used, or the response code is 204 No Content.