### PR TITLE
Re-export `http::status::InvalidStatusCode`

### DIFF
--- a/actix-http/src/error.rs
+++ b/actix-http/src/error.rs
@@ -3,7 +3,7 @@
 use std::{error::Error as StdError, fmt, io, str::Utf8Error, string::FromUtf8Error};
 
 use derive_more::{Display, Error, From};
-pub use http::Error as HttpError;
+pub use http::{status::InvalidStatusCode, Error as HttpError};
 use http::{uri::InvalidUri, StatusCode};
 
 use crate::{body::BoxBody, Response};

--- a/actix-http/src/lib.rs
+++ b/actix-http/src/lib.rs
@@ -31,7 +31,7 @@
 #![doc(html_favicon_url = "https://actix.rs/favicon.ico")]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
-pub use http::{uri, uri::Uri, Method, StatusCode, Version, status::InvalidStatusCode};
+pub use http::{uri, uri::Uri, Method, StatusCode, Version};
 
 pub mod body;
 mod builder;

--- a/actix-http/src/lib.rs
+++ b/actix-http/src/lib.rs
@@ -31,7 +31,7 @@
 #![doc(html_favicon_url = "https://actix.rs/favicon.ico")]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
-pub use http::{uri, uri::Uri, Method, StatusCode, Version};
+pub use http::{uri, uri::Uri, Method, StatusCode, Version, status::InvalidStatusCode};
 
 pub mod body;
 mod builder;


### PR DESCRIPTION
## PR Type

Feature

## PR Checklist

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.

## Overview
Adding a custom error type as per your guide and want to percolate up the errors rather than `unwrap` in any child functions:
```rs
fn status_code(&self) -> Result<actix_web::http::StatusCode, actix_web::http::status::InvalidStatusCode> {
```

But I can't do that because you don't export [`InvalidStatusCode`](https://docs.rs/http/latest/http/status/struct.InvalidStatusCode.html). Happy to export the whole `status` module or just this one `struct`.