### PR TITLE
Fix Rustls 0.22 & 0.23 are limited to 256 handshakes per second.

### DIFF
--- a/actix-http/Cargo.toml
+++ b/actix-http/Cargo.toml
@@ -70,22 +70,22 @@ ws = [
 ]
 
 # TLS via OpenSSL
-openssl = ["actix-tls/accept", "actix-tls/openssl"]
+openssl = ["__tls", "actix-tls/accept", "actix-tls/openssl"]
 
 # TLS via Rustls v0.20
-rustls = ["rustls-0_20"]
+rustls = ["__tls", "rustls-0_20"]
 
 # TLS via Rustls v0.20
-rustls-0_20 = ["actix-tls/accept", "actix-tls/rustls-0_20"]
+rustls-0_20 = ["__tls", "actix-tls/accept", "actix-tls/rustls-0_20"]
 
 # TLS via Rustls v0.21
-rustls-0_21 = ["actix-tls/accept", "actix-tls/rustls-0_21"]
+rustls-0_21 = ["__tls", "actix-tls/accept", "actix-tls/rustls-0_21"]
 
 # TLS via Rustls v0.22
-rustls-0_22 = ["actix-tls/accept", "actix-tls/rustls-0_22"]
+rustls-0_22 = ["__tls", "actix-tls/accept", "actix-tls/rustls-0_22"]
 
 # TLS via Rustls v0.23
-rustls-0_23 = ["actix-tls/accept", "actix-tls/rustls-0_23"]
+rustls-0_23 = ["__tls", "actix-tls/accept", "actix-tls/rustls-0_23"]
 
 # Compression codecs
 compress-brotli = ["__compress", "brotli"]
@@ -95,6 +95,10 @@ compress-zstd   = ["__compress", "zstd"]
 # Internal (PRIVATE!) features used to aid testing and checking feature status.
 # Don't rely on these whatsoever. They are semver-exempt and may disappear at anytime.
 __compress = []
+
+# Internal (PRIVATE!) features used to aid checking feature status.
+# Don't rely on these whatsoever. They may disappear at anytime.
+__tls = []
 
 [dependencies]
 actix-service = "2"

--- a/actix-http/src/lib.rs
+++ b/actix-http/src/lib.rs
@@ -61,13 +61,7 @@ pub mod ws;
 
 #[allow(deprecated)]
 pub use self::payload::PayloadStream;
-#[cfg(any(
-    feature = "openssl",
-    feature = "rustls-0_20",
-    feature = "rustls-0_21",
-    feature = "rustls-0_22",
-    feature = "rustls-0_23",
-))]
+#[cfg(feature = "__tls")]
 pub use self::service::TlsAcceptorConfig;
 pub use self::{
     builder::HttpServiceBuilder,

--- a/actix-http/src/service.rs
+++ b/actix-http/src/service.rs
@@ -241,25 +241,13 @@ where
 }
 
 /// Configuration options used when accepting TLS connection.
-#[cfg(any(
-    feature = "openssl",
-    feature = "rustls-0_20",
-    feature = "rustls-0_21",
-    feature = "rustls-0_22",
-    feature = "rustls-0_23",
-))]
+#[cfg(feature = "__tls")]
 #[derive(Debug, Default)]
 pub struct TlsAcceptorConfig {
     pub(crate) handshake_timeout: Option<std::time::Duration>,
 }
 
-#[cfg(any(
-    feature = "openssl",
-    feature = "rustls-0_20",
-    feature = "rustls-0_21",
-    feature = "rustls-0_22",
-    feature = "rustls-0_23",
-))]
+#[cfg(feature = "__tls")]
 impl TlsAcceptorConfig {
     /// Set TLS handshake timeout duration.
     pub fn handshake_timeout(self, dur: std::time::Duration) -> Self {

--- a/actix-web/CHANGES.md
+++ b/actix-web/CHANGES.md
@@ -11,6 +11,7 @@
 
 - `ConnectionInfo::realip_remote_addr()` now handles IPv6 addresses from `Forwarded` header correctly. Previously, it sometimes returned the forwarded port as well.
 - The `UrlencodedError::ContentType` variant (relevant to the `Form` extractor) now uses the 415 (Media Type Unsupported) status code in it's `ResponseError` implementation.
+- `HttpServer::method.max_connection_rate` now takes effect on any TLS implementation. Previously, the configuration was missing for rustls versions 0.22 and 0.23.
 
 ## 4.7.0
 

--- a/actix-web/Cargo.toml
+++ b/actix-web/Cargo.toml
@@ -93,18 +93,18 @@ secure-cookies = ["cookies", "cookie/secure"]
 http2 = ["actix-http/http2"]
 
 # TLS via OpenSSL
-openssl = ["http2", "actix-http/openssl", "actix-tls/accept", "actix-tls/openssl"]
+openssl = ["__tls", "http2", "actix-http/openssl", "actix-tls/accept", "actix-tls/openssl"]
 
 # TLS via Rustls v0.20
 rustls = ["rustls-0_20"]
 # TLS via Rustls v0.20
-rustls-0_20 = ["http2", "actix-http/rustls-0_20", "actix-tls/accept", "actix-tls/rustls-0_20"]
+rustls-0_20 = ["__tls", "http2", "actix-http/rustls-0_20", "actix-tls/accept", "actix-tls/rustls-0_20"]
 # TLS via Rustls v0.21
-rustls-0_21 = ["http2", "actix-http/rustls-0_21", "actix-tls/accept", "actix-tls/rustls-0_21"]
+rustls-0_21 = ["__tls", "http2", "actix-http/rustls-0_21", "actix-tls/accept", "actix-tls/rustls-0_21"]
 # TLS via Rustls v0.22
-rustls-0_22 = ["http2", "actix-http/rustls-0_22", "actix-tls/accept", "actix-tls/rustls-0_22"]
+rustls-0_22 = ["__tls", "http2", "actix-http/rustls-0_22", "actix-tls/accept", "actix-tls/rustls-0_22"]
 # TLS via Rustls v0.23
-rustls-0_23 = ["http2", "actix-http/rustls-0_23", "actix-tls/accept", "actix-tls/rustls-0_23"]
+rustls-0_23 = ["__tls", "http2", "actix-http/rustls-0_23", "actix-tls/accept", "actix-tls/rustls-0_23"]
 
 # Full unicode support
 unicode = ["dep:regex", "actix-router/unicode"]
@@ -112,6 +112,10 @@ unicode = ["dep:regex", "actix-router/unicode"]
 # Internal (PRIVATE!) features used to aid testing and checking feature status.
 # Don't rely on these whatsoever. They may disappear at anytime.
 __compress = []
+
+# Internal (PRIVATE!) features used to aid checking feature status.
+# Don't rely on these whatsoever. They may disappear at anytime.
+__tls = []
 
 # io-uring feature only available for Linux OSes.
 experimental-io-uring = ["actix-server/io-uring"]

--- a/actix-web/src/server.rs
+++ b/actix-web/src/server.rs
@@ -7,13 +7,7 @@ use std::{
     time::Duration,
 };
 
-#[cfg(any(
-    feature = "openssl",
-    feature = "rustls-0_20",
-    feature = "rustls-0_21",
-    feature = "rustls-0_22",
-    feature = "rustls-0_23",
-))]
+#[cfg(feature = "__tls")]
 use actix_http::TlsAcceptorConfig;
 use actix_http::{body::MessageBody, Extensions, HttpService, KeepAlive, Request, Response};
 use actix_server::{Server, ServerBuilder};
@@ -190,7 +184,7 @@ where
     /// By default max connections is set to a 256.
     #[allow(unused_variables)]
     pub fn max_connection_rate(self, num: usize) -> Self {
-        #[cfg(any(feature = "rustls-0_20", feature = "rustls-0_21", feature = "openssl"))]
+        #[cfg(feature = "__tls")]
         actix_tls::accept::max_concurrent_tls_connect(num);
         self
     }
@@ -243,13 +237,7 @@ where
     /// time, the connection is closed.
     ///
     /// By default, the handshake timeout is 3 seconds.
-    #[cfg(any(
-        feature = "openssl",
-        feature = "rustls-0_20",
-        feature = "rustls-0_21",
-        feature = "rustls-0_22",
-        feature = "rustls-0_23",
-    ))]
+    #[cfg(feature = "__tls")]
     pub fn tls_handshake_timeout(self, dur: Duration) -> Self {
         self.config
             .lock()


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type

<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->

Bug Fix

## PR Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] ~Tests for the changes have been added / updated.~
- [x] ~Documentation comments have been added / updated.~
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.

## Overview

<!-- Describe the current and new behavior. -->
Currently due to possibly accidentally missed features with `rustls 0.22` and `0.23` above configuration statement the server does not allow configuration of TLS handshakes limit per seconds.
The proposed approach is to define internal feature `__tls` and rely on it when writing feature conditions where it is expected to work on any tls implementation. Similar approach is already used by `__compress` feature. Such approach will make addition of new version of rustls less error prone.

<!-- Emphasize any breaking changes. -->
The breaking change proposed is to make [HttpServer::method.max_connection_rate](https://docs.rs/actix-web/latest/actix_web/struct.HttpServer.html#method.max_connection_rate) conditionally defined based on `__tls` feature. This will make it obvious that this method take effect only for TLS connections rate.
This breaking change is completely avoidable just by moving feature condition inside method as it was before.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
Closes #3407