### PR TITLE
docs(actix-web): add missing 'that' to doc comments for Compress middleware

### DIFF
--- a/actix-web/src/middleware/compress.rs
+++ b/actix-web/src/middleware/compress.rs
@@ -33,7 +33,7 @@ use crate::{
 /// considered in this selection process.
 ///
 /// # Pre-compressed Payload
-/// If you are serving some data is already using a compressed representation (e.g., a gzip
+/// If you are serving some data that is already using a compressed representation (e.g., a gzip
 /// compressed HTML file from disk) you can signal this to `Compress` by setting an appropriate
 /// `Content-Encoding` header. In addition to preventing double compressing the payload, this header
 /// is required by the spec when using compressed representations and will inform the client that


### PR DESCRIPTION
This PR just adds a missing `that` to the doc comments for the Compress middleware struct.

<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type

<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Other

## PR Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.

## Overview

<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
