### PR TITLE
actix-http: Bump h2 to fix a resource exhaustion vulnerability

### DIFF
--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -2,8 +2,6 @@
 
 ## Unreleased
 
-- Updated `h2` dependency to `0.3.24`.
-
 ## 3.5.1
 
 ### Fixed

--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Updated `h2` dependency to `0.3.24`.
+
 ## 3.5.1
 
 ### Fixed

--- a/actix-http/Cargo.toml
+++ b/actix-http/Cargo.toml
@@ -89,7 +89,7 @@ tokio-util = { version = "0.7", features = ["io", "codec"] }
 tracing = { version = "0.1.30", default-features = false, features = ["log"] }
 
 # http2
-h2 = { version = "0.3.17", optional = true }
+h2 = { version = "0.3.24", optional = true }
 
 # websockets
 local-channel = { version = "0.1", optional = true }


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type

<!-- What kind of change does this PR make? -->
Bump [h2](https://crates.io/crates/h2) to fix a resource exhaustion vulnerability.

## PR Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.

## Overview

<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

This has been reported by Github on one of my projects, so I thought I could just raise this upstream.

You can check the Github Advisory database entry here:
https://github.com/advisories/GHSA-8r5v-vm4m-4g25

![CleanShot 2024-01-24 at 14 49 16@2x](https://github.com/actix/actix-web/assets/2049560/69b805c5-35ab-48b7-8db6-44f238ec96a0)
