### PR TITLE
Update cookie dependency to 0.18

### DIFF
--- a/actix-web/CHANGES.md
+++ b/actix-web/CHANGES.md
@@ -9,6 +9,7 @@
 ### Changed
 
 - Minimum supported Rust version (MSRV) is now 1.72.
+- Updated `cookie` dependency to `0.18`.
 
 ## 4.5.1
 

--- a/actix-web/Cargo.toml
+++ b/actix-web/Cargo.toml
@@ -99,7 +99,7 @@ ahash = "0.8"
 bytes = "1"
 bytestring = "1"
 cfg-if = "1"
-cookie = { version = "0.16", features = ["percent-encode"], optional = true }
+cookie = { version = "0.18", features = ["percent-encode"], optional = true }
 derive_more = "0.99.8"
 encoding_rs = "0.8"
 futures-core = { version = "0.3.17", default-features = false }

--- a/actix-web/src/response/builder.rs
+++ b/actix-web/src/response/builder.rs
@@ -228,12 +228,12 @@ impl HttpResponseBuilder {
     ///
     /// let res = HttpResponse::Ok()
     ///     .cookie(
-    ///         Cookie::build("name", "value")
+    ///         Cookie::build(("name", "value"))
     ///             .domain("www.rust-lang.org")
     ///             .path("/")
     ///             .secure(true)
     ///             .http_only(true)
-    ///             .finish(),
+    ///             .build(),
     ///     )
     ///     .finish();
     /// ```
@@ -243,10 +243,10 @@ impl HttpResponseBuilder {
     /// use actix_web::{HttpResponse, cookie::Cookie};
     ///
     /// // the name, domain and path match the cookie created in the previous example
-    /// let mut cookie = Cookie::build("name", "value-does-not-matter")
+    /// let mut cookie = Cookie::build(("name", "value-does-not-matter"))
     ///     .domain("www.rust-lang.org")
     ///     .path("/")
-    ///     .finish();
+    ///     .build();
     /// cookie.make_removal();
     ///
     /// let res = HttpResponse::Ok()

--- a/actix-web/tests/test_server.rs
+++ b/actix-web/tests/test_server.rs
@@ -776,9 +776,9 @@ async fn test_server_cookies() {
         App::new().default_service(web::to(|| async {
             HttpResponse::Ok()
                 .cookie(
-                    Cookie::build("first", "first_value")
+                    Cookie::build(("first", "first_value"))
                         .http_only(true)
-                        .finish(),
+                        .build(),
                 )
                 .cookie(Cookie::new("second", "first_value"))
                 .cookie(Cookie::new("second", "second_value"))
@@ -791,9 +791,9 @@ async fn test_server_cookies() {
     assert!(res.status().is_success());
 
     {
-        let first_cookie = Cookie::build("first", "first_value")
+        let first_cookie = Cookie::build(("first", "first_value"))
             .http_only(true)
-            .finish();
+            .build();
         let second_cookie = Cookie::new("second", "first_value");
 
         let cookies = res.cookies().expect("To have cookies");

--- a/awc/CHANGES.md
+++ b/awc/CHANGES.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Minimum supported Rust version (MSRV) is now 1.72.
+- Update `cookie` dependency to `0.18`.
 
 ## 3.4.0
 

--- a/awc/Cargo.toml
+++ b/awc/Cargo.toml
@@ -98,7 +98,7 @@ serde_json = "1.0"
 serde_urlencoded = "0.7"
 tokio = { version = "1.24.2", features = ["sync"] }
 
-cookie = { version = "0.16", features = ["percent-encode"], optional = true }
+cookie = { version = "0.18", features = ["percent-encode"], optional = true }
 
 tls-openssl = { package = "openssl", version = "0.10.55", optional = true }
 tls-rustls-0_20 = { package = "rustls", version = "0.20", optional = true, features = ["dangerous_configuration"] }

--- a/awc/src/test.rs
+++ b/awc/src/test.rs
@@ -110,7 +110,7 @@ mod tests {
         let res = TestResponse::default()
             .version(Version::HTTP_2)
             .insert_header((header::DATE, HttpDate::from(SystemTime::now())))
-            .cookie(cookie::Cookie::build("name", "value").finish())
+            .cookie(cookie::Cookie::build(("name", "value")).build())
             .finish();
         assert!(res.headers().contains_key(header::SET_COOKIE));
         assert!(res.headers().contains_key(header::DATE));

--- a/awc/src/ws.rs
+++ b/awc/src/ws.rs
@@ -520,7 +520,7 @@ mod tests {
             .protocols(["v1", "v2"])
             .set_header_if_none(header::CONTENT_TYPE, "json")
             .set_header_if_none(header::CONTENT_TYPE, "text")
-            .cookie(Cookie::build("cookie1", "value1").finish());
+            .cookie(Cookie::build(("cookie1", "value1")).build());
         assert_eq!(
             req.origin.as_ref().unwrap().to_str().unwrap(),
             "test-origin"

--- a/awc/tests/test_client.rs
+++ b/awc/tests/test_client.rs
@@ -679,13 +679,13 @@ async fn body_streaming_implicit() {
 async fn client_cookie_handling() {
     use std::io::{Error as IoError, ErrorKind};
 
-    let cookie1 = Cookie::build("cookie1", "value1").finish();
-    let cookie2 = Cookie::build("cookie2", "value2")
+    let cookie1 = Cookie::build(("cookie1", "value1")).build();
+    let cookie2 = Cookie::build(("cookie2", "value2"))
         .domain("www.example.org")
         .path("/")
         .secure(true)
         .http_only(true)
-        .finish();
+        .build();
     // Q: are all these clones really necessary? A: Yes, possibly
     let cookie1b = cookie1.clone();
     let cookie2b = cookie2.clone();


### PR DESCRIPTION
## PR Type

Update dependency

PR_TYPE

## PR Checklist

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.

## Overview

Update the cookie dependency to 0.18 since increasingly more browsers require the "Partitioned" attribute to be able to send cross-site-requests containing cookies. It was added to the cookie crate with version 0.18.1. 

The changes in the cookie crate introduce breaking changes in the creation of cookies.
