### PR TITLE
actix-test: re-export types from awc

### DIFF
--- a/actix-test/CHANGES.md
+++ b/actix-test/CHANGES.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Minimum supported Rust version (MSRV) is now 1.72.
+- Various types from `awc`, such as `ClientRequest` and `ClientResponse`, are now re-exported.
 
 ## 0.1.3
 

--- a/actix-test/src/lib.rs
+++ b/actix-test/src/lib.rs
@@ -52,7 +52,7 @@ use actix_web::{
     rt::{self, System},
     web, Error,
 };
-use awc::{error::PayloadError, Client, ClientRequest, ClientResponse, Connector};
+pub use awc::{error::PayloadError, Client, ClientRequest, ClientResponse, Connector};
 use futures_core::Stream;
 use tokio::sync::mpsc;
 


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type

<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->

... Other, I guess?

## PR Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.

## Overview

<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
At present, if you want to be able to pass (for example) the response from `srv.get()...` to a function (so you can, say, parse out the response body and parse it as HTML), you've got to add `awc` as a dependency and `use` the types from there.

This change re-exports these `awc` types directly, to avoid the need for the extra dependency, as well as the risk of dependencies getting out of sync and laying waste to the landscape.
<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
