### PR TITLE
Implement `From<&HeaderMap>` for `http::HeaderMap`

### DIFF
--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- Implement `From<&HeaderMap>` for `http::HeaderMap` and vice versa.
+- Implement `From<&HeaderMap>` for `http::HeaderMap`.
 
 ## 3.5.1
 

--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-### Changed
+### Added
 
 - Implement `From<&HeaderMap>` for `http::HeaderMap`.
 

--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- Implement `From<&HeaderMap>` for `http::HeaderMap` and vice versa.
+
 ## 3.5.0
 
 ### Changed

--- a/actix-http/src/header/map.rs
+++ b/actix-http/src/header/map.rs
@@ -643,15 +643,6 @@ impl From<http::HeaderMap> for HeaderMap {
     }
 }
 
-impl<T> From<&T> for HeaderMap
-where
-    T: Into<http::HeaderMap>,
-{
-    fn from(map: &T) -> Self {
-        map.to_owned().into()
-    }
-}
-
 /// Convert our `HeaderMap` to a `http::HeaderMap`.
 impl From<HeaderMap> for http::HeaderMap {
     fn from(map: HeaderMap) -> Self {

--- a/actix-http/src/header/map.rs
+++ b/actix-http/src/header/map.rs
@@ -643,10 +643,26 @@ impl From<http::HeaderMap> for HeaderMap {
     }
 }
 
+impl<T> From<&T> for HeaderMap
+where
+    T: Into<http::HeaderMap>,
+{
+    fn from(map: &T) -> Self {
+        map.to_owned().into()
+    }
+}
+
 /// Convert our `HeaderMap` to a `http::HeaderMap`.
 impl From<HeaderMap> for http::HeaderMap {
     fn from(map: HeaderMap) -> Self {
         Self::from_iter(map)
+    }
+}
+
+/// Convert our `&HeaderMap` to a `http::HeaderMap`.
+impl From<&HeaderMap> for http::HeaderMap {
+    fn from(map: &HeaderMap) -> Self {
+        map.to_owned().into()
     }
 }
 


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type

<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->

Feature

## PR Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.

## Overview

Related to the last PR I made. I forgot to implement `From` for the header map references in addition to the owned ones.