### PR TITLE
add replacement for current thread name in Logger

### DIFF
--- a/actix-web/src/middleware/logger.rs
+++ b/actix-web/src/middleware/logger.rs
@@ -10,6 +10,7 @@ use std::{
     pin::Pin,
     rc::Rc,
     task::{Context, Poll},
+    thread::current
 };
 
 use actix_service::{Service, Transform};
@@ -512,6 +513,7 @@ impl Format {
                     "U" => FormatText::UrlPath,
                     "T" => FormatText::Time,
                     "D" => FormatText::TimeMillis,
+                    "P" => FormatText::ThreadName,
                     _ => FormatText::Str(m.as_str().to_owned()),
                 });
             }
@@ -531,6 +533,7 @@ impl Format {
 #[derive(Debug, Clone)]
 enum FormatText {
     Str(String),
+    ThreadName,
     Percent,
     RequestLine,
     RequestTime,
@@ -593,6 +596,9 @@ impl FormatText {
             FormatText::Str(ref string) => fmt.write_str(string),
             FormatText::Percent => "%".fmt(fmt),
             FormatText::ResponseSize => size.fmt(fmt),
+            FormatText::ThreadName => {
+                fmt.write_fmt(format_args!("{}", current().name().unwrap()))
+            }
             FormatText::Time => {
                 let rt = OffsetDateTime::now_utc() - entry_time;
                 let rt = rt.as_seconds_f64();


### PR DESCRIPTION
## PR Type: [Supoort]

<!-- What kind of change does this PR make? -->
This PR provides support to log the name of current thread which is handling the request.




## PR Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.

## Overview

<!-- Describe the current and new behavior. -->
Current behaviour with default Format shown below 
```
r#"%a "%r" %s %b "%{Referer}i" "%{User-Agent}i" %T"#
```

We get Log:
```
[2024-04-11T17:29:13.432712900Z INFO  actix_web::middleware::logger] 127.0.0.1 "GET /spells HTTP/1.1" 200 285229 "-" "PostmanRuntime/7.37.3" 0.020495
```

New Behaviour (With custom Format shown below)
```
wrap(Logger::new(r#"[%P] [%a] ["%r"] [Response = %s] [Size = %b] "%{Referer}i" "%{User-Agent}i" Processed in %Tms."#))
```

We get Log:
```
[2024-04-11T17:31:15.122169300Z INFO  actix_web::middleware::logger] [actix-rt|system:0|arbiter:0] [127.0.0.1] ["GET /spells HTTP/1.1"] [Response = 200] [Size = 285229] "-" "PostmanRuntime/7.37.3" Processed in 0.020377ms.
```
