### PR TITLE
perf: remove unnecessary allocation when writing http dates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           - { name: macOS, os: macos-latest, triple: x86_64-apple-darwin }
           - { name: Windows, os: windows-latest, triple: x86_64-pc-windows-msvc }
         version:
-          - { name: msrv, version: 1.68.0 }
+          - { name: msrv, version: 1.70.0 }
           - { name: stable, version: stable }
 
     name: ${{ matrix.target.name }} / ${{ matrix.version.name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,8 @@ jobs:
       - name: workaround MSRV issues
         if: matrix.version.name == 'msrv'
         run: |
+          cargo update -p=ciborium --precise=0.2.1
+          cargo update -p=ciborium-ll --precise=0.2.1
           cargo update -p=clap --precise=4.3.24
           cargo update -p=clap_lex --precise=0.5.0
           cargo update -p=anstyle --precise=1.0.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,14 +54,10 @@ jobs:
         with:
           tool: cargo-hack,cargo-ci-cache-clean
 
-      - name: workaround MSRV issues
-        if: matrix.version.name == 'msrv'
-        run: |
-          cargo update -p=ciborium --precise=0.2.1
-          cargo update -p=ciborium-ll --precise=0.2.1
-          cargo update -p=clap --precise=4.3.24
-          cargo update -p=clap_lex --precise=0.5.0
-          cargo update -p=anstyle --precise=1.0.2
+      # - name: workaround MSRV issues
+      #   if: matrix.version.name == 'msrv'
+      #   run: |
+      #     cargo update -p=anstyle --precise=1.0.2
 
       - name: check minimal
         run: cargo ci-check-min

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 [workspace.package]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.68"
+rust-version = "1.70"
 
 [profile.dev]
 # Disabling debug info speeds up builds a bunch and we don't rely on it for debugging that much.

--- a/actix-files/CHANGES.md
+++ b/actix-files/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Minimum supported Rust version (MSRV) is now 1.70.
+
 ## 0.6.5
 
 - Fix handling of special characters in filenames.

--- a/actix-files/README.md
+++ b/actix-files/README.md
@@ -4,7 +4,7 @@
 
 [![crates.io](https://img.shields.io/crates/v/actix-files?label=latest)](https://crates.io/crates/actix-files)
 [![Documentation](https://docs.rs/actix-files/badge.svg?version=0.6.5)](https://docs.rs/actix-files/0.6.5)
-![Version](https://img.shields.io/badge/rustc-1.68+-ab6000.svg)
+![Version](https://img.shields.io/badge/rustc-1.70+-ab6000.svg)
 ![License](https://img.shields.io/crates/l/actix-files.svg)
 <br />
 [![dependency status](https://deps.rs/crate/actix-files/0.6.5/status.svg)](https://deps.rs/crate/actix-files/0.6.5)

--- a/actix-http-test/CHANGES.md
+++ b/actix-http-test/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Minimum supported Rust version (MSRV) is now 1.70.
+
 ## 3.2.0
 
 - Minimum supported Rust version (MSRV) is now 1.68 due to transitive `time` dependency.

--- a/actix-http-test/README.md
+++ b/actix-http-test/README.md
@@ -6,7 +6,7 @@
 
 [![crates.io](https://img.shields.io/crates/v/actix-http-test?label=latest)](https://crates.io/crates/actix-http-test)
 [![Documentation](https://docs.rs/actix-http-test/badge.svg?version=3.2.0)](https://docs.rs/actix-http-test/3.2.0)
-![Version](https://img.shields.io/badge/rustc-1.68+-ab6000.svg)
+![Version](https://img.shields.io/badge/rustc-1.70+-ab6000.svg)
 ![MIT or Apache 2.0 licensed](https://img.shields.io/crates/l/actix-http-test)
 <br>
 [![Dependency Status](https://deps.rs/crate/actix-http-test/3.2.0/status.svg)](https://deps.rs/crate/actix-http-test/3.2.0)
@@ -14,8 +14,3 @@
 [![Chat on Discord](https://img.shields.io/discord/771444961383153695?label=chat&logo=discord)](https://discord.gg/NWpN5mmg3x)
 
 <!-- prettier-ignore-end -->
-
-## Documentation & Resources
-
-- [API Documentation](https://docs.rs/actix-http-test)
-- Minimum Supported Rust Version (MSRV): 1.68

--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- Minimum supported Rust version (MSRV) is now 1.70.
+
 ## 3.6.0
 
 ### Added

--- a/actix-http/Cargo.toml
+++ b/actix-http/Cargo.toml
@@ -113,6 +113,7 @@ actix-web = "4"
 
 async-stream = "0.3"
 criterion = { version = "0.5", features = ["html_reports"] }
+divan = "0.1.8"
 env_logger = "0.10"
 futures-util = { version = "0.3.17", default-features = false, features = ["alloc"] }
 memchr = "2.4"
@@ -140,3 +141,7 @@ required-features = ["http2", "rustls-0_21"]
 name = "response-body-compression"
 harness = false
 required-features = ["compress-brotli", "compress-gzip", "compress-zstd"]
+
+[[bench]]
+name = "date-formatting"
+harness = false

--- a/actix-http/README.md
+++ b/actix-http/README.md
@@ -6,7 +6,7 @@
 
 [![crates.io](https://img.shields.io/crates/v/actix-http?label=latest)](https://crates.io/crates/actix-http)
 [![Documentation](https://docs.rs/actix-http/badge.svg?version=3.6.0)](https://docs.rs/actix-http/3.6.0)
-![Version](https://img.shields.io/badge/rustc-1.68+-ab6000.svg)
+![Version](https://img.shields.io/badge/rustc-1.70+-ab6000.svg)
 ![MIT or Apache 2.0 licensed](https://img.shields.io/crates/l/actix-http.svg)
 <br />
 [![dependency status](https://deps.rs/crate/actix-http/3.6.0/status.svg)](https://deps.rs/crate/actix-http/3.6.0)
@@ -14,11 +14,6 @@
 [![Chat on Discord](https://img.shields.io/discord/771444961383153695?label=chat&logo=discord)](https://discord.gg/NWpN5mmg3x)
 
 <!-- prettier-ignore-end -->
-
-## Documentation & Resources
-
-- [API Documentation](https://docs.rs/actix-http)
-- Minimum Supported Rust Version (MSRV): 1.68
 
 ## Examples
 

--- a/actix-http/benches/date-formatting.rs
+++ b/actix-http/benches/date-formatting.rs
@@ -1,0 +1,20 @@
+use std::time::SystemTime;
+
+use actix_http::header::HttpDate;
+use divan::{black_box, AllocProfiler, Bencher};
+
+#[global_allocator]
+static ALLOC: AllocProfiler = AllocProfiler::system();
+
+#[divan::bench]
+fn date_formatting(b: Bencher<'_, '_>) {
+    let now = SystemTime::now();
+
+    b.bench(|| {
+        black_box(HttpDate::from(black_box(now)).to_string());
+    })
+}
+
+fn main() {
+    divan::main();
+}

--- a/actix-http/src/date.rs
+++ b/actix-http/src/date.rs
@@ -28,7 +28,7 @@ impl Date {
 
     fn update(&mut self) {
         self.pos = 0;
-        write!(self, "{}", httpdate::fmt_http_date(SystemTime::now())).unwrap();
+        write!(self, "{}", httpdate::HttpDate::from(SystemTime::now())).unwrap();
     }
 }
 

--- a/actix-http/src/header/shared/http_date.rs
+++ b/actix-http/src/header/shared/http_date.rs
@@ -24,8 +24,7 @@ impl FromStr for HttpDate {
 
 impl fmt::Display for HttpDate {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let date_str = httpdate::fmt_http_date(self.0);
-        f.write_str(&date_str)
+        httpdate::HttpDate::from(self.0).fmt(f)
     }
 }
 
@@ -37,7 +36,7 @@ impl TryIntoHeaderValue for HttpDate {
         let mut wrt = MutWriter(&mut buf);
 
         // unwrap: date output is known to be well formed and of known length
-        write!(wrt, "{}", httpdate::fmt_http_date(self.0)).unwrap();
+        write!(wrt, "{}", self).unwrap();
 
         HeaderValue::from_maybe_shared(buf.split().freeze())
     }

--- a/actix-multipart-derive/CHANGES.md
+++ b/actix-multipart-derive/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Minimum supported Rust version (MSRV) is now 1.70.
+
 ## 0.6.1
 
 - Update `syn` dependency to `2`.

--- a/actix-multipart-derive/README.md
+++ b/actix-multipart-derive/README.md
@@ -6,7 +6,7 @@
 
 [![crates.io](https://img.shields.io/crates/v/actix-multipart-derive?label=latest)](https://crates.io/crates/actix-multipart-derive)
 [![Documentation](https://docs.rs/actix-multipart-derive/badge.svg?version=0.6.1)](https://docs.rs/actix-multipart-derive/0.6.1)
-![Version](https://img.shields.io/badge/rustc-1.68+-ab6000.svg)
+![Version](https://img.shields.io/badge/rustc-1.70+-ab6000.svg)
 ![MIT or Apache 2.0 licensed](https://img.shields.io/crates/l/actix-multipart-derive.svg)
 <br />
 [![dependency status](https://deps.rs/crate/actix-multipart-derive/0.6.1/status.svg)](https://deps.rs/crate/actix-multipart-derive/0.6.1)
@@ -14,8 +14,3 @@
 [![Chat on Discord](https://img.shields.io/discord/771444961383153695?label=chat&logo=discord)](https://discord.gg/NWpN5mmg3x)
 
 <!-- prettier-ignore-end -->
-
-## Documentation & Resources
-
-- [API Documentation](https://docs.rs/actix-multipart-derive)
-- Minimum Supported Rust Version (MSRV): 1.68

--- a/actix-multipart-derive/tests/trybuild.rs
+++ b/actix-multipart-derive/tests/trybuild.rs
@@ -1,4 +1,4 @@
-#[rustversion::stable(1.68)] // MSRV
+#[rustversion::stable(1.70)] // MSRV
 #[test]
 fn compile_macros() {
     let t = trybuild::TestCases::new();

--- a/actix-multipart/CHANGES.md
+++ b/actix-multipart/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Minimum supported Rust version (MSRV) is now 1.70.
+
 ## 0.6.1
 
 - Minimum supported Rust version (MSRV) is now 1.68 due to transitive `time` dependency.

--- a/actix-multipart/README.md
+++ b/actix-multipart/README.md
@@ -6,7 +6,7 @@
 
 [![crates.io](https://img.shields.io/crates/v/actix-multipart?label=latest)](https://crates.io/crates/actix-multipart)
 [![Documentation](https://docs.rs/actix-multipart/badge.svg?version=0.6.1)](https://docs.rs/actix-multipart/0.6.1)
-![Version](https://img.shields.io/badge/rustc-1.68+-ab6000.svg)
+![Version](https://img.shields.io/badge/rustc-1.70+-ab6000.svg)
 ![MIT or Apache 2.0 licensed](https://img.shields.io/crates/l/actix-multipart.svg)
 <br />
 [![dependency status](https://deps.rs/crate/actix-multipart/0.6.1/status.svg)](https://deps.rs/crate/actix-multipart/0.6.1)
@@ -14,8 +14,3 @@
 [![Chat on Discord](https://img.shields.io/discord/771444961383153695?label=chat&logo=discord)](https://discord.gg/NWpN5mmg3x)
 
 <!-- prettier-ignore-end -->
-
-## Documentation & Resources
-
-- [API Documentation](https://docs.rs/actix-multipart)
-- Minimum Supported Rust Version (MSRV): 1.68

--- a/actix-router/CHANGES.md
+++ b/actix-router/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Minimum supported Rust version (MSRV) is now 1.70.
+
 ## 0.5.2
 
 - Minimum supported Rust version (MSRV) is now 1.68 due to transitive `time` dependency.

--- a/actix-router/README.md
+++ b/actix-router/README.md
@@ -4,7 +4,7 @@
 
 [![crates.io](https://img.shields.io/crates/v/actix-router?label=latest)](https://crates.io/crates/actix-router)
 [![Documentation](https://docs.rs/actix-router/badge.svg?version=0.5.2)](https://docs.rs/actix-router/0.5.2)
-![Version](https://img.shields.io/badge/rustc-1.68+-ab6000.svg)
+![Version](https://img.shields.io/badge/rustc-1.70+-ab6000.svg)
 ![MIT or Apache 2.0 licensed](https://img.shields.io/crates/l/actix-router.svg)
 <br />
 [![dependency status](https://deps.rs/crate/actix-router/0.5.2/status.svg)](https://deps.rs/crate/actix-router/0.5.2)

--- a/actix-test/CHANGES.md
+++ b/actix-test/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Minimum supported Rust version (MSRV) is now 1.70.
+
 ## 0.1.3
 
 - Add `TestServerConfig::rustls_0_22()` method for Rustls v0.22 support behind new `rustls-0_22` crate feature.

--- a/actix-web-actors/CHANGES.md
+++ b/actix-web-actors/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Minimum supported Rust version (MSRV) is now 1.70.
+
 ## 4.3.0
 
 - Minimum supported Rust version (MSRV) is now 1.68 due to transitive `time` dependency.

--- a/actix-web-actors/README.md
+++ b/actix-web-actors/README.md
@@ -6,7 +6,7 @@
 
 [![crates.io](https://img.shields.io/crates/v/actix-web-actors?label=latest)](https://crates.io/crates/actix-web-actors)
 [![Documentation](https://docs.rs/actix-web-actors/badge.svg?version=4.3.0)](https://docs.rs/actix-web-actors/4.3.0)
-![Version](https://img.shields.io/badge/rustc-1.68+-ab6000.svg)
+![Version](https://img.shields.io/badge/rustc-1.70+-ab6000.svg)
 ![License](https://img.shields.io/crates/l/actix-web-actors.svg)
 <br />
 [![dependency status](https://deps.rs/crate/actix-web-actors/4.3.0/status.svg)](https://deps.rs/crate/actix-web-actors/4.3.0)
@@ -14,8 +14,3 @@
 [![Chat on Discord](https://img.shields.io/discord/771444961383153695?label=chat&logo=discord)](https://discord.gg/NWpN5mmg3x)
 
 <!-- prettier-ignore-end -->
-
-## Documentation & Resources
-
-- [API Documentation](https://docs.rs/actix-web-actors)
-- Minimum Supported Rust Version (MSRV): 1.68

--- a/actix-web-codegen/CHANGES.md
+++ b/actix-web-codegen/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Minimum supported Rust version (MSRV) is now 1.70.
+
 ## 4.2.2
 
 - Fix regression when declaring `wrap` attribute using an expression.

--- a/actix-web-codegen/README.md
+++ b/actix-web-codegen/README.md
@@ -6,7 +6,7 @@
 
 [![crates.io](https://img.shields.io/crates/v/actix-web-codegen?label=latest)](https://crates.io/crates/actix-web-codegen)
 [![Documentation](https://docs.rs/actix-web-codegen/badge.svg?version=4.2.2)](https://docs.rs/actix-web-codegen/4.2.2)
-![Version](https://img.shields.io/badge/rustc-1.68+-ab6000.svg)
+![Version](https://img.shields.io/badge/rustc-1.70+-ab6000.svg)
 ![License](https://img.shields.io/crates/l/actix-web-codegen.svg)
 <br />
 [![dependency status](https://deps.rs/crate/actix-web-codegen/4.2.2/status.svg)](https://deps.rs/crate/actix-web-codegen/4.2.2)
@@ -14,11 +14,6 @@
 [![Chat on Discord](https://img.shields.io/discord/771444961383153695?label=chat&logo=discord)](https://discord.gg/NWpN5mmg3x)
 
 <!-- prettier-ignore-end -->
-
-## Documentation & Resources
-
-- [API Documentation](https://docs.rs/actix-web-codegen)
-- Minimum Supported Rust Version (MSRV): 1.68
 
 ## Compile Testing
 

--- a/actix-web-codegen/tests/trybuild.rs
+++ b/actix-web-codegen/tests/trybuild.rs
@@ -1,4 +1,4 @@
-#[rustversion::stable(1.68)] // MSRV
+#[rustversion::stable(1.70)] // MSRV
 #[test]
 fn compile_macros() {
     let t = trybuild::TestCases::new();

--- a/actix-web/CHANGES.md
+++ b/actix-web/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- Minimum supported Rust version (MSRV) is now 1.70.
+
 ## 4.5.1
 
 ### Fixed

--- a/actix-web/README.md
+++ b/actix-web/README.md
@@ -9,7 +9,7 @@
 
 [![crates.io](https://img.shields.io/crates/v/actix-web?label=latest)](https://crates.io/crates/actix-web)
 [![Documentation](https://docs.rs/actix-web/badge.svg?version=4.5.1)](https://docs.rs/actix-web/4.5.1)
-![MSRV](https://img.shields.io/badge/rustc-1.68+-ab6000.svg)
+![MSRV](https://img.shields.io/badge/rustc-1.70+-ab6000.svg)
 ![MIT or Apache 2.0 licensed](https://img.shields.io/crates/l/actix-web.svg)
 [![Dependency Status](https://deps.rs/crate/actix-web/4.5.1/status.svg)](https://deps.rs/crate/actix-web/4.5.1)
 <br />
@@ -37,7 +37,7 @@
 - SSL support using OpenSSL or Rustls
 - Middlewares ([Logger, Session, CORS, etc](https://actix.rs/docs/middleware/))
 - Integrates with the [`awc` HTTP client](https://docs.rs/awc/)
-- Runs on stable Rust 1.68+
+- Runs on stable Rust 1.70+
 
 ## Documentation
 

--- a/awc/CHANGES.md
+++ b/awc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Minimum supported Rust version (MSRV) is now 1.70.
+
 ## 3.4.0
 
 - Add `rustls-0_22-webpki-roots` and `rustls-0_22-native-roots` crate feature.

--- a/awc/README.md
+++ b/awc/README.md
@@ -12,13 +12,11 @@
 
 <!-- prettier-ignore-end -->
 
-## Documentation & Resources
+## Examples
 
-- [API Documentation](https://docs.rs/awc)
-- [Example Project](https://github.com/actix/examples/tree/master/https-tls/awc-https)
-- Minimum Supported Rust Version (MSRV): 1.68
+[Example project using TLS-enabled client →](https://github.com/actix/examples/tree/master/https-tls/awc-https)
 
-## Example
+Basic usage:
 
 ```rust
 use actix_rt::System;


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type

<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->

Perf

## PR Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] ~Documentation comments have been added / updated.~
- [x] ~A changelog entry has been made for the appropriate packages.~
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.

## Overview

Removes unnecessary allocation when formatting HTTP Dates.

## Results from divan benchmark

Before:

```
Timer precision: 41 ns
date_formatting     fastest       │ slowest       │ median        │ mean          │ samples │ iters
╰─ date_formatting  94.87 ns      │ 107.6 ns      │ 95.29 ns      │ 95.79 ns      │ 100     │ 100000
                    alloc:        │               │               │               │         │
                      2           │ 0             │ 2             │ 1.98          │         │
                      58 B        │ 0 B           │ 58 B          │ 57.42 B       │         │
                    dealloc:      │               │               │               │         │
                      2           │ 0             │ 2             │ 1.98          │         │
                      58 B        │ 0 B           │ 58 B          │ 57.42 B       │         │

```

After:

```
Timer precision: 41 ns
date_formatting     fastest       │ slowest       │ median        │ mean          │ samples │ iters
╰─ date_formatting  77.34 ns      │ 127.9 ns      │ 80.63 ns      │ 83.82 ns      │ 100     │ 100000
                    alloc:        │               │               │               │         │
                      1           │ 1             │ 1             │ 0.99          │         │
                      29 B        │ 29 B          │ 29 B          │ 28.71 B       │         │
                    dealloc:      │               │               │               │         │
                      1           │ 1             │ 1             │ 0.99          │         │
                      29 B        │ 29 B          │ 29 B          │ 28.71 B       │         │
```