### PR TITLE
Update HTTP dependencies to use most recent version

### DIFF
--- a/actix-http-test/CHANGES.md
+++ b/actix-http-test/CHANGES.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Minimum supported Rust version (MSRV) is now 1.72.
+- Update `http` dependency to `1`
 
 ## 3.2.0
 

--- a/actix-http-test/Cargo.toml
+++ b/actix-http-test/Cargo.toml
@@ -39,8 +39,8 @@ awc = { version = "3", default-features = false }
 
 bytes = "1"
 futures-core = { version = "0.3.17", default-features = false }
-http = "0.2.7"
-log = "0.4"
+http = "1"
+log = "0.4.7"
 socket2 = "0.5"
 serde = "1"
 serde_json = "1"

--- a/actix-http-test/Cargo.toml
+++ b/actix-http-test/Cargo.toml
@@ -40,7 +40,7 @@ awc = { version = "3", default-features = false }
 bytes = "1"
 futures-core = { version = "0.3.17", default-features = false }
 http = "1"
-log = "0.4.7"
+log = "0.4"
 socket2 = "0.5"
 serde = "1"
 serde_json = "1"

--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Update `http` dependency to `1`.
+- Update `h2` dependency to `0.4.5`
+
 ## 3.7.0
 
 ### Added

--- a/actix-http/Cargo.toml
+++ b/actix-http/Cargo.toml
@@ -92,7 +92,7 @@ bytestring = "1"
 derive_more = "0.99.5"
 encoding_rs = "0.8"
 futures-core = { version = "0.3.17", default-features = false, features = ["alloc"] }
-http = "0.2.7"
+http = "1"
 httparse = "1.5.1"
 httpdate = "1.0.1"
 itoa = "1"
@@ -106,7 +106,7 @@ tokio-util = { version = "0.7", features = ["io", "codec"] }
 tracing = { version = "0.1.30", default-features = false, features = ["log"] }
 
 # http2
-h2 = { version = "0.3.24", optional = true }
+h2 = { version = "0.4.5", optional = true }
 
 # websockets
 local-channel = { version = "0.1", optional = true }

--- a/actix-router/CHANGES.md
+++ b/actix-router/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Update `http` dependency to `1`
+
 ## 0.5.3
 
 - Add `unicode` crate feature (on-by-default) to switch between `regex` and `regex-lite` as a trade-off between full unicode support and binary size.

--- a/actix-router/Cargo.toml
+++ b/actix-router/Cargo.toml
@@ -24,7 +24,7 @@ unicode = ["dep:regex"]
 [dependencies]
 bytestring = ">=0.1.5, <2"
 cfg-if = "1"
-http = { version = "0.2.7", optional = true }
+http = { version = "1", optional = true }
 regex = { version = "1.5", optional = true }
 regex-lite = "0.1"
 serde = "1"
@@ -32,7 +32,7 @@ tracing = { version = "0.1.30", default-features = false, features = ["log"] }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
-http = "0.2.7"
+http = "1"
 serde = { version = "1", features = ["derive"] }
 percent-encoding = "2.1"
 

--- a/awc/CHANGES.md
+++ b/awc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Update `http` dependency to `1`
+
 ## 3.5.0
 
 - Add `rustls-0_23`, `rustls-0_23-webpki-roots`, and `rustls-0_23-native-roots` crate features.

--- a/awc/Cargo.toml
+++ b/awc/Cargo.toml
@@ -92,8 +92,8 @@ cfg-if = "1"
 derive_more = "0.99.5"
 futures-core = { version = "0.3.17", default-features = false, features = ["alloc"] }
 futures-util = { version = "0.3.17", default-features = false, features = ["alloc", "sink"] }
-h2 = "0.3.24"
-http = "0.2.7"
+h2 = "0.4.5"
+http = "1"
 itoa = "1"
 log =" 0.4"
 mime = "0.3"


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type

<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->

Chore

## PR Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [ ] (Team) Label with affected crates and semver status.

## Overview
The `http` crate reached version 1 the better part of a year ago. This PR updates the crates that use the old version of the dependency to use the new version.
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
