### PR TITLE
[SUPPORT] Added Current Thread Name Support In Logging as Mentioned i…

### DIFF
--- a/actix-web/src/middleware/logger.rs
+++ b/actix-web/src/middleware/logger.rs
@@ -10,6 +10,7 @@ use std::{
     pin::Pin,
     rc::Rc,
     task::{Context, Poll},
+    thread::current
 };
 
 use actix_service::{Service, Transform};
@@ -512,6 +513,7 @@ impl Format {
                     "U" => FormatText::UrlPath,
                     "T" => FormatText::Time,
                     "D" => FormatText::TimeMillis,
+                    "P" => FormatText::ThreadName,
                     _ => FormatText::Str(m.as_str().to_owned()),
                 });
             }
@@ -531,6 +533,7 @@ impl Format {
 #[derive(Debug, Clone)]
 enum FormatText {
     Str(String),
+    ThreadName,
     Percent,
     RequestLine,
     RequestTime,
@@ -609,6 +612,9 @@ impl FormatText {
                 } else {
                     "-".fmt(fmt)
                 }
+            }
+            FormatText::ThreadName() => {
+                fmt.write_fmt(format_args!("{}", current().name().unwrap()))
             }
             _ => Ok(()),
         }


### PR DESCRIPTION

<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type


**[Support]** : Added Support to view currunt thread name in Logger. This feature should be supported by default as per mentioned in the  official [documnetation](https://actix.rs/docs/middleware/).
## PR Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [ ] (Team) Label with affected crates and semver status.

## Overview

<!-- Describe the current and new behavior. -->
Current Behaviour with default Regex 

```
.wrap(Logger::default())
```

We get Log:

```
[2024-04-10T18:38:40.911730700Z INFO  actix_web::middleware::logger] 127.0.0.1 "GET /spells HTTP/1.1" 200 285229 "-" "PostmanRuntime/7.37.3" 0.020350
```


Now when we call new() with below regex
```
.wrap(Logger::new(r#"[%P] [%a] ["%r"] [Response = %s] [Size = %b] "%{Referer}i" "%{User-Agent}i" Processed in %Tms."#))
```

We should get Processor Thread Name also 

```
[2024-04-10T18:41:31.460759800Z INFO  actix_web::middleware::logger] [actix-rt|system:0|arbiter:0] [127.0.0.1] ["GET /spells HTTP/1.1"] [Response = 200] [Size = 285229] "-" "PostmanRuntime/7.37.3" Processed in 0.019820ms.
```
