### PR TITLE
Fix type confusion in some scenarios

### DIFF
--- a/actix-web/CHANGES.md
+++ b/actix-web/CHANGES.md
@@ -9,6 +9,7 @@
 ### Changed
 
 - Minimum supported Rust version (MSRV) is now 1.72.
+- Avoid type confusion in rare circumstances
 
 ## 4.5.1
 

--- a/actix-web/src/app_service.rs
+++ b/actix-web/src/app_service.rs
@@ -263,8 +263,9 @@ impl ServiceFactory<ServiceRequest> for AppRoutingFactory {
             let guards = guards.borrow_mut().take().unwrap_or_default();
             let factory_fut = factory.new_service(());
             async move {
-                let service = factory_fut.await?;
-                Ok((path, guards, service))
+                factory_fut
+                    .await
+                    .map(move |service| (path, guards, service))
             }
         }));
 

--- a/actix-web/src/scope.rs
+++ b/actix-web/src/scope.rs
@@ -470,8 +470,9 @@ impl ServiceFactory<ServiceRequest> for ScopeFactory {
             let guards = guards.borrow_mut().take().unwrap_or_default();
             let factory_fut = factory.new_service(());
             async move {
-                let service = factory_fut.await?;
-                Ok((path, guards, service))
+                factory_fut
+                    .await
+                    .map(move |service| (path, guards, service))
             }
         }));
 


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type

<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->

Bug Fix

## PR Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.

## Overview

<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->

When the feature for rustls 0.22 is enabled, and rustls 0.23 is also present in a project, there suddently exist multiple paths for errors when building middleware chains due to the use of two consecutive `?` operators without specifying the intermediate error type.

This commit addresses the issue by removing the first `?`, so that the first error type will always be known, and the second `?` always has a well defined implementation.
