### PR TITLE
test: demonstrate panic in multipart forms

### DIFF
--- a/actix-multipart/src/form/mod.rs
+++ b/actix-multipart/src/form/mod.rs
@@ -33,6 +33,14 @@ pub trait FieldReader<'t>: Sized + Any {
     type Future: Future<Output = Result<Self, MultipartError>>;
 
     /// The form will call this function to handle the field.
+    ///
+    /// # Panics
+    ///
+    /// When reading the `field` payload using its `Stream` implementation, polling (manually or via
+    /// `next()`/`try_next()`) may panic after the payload is exhausted. If this is a problem for
+    /// your implementation of this method, you should [`fuse()`] the `Field` first.
+    ///
+    /// [`fuse()`]: https://docs.rs/futures-util/0.3/futures_util/stream/trait.StreamExt.html#method.fuse
     fn read_field(req: &'t HttpRequest, field: Field, limits: &'t mut Limits) -> Self::Future;
 }
 
@@ -396,11 +404,20 @@ mod tests {
     use actix_http::encoding::Decoder;
     use actix_multipart_rfc7578::client::multipart;
     use actix_test::TestServer;
-    use actix_web::{dev::Payload, http::StatusCode, web, App, HttpResponse, Responder};
+    use actix_web::{
+        dev::Payload, http::StatusCode, web, App, HttpRequest, HttpResponse, Resource, Responder,
+    };
     use awc::{Client, ClientResponse};
+    use futures_core::future::LocalBoxFuture;
+    use futures_util::TryStreamExt as _;
 
     use super::MultipartForm;
-    use crate::form::{bytes::Bytes, tempfile::TempFile, text::Text, MultipartFormConfig};
+    use crate::{
+        form::{
+            bytes::Bytes, tempfile::TempFile, text::Text, FieldReader, Limits, MultipartFormConfig,
+        },
+        Field, MultipartError,
+    };
 
     pub async fn send_form(
         srv: &TestServer,
@@ -733,5 +750,50 @@ mod tests {
         form.add_text("field", "this string is 28 bytes long");
         let response = send_form(&srv, form, "/").await;
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[should_panic(expected = "called `Result::unwrap()` on an `Err` value: Connect(Disconnected)")]
+    #[actix_web::test]
+    async fn field_try_next_panic() {
+        #[derive(Debug)]
+        struct NullSink;
+
+        impl<'t> FieldReader<'t> for NullSink {
+            type Future = LocalBoxFuture<'t, Result<Self, MultipartError>>;
+
+            fn read_field(
+                _: &'t HttpRequest,
+                mut field: Field,
+                _limits: &'t mut Limits,
+            ) -> Self::Future {
+                Box::pin(async move {
+                    // exhaust field stream
+                    while let Some(_chunk) = field.try_next().await? {}
+
+                    // poll again, crash
+                    let _post = field.try_next().await;
+
+                    Ok(Self)
+                })
+            }
+        }
+
+        #[allow(dead_code)]
+        #[derive(MultipartForm)]
+        struct NullSinkForm {
+            foo: NullSink,
+        }
+
+        async fn null_sink(_form: MultipartForm<NullSinkForm>) -> impl Responder {
+            "unreachable"
+        }
+
+        let srv = actix_test::start(|| App::new().service(Resource::new("/").post(null_sink)));
+
+        let mut form = multipart::Form::default();
+        form.add_text("foo", "data is not important to this test");
+
+        // panics with Err(Connect(Disconnected)) due to form NullSink panic
+        let _res = send_form(&srv, form, "/").await;
     }
 }


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type

<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->

Test (+fix?)

## PR Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.

## Overview

<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

A follow up to #3047.

Adds reproduction of the unwrap panic. Question is whether this is considered an implementation fault, and a panic is the correct / desired behavior or if the change presented in #3047 should be applied.

Panic from test:
```
---- form::tests::field_try_next_panic stdout ----
thread 'actix-rt|system:1|arbiter:0' panicked at actix-multipart/src/server.rs:468:58:
called `Option::unwrap()` on a `None` value
```

Which indeed points to the same line of code with the unwrap asserting we still hold a reference to the payload buffer.

https://github.com/actix/actix-web/blob/9b3de1f1fe59bd6d3ebc645590eb49f77260a20b/actix-multipart/src/server.rs#L468

The condition is:
- an implementation of `FieldReader`
- ...that collects/drains the payload's stream
- ...then calls `Stream::next()` / `TryStream::try_next()`

Other considerations:
- There's precedent in the async world to panic if a future is completed.
- It's possible that we should take more care to "fuse" the `Field` type.
- I haven't thought of a use-case for calling `try_next` after the stream is complete.
- Could change it to `.expect()` and require explicit use of [`.fuse()`](https://docs.rs/futures-util/latest/futures_util/stream/trait.StreamExt.html#method.fuse) if `try_next` after completion is required.

