### PR TITLE
[actix-web/src/helpers.rs] Make `MutWriter` `pub`lic

### DIFF
--- a/actix-web/src/helpers.rs
+++ b/actix-web/src/helpers.rs
@@ -8,7 +8,7 @@ use bytes::BufMut;
 ///
 /// This is slightly faster (~10%) than `bytes::buf::Writer` in such cases because it does not
 /// perform a remaining length check before writing.
-pub(crate) struct MutWriter<'a, B>(pub(crate) &'a mut B);
+pub struct MutWriter<'a, B>(pub(crate) &'a mut B);
 
 impl<'a, B> io::Write for MutWriter<'a, B>
 where


### PR DESCRIPTION
## PR Type

Feature

## PR Checklist

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.

## Overview

Due to insufficient document I usually run through your codebase to find the best way of doing things. For example, to `impl actix_web::ResponseError for` my error type, I see:
https://github.com/actix/actix-web/blob/5e29726/actix-web/src/error/response_error.rs#L43

Which uses your `pub(crate) MutWriter`; which I cannot use. This PR makes it usable. Can you consider either merging this PR or changing the body of `actix-web/src/error/response_error.rs` to only use `pub`lic types / functions / symbols?

🙏 