### PR TITLE
actix-web-actors: take the internal buffer when yielding

### DIFF
--- a/actix-web-actors/CHANGES.md
+++ b/actix-web-actors/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Take the encoded buffer when yielding bytes in the response stream rather than splitting the buffer, reducing memory use
 - Minimum supported Rust version (MSRV) is now 1.72.
 
 ## 4.3.0

--- a/actix-web-actors/src/ws.rs
+++ b/actix-web-actors/src/ws.rs
@@ -710,7 +710,7 @@ where
         }
 
         if !this.buf.is_empty() {
-            Poll::Ready(Some(Ok(this.buf.split().freeze())))
+            Poll::Ready(Some(Ok(std::mem::take(&mut this.buf).freeze())))
         } else if this.fut.alive() && !this.closed {
             Poll::Pending
         } else {


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type

<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->

Bug Fix i think

## PR Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.

## Overview
This just takes the internal buffer when yielding in the websocket context future rather than splitting it. The result is that the internal buffer is not re-used between yields, but it also no longer grows perpetually

relates to https://github.com/actix/actix-web/issues/3367

<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
