### PR TITLE
awc: gate TlsConnectorService behind any feature that uses it

### DIFF
--- a/awc/CHANGES.md
+++ b/awc/CHANGES.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Minimum supported Rust version (MSRV) is now 1.72.
+- Fix warning on 1.78 due to unused TlsConnectorService struct
 
 ## 3.4.0
 

--- a/awc/src/client/connector.rs
+++ b/awc/src/client/connector.rs
@@ -649,6 +649,14 @@ where
 
 /// service for establish tcp connection and do client tls handshake.
 /// operation is canceled when timeout limit reached.
+#[cfg(any(
+    feature = "dangerous-h2c",
+    feature = "openssl",
+    feature = "rustls-0_20",
+    feature = "rustls-0_21",
+    feature = "rustls-0_22-webpki-roots",
+    feature = "rustls-0_22-native-roots",
+))]
 struct TlsConnectorService<Tcp, Tls> {
     /// TCP connection is canceled on `TcpConnectorInnerService`'s timeout setting.
     tcp_service: Tcp,
@@ -659,6 +667,14 @@ struct TlsConnectorService<Tcp, Tls> {
     timeout: Duration,
 }
 
+#[cfg(any(
+    feature = "dangerous-h2c",
+    feature = "openssl",
+    feature = "rustls-0_20",
+    feature = "rustls-0_21",
+    feature = "rustls-0_22-webpki-roots",
+    feature = "rustls-0_22-native-roots",
+))]
 impl<Tcp, Tls, IO> Service<Connect> for TlsConnectorService<Tcp, Tls>
 where
     Tcp:


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type

<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->

Bug Fix

## PR Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [ ] (Team) Label with affected crates and semver status.

## Overview
Gate this struct behind the features that use it, preventing a compiler warning introduced in 1.78 for unused code detection

<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
