### PR TITLE
increase minimum h2 version

### DIFF
--- a/awc/Cargo.toml
+++ b/awc/Cargo.toml
@@ -72,7 +72,7 @@ cfg-if = "1"
 derive_more = "0.99.5"
 futures-core = { version = "0.3.17", default-features = false, features = ["alloc"] }
 futures-util = { version = "0.3.17", default-features = false, features = ["alloc", "sink"] }
-h2 = "0.3.17"
+h2 = "0.3.24"
 http = "0.2.7"
 itoa = "1"
 log =" 0.4"


### PR DESCRIPTION
Updates h2 to 0.3.24 as per [advisory](https://rustsec.org/advisories/RUSTSEC-2024-0003.html). I would also consider upgrading to 0.4 at some point