### PR TITLE
actix-files: Properly handle newlines in file names

### DIFF
--- a/actix-files/CHANGES.md
+++ b/actix-files/CHANGES.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Minimum supported Rust version (MSRV) is now 1.68 due to transitive `time` dependency.
+- Properly handle newlines in filenames. [#3235]
 
 ## 0.6.3
 

--- a/actix-files/src/named.rs
+++ b/actix-files/src/named.rs
@@ -24,7 +24,6 @@ use bitflags::bitflags;
 use derive_more::{Deref, DerefMut};
 use futures_core::future::LocalBoxFuture;
 use mime::Mime;
-use mime_guess::from_path;
 
 use crate::{encoding::equiv_utf8_text, range::HttpRange};
 
@@ -128,7 +127,7 @@ impl NamedFile {
                 }
             };
 
-            let ct = from_path(&path).first_or_octet_stream();
+            let ct = mime_guess::from_path(&path).first_or_octet_stream();
 
             let disposition = match ct.type_() {
                 mime::IMAGE | mime::TEXT | mime::AUDIO | mime::VIDEO => DispositionType::Inline,
@@ -140,7 +139,9 @@ impl NamedFile {
                 _ => DispositionType::Attachment,
             };
 
-            let mut parameters = vec![DispositionParam::Filename(String::from(filename.as_ref()))];
+            // Replace newlines in filenames which could occur on some filesystems.
+            let filename_s = filename.replace('\n', "%0A");
+            let mut parameters = vec![DispositionParam::Filename(filename_s)];
 
             if !filename.is_ascii() {
                 parameters.push(DispositionParam::FilenameExt(ExtendedValue {


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type

<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->

Bug Fix

## PR Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.

## Overview

This used to result in the issue I reported here: https://github.com/actix/actix-web/issues/3234
This shouldn't break anything as so far it was just a 500 error. Afterwards, it should be fixed. On Windows where newlines are illegal (I think), this shouldn't even get there.

Closes #3234.