### PR TITLE
actix-files: fix handling linebreaks in filenames

### DIFF
--- a/actix-files/CHANGES.md
+++ b/actix-files/CHANGES.md
@@ -4,7 +4,8 @@
 
 ## 0.6.4
 
-- Fix handling of newlines in filenames.
+- Fix handling of linebreaks in filenames. [#3237]
+- Fix handling of newlines in filenames. [#3235]
 - Minimum supported Rust version (MSRV) is now 1.68 due to transitive `time` dependency.
 
 ## 0.6.3

--- a/actix-files/CHANGES.md
+++ b/actix-files/CHANGES.md
@@ -2,10 +2,11 @@
 
 ## Unreleased
 
+- Fix handling of special characters in filenames.
+
 ## 0.6.4
 
-- Fix handling of linebreaks in filenames. [#3237]
-- Fix handling of newlines in filenames. [#3235]
+- Fix handling of newlines in filenames.
 - Minimum supported Rust version (MSRV) is now 1.68 due to transitive `time` dependency.
 
 ## 0.6.3

--- a/actix-files/src/lib.rs
+++ b/actix-files/src/lib.rs
@@ -569,7 +569,7 @@ mod tests {
     }
 
     #[actix_rt::test]
-    async fn test_static_files_with_newlines() {
+    async fn test_static_files_with_special_characters() {
         // Create the file we want to test against ad-hoc. We can't check it in as otherwise
         // Windows can't even checkout this repository.
         let temp_dir = tempfile::tempdir().unwrap();

--- a/actix-files/src/lib.rs
+++ b/actix-files/src/lib.rs
@@ -580,7 +580,9 @@ mod tests {
             App::new().service(Files::new("/", temp_dir.path()).index_file("Cargo.toml")),
         )
         .await;
-        let request = TestRequest::get().uri("/test%0A%0B%0C%0Dnewline.text").to_request();
+        let request = TestRequest::get()
+            .uri("/test%0A%0B%0C%0Dnewline.text")
+            .to_request();
         let response = test::call_service(&srv, request).await;
         assert_eq!(response.status(), StatusCode::OK);
 

--- a/actix-files/src/lib.rs
+++ b/actix-files/src/lib.rs
@@ -573,14 +573,14 @@ mod tests {
         // Create the file we want to test against ad-hoc. We can't check it in as otherwise
         // Windows can't even checkout this repository.
         let temp_dir = tempfile::tempdir().unwrap();
-        let file_with_newlines = temp_dir.path().join("test\nnewline.text");
+        let file_with_newlines = temp_dir.path().join("test\n\x0B\x0C\rnewline.text");
         fs::write(&file_with_newlines, "Look at my newlines").unwrap();
 
         let srv = test::init_service(
             App::new().service(Files::new("/", temp_dir.path()).index_file("Cargo.toml")),
         )
         .await;
-        let request = TestRequest::get().uri("/test%0Anewline.text").to_request();
+        let request = TestRequest::get().uri("/test%0A%0B%0C%0Dnewline.text").to_request();
         let response = test::call_service(&srv, request).await;
         assert_eq!(response.status(), StatusCode::OK);
 

--- a/actix-files/src/named.rs
+++ b/actix-files/src/named.rs
@@ -139,12 +139,12 @@ impl NamedFile {
                 _ => DispositionType::Attachment,
             };
 
-            // Replace newlines and other line breaks in filenames which could occur on some filesystems.
+            // replace special characters in filenames which could occur on some filesystems
             let filename_s = filename
-                .replace('\n', "%0A")
+                .replace('\n', "%0A") // \n line break
                 .replace('\x0B', "%0B") // \v vertical tab
                 .replace('\x0C', "%0C") // \f form feed
-                .replace('\r', "%0D");
+                .replace('\r', "%0D"); // \r carriage return
             let mut parameters = vec![DispositionParam::Filename(filename_s)];
 
             if !filename.is_ascii() {

--- a/actix-files/src/named.rs
+++ b/actix-files/src/named.rs
@@ -139,8 +139,12 @@ impl NamedFile {
                 _ => DispositionType::Attachment,
             };
 
-            // Replace newlines in filenames which could occur on some filesystems.
-            let filename_s = filename.replace('\n', "%0A");
+            // Replace newlines and other line breaks in filenames which could occur on some filesystems.
+            let filename_s = filename
+                .replace('\n', "%0A")
+                .replace('\x0B', "%0B") // \v vertical tab
+                .replace('\x0C', "%0C") // \f form feed
+                .replace('\r', "%0D");
             let mut parameters = vec![DispositionParam::Filename(filename_s)];
 
             if !filename.is_ascii() {


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type

Fix handling line breaks in filenames.

## PR Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.

## Overview

Extension of PR #3235.
Fix handling \r, \f and \v in file names.