### PR TITLE
From Boxed ResponseError impl added

### DIFF
--- a/actix-web/CHANGES.md
+++ b/actix-web/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- Implement `From<Box<dyn ResponseError>>` for `Error`.
+
 ## 4.6.0
 
 ### Added

--- a/actix-web/src/error/error.rs
+++ b/actix-web/src/error/error.rs
@@ -60,6 +60,12 @@ impl<T: ResponseError + 'static> From<T> for Error {
     }
 }
 
+impl From<Box<dyn ResponseError>> for Error {
+    fn from(value: Box<dyn ResponseError>) -> Self {
+        Error { cause: value }
+    }
+}
+
 impl From<Error> for Response<BoxBody> {
     fn from(err: Error) -> Response<BoxBody> {
         err.error_response().into()


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type

<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->

Feature (kind of)

## PR Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] ~Tests for the changes have been added / updated.~
- [x] ~Documentation comments have been added / updated.~
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.

## Overview

<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
`Error` struct has a private cause property with type `Box<dyn ResponseError>` so why not implement `From<Box<dyn ResponseError>>` for it? It is basically a `new` method for the `Error` struct 

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
