### PR TITLE
Implement From<HeaderMap> for http::HeaderMap

### DIFF
--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Updated `zstd` dependency to `0.13`.
+- Implemented `From<HeaderMap>` for `http::HeaderMap`.
 
 ### Fixed
 

--- a/actix-http/src/header/map.rs
+++ b/actix-http/src/header/map.rs
@@ -646,7 +646,7 @@ impl From<http::HeaderMap> for HeaderMap {
 /// Convert our 'HeaderMap' to 'http::HeaderMap'.
 impl From<HeaderMap> for http::HeaderMap {
     fn from(map: HeaderMap) -> Self {
-        Self::from_iter(map.into_iter())
+        Self::from_iter(map)
     }
 }
 

--- a/actix-http/src/header/map.rs
+++ b/actix-http/src/header/map.rs
@@ -638,8 +638,15 @@ impl<'a> IntoIterator for &'a HeaderMap {
 
 /// Convert `http::HeaderMap` to our `HeaderMap`.
 impl From<http::HeaderMap> for HeaderMap {
-    fn from(mut map: http::HeaderMap) -> HeaderMap {
-        HeaderMap::from_drain(map.drain())
+    fn from(mut map: http::HeaderMap) -> Self {
+        Self::from_drain(map.drain())
+    }
+}
+
+/// Convert our 'HeaderMap' to 'http::HeaderMap'.
+impl From<HeaderMap> for http::HeaderMap {
+    fn from(map: HeaderMap) -> Self {
+        Self::from_iter(map.into_iter())
     }
 }
 

--- a/actix-http/src/header/map.rs
+++ b/actix-http/src/header/map.rs
@@ -636,14 +636,14 @@ impl<'a> IntoIterator for &'a HeaderMap {
     }
 }
 
-/// Convert `http::HeaderMap` to our `HeaderMap`.
+/// Convert a `http::HeaderMap` to our `HeaderMap`.
 impl From<http::HeaderMap> for HeaderMap {
     fn from(mut map: http::HeaderMap) -> Self {
         Self::from_drain(map.drain())
     }
 }
 
-/// Convert our 'HeaderMap' to 'http::HeaderMap'.
+/// Convert our `HeaderMap` to a `http::HeaderMap`.
 impl From<HeaderMap> for http::HeaderMap {
     fn from(map: HeaderMap) -> Self {
         Self::from_iter(map)


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type

<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->

Feature

## PR Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.

## Overview

In the most recent release of `actix_http`, you can use `from`/`into` to convert from the http crate `HeaderMap` into the actix `HeaderMap`, but not the other way around. This PR addresses that.

<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
