### PR TITLE
fix(multipart): optional content-disposition for non-form-data requests

### DIFF
--- a/actix-multipart-derive/src/lib.rs
+++ b/actix-multipart-derive/src/lib.rs
@@ -138,7 +138,7 @@ struct ParsedField<'t> {
 /// `#[multipart(duplicate_field = "<behavior>")]` attribute:
 ///
 /// - "ignore": (default) Extra fields are ignored. I.e., the first one is persisted.
-/// - "deny": A `MultipartError::UnsupportedField` error response is returned.
+/// - "deny": A `MultipartError::UnknownField` error response is returned.
 /// - "replace": Each field is processed, but only the last one is persisted.
 ///
 /// Note that `Vec` fields will ignore this option.
@@ -229,7 +229,7 @@ pub fn impl_multipart_form(input: proc_macro::TokenStream) -> proc_macro::TokenS
     // Return value when a field name is not supported by the form
     let unknown_field_result = if attrs.deny_unknown_fields {
         quote!(::std::result::Result::Err(
-            ::actix_multipart::MultipartError::UnsupportedField(field.name().to_string())
+            ::actix_multipart::MultipartError::UnknownField(field.name().unwrap().to_string())
         ))
     } else {
         quote!(::std::result::Result::Ok(()))
@@ -292,7 +292,7 @@ pub fn impl_multipart_form(input: proc_macro::TokenStream) -> proc_macro::TokenS
                 limits: &'t mut ::actix_multipart::form::Limits,
                 state: &'t mut ::actix_multipart::form::State,
             ) -> ::std::pin::Pin<::std::boxed::Box<dyn ::std::future::Future<Output = ::std::result::Result<(), ::actix_multipart::MultipartError>> + 't>> {
-                match field.name() {
+                match field.name().unwrap() {
                     #handle_field_impl
                     _ => return ::std::boxed::Box::pin(::std::future::ready(#unknown_field_result)),
                 }

--- a/actix-multipart/CHANGES.md
+++ b/actix-multipart/CHANGES.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+- Add `MultipartError::ContentTypeIncompatible` variant.
+- Add `MultipartError::ContentDispositionNameMissing` variant.
+- Rename `MultipartError::{NoContentDisposition => ContentDispositionMissing}` variant.
+- Rename `MultipartError::{NoContentType => ContentTypeMissing}` variant.
+- Rename `MultipartError::{ParseContentType => ContentTypeParse}` variant.
+- Rename `MultipartError::{Boundary => BoundaryMissing}` variant.
+- Rename `MultipartError::{UnsupportedField => UnknownField}` variant.
+- Remove top-level re-exports of `test` utilities.
+
 ## 0.6.2
 
 - Add testing utilities under new module `test`.

--- a/actix-multipart/Cargo.toml
+++ b/actix-multipart/Cargo.toml
@@ -63,7 +63,9 @@ actix-multipart-rfc7578 = "0.10"
 actix-rt = "2.2"
 actix-test = "0.1"
 actix-web = "4"
+assert_matches = "1"
 awc = "3"
+env_logger = "0.11"
 futures-util = { version = "0.3.17", default-features = false, features = ["alloc"] }
 multer = "3"
 tokio = { version = "1.24.2", features = ["sync"] }

--- a/actix-multipart/README.md
+++ b/actix-multipart/README.md
@@ -54,15 +54,15 @@ async fn main() -> std::io::Result<()> {
 }
 ```
 
-<!-- cargo-rdme end -->
+cURL request:
 
-[More available in the examples repo &rarr;](https://github.com/actix/examples/tree/master/forms/multipart)
-
-Curl request :
-
-```bash
+```sh
 curl -v --request POST \
   --url http://localhost:8080/videos \
   -F 'json={"name": "Cargo.lock"};type=application/json' \
   -F file=@./Cargo.lock
 ```
+
+<!-- cargo-rdme end -->
+
+[More available in the examples repo &rarr;](https://github.com/actix/examples/tree/master/forms/multipart)

--- a/actix-multipart/examples/form.rs
+++ b/actix-multipart/examples/form.rs
@@ -1,0 +1,36 @@
+use actix_multipart::form::{json::Json as MpJson, tempfile::TempFile, MultipartForm};
+use actix_web::{middleware::Logger, post, App, HttpServer, Responder};
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct Metadata {
+    name: String,
+}
+
+#[derive(Debug, MultipartForm)]
+struct UploadForm {
+    #[multipart(limit = "100MB")]
+    file: TempFile,
+    json: MpJson<Metadata>,
+}
+
+#[post("/videos")]
+async fn post_video(MultipartForm(form): MultipartForm<UploadForm>) -> impl Responder {
+    format!(
+        "Uploaded file {}, with size: {}\ntemporary file ({}) was deleted\n",
+        form.json.name,
+        form.file.size,
+        form.file.file.path().display(),
+    )
+}
+
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    env_logger::init_from_env(env_logger::Env::new().default_filter_or("info"));
+
+    HttpServer::new(move || App::new().service(post_video).wrap(Logger::default()))
+        .workers(2)
+        .bind(("127.0.0.1", 8080))?
+        .run()
+        .await
+}

--- a/actix-multipart/src/extractor.rs
+++ b/actix-multipart/src/extractor.rs
@@ -10,6 +10,7 @@ use crate::server::Multipart;
 /// Content-type: multipart/form-data;
 ///
 /// # Examples
+///
 /// ```
 /// use actix_web::{web, HttpResponse, Error};
 /// use actix_multipart::Multipart;
@@ -35,9 +36,6 @@ impl FromRequest for Multipart {
 
     #[inline]
     fn from_request(req: &HttpRequest, payload: &mut Payload) -> Self::Future {
-        ready(Ok(match Multipart::boundary(req.headers()) {
-            Ok(boundary) => Multipart::from_boundary(boundary, payload.take()),
-            Err(err) => Multipart::from_error(err),
-        }))
+        ready(Ok(Multipart::from_req(req, payload)))
     }
 }

--- a/actix-multipart/src/form/bytes.rs
+++ b/actix-multipart/src/form/bytes.rs
@@ -41,8 +41,9 @@ impl<'t> FieldReader<'t> for Bytes {
                 content_type: field.content_type().map(ToOwned::to_owned),
                 file_name: field
                     .content_disposition()
+                    .expect("multipart form fields should have a content-disposition header")
                     .get_filename()
-                    .map(str::to_owned),
+                    .map(ToOwned::to_owned),
             })
         })
     }

--- a/actix-multipart/src/form/tempfile.rs
+++ b/actix-multipart/src/form/tempfile.rs
@@ -42,38 +42,36 @@ impl<'t> FieldReader<'t> for TempFile {
     fn read_field(req: &'t HttpRequest, mut field: Field, limits: &'t mut Limits) -> Self::Future {
         Box::pin(async move {
             let config = TempFileConfig::from_req(req);
-            let field_name = field.name().to_owned();
             let mut size = 0;
 
-            let file = config
-                .create_tempfile()
-                .map_err(|err| config.map_error(req, &field_name, TempFileError::FileIo(err)))?;
+            let file = config.create_tempfile().map_err(|err| {
+                config.map_error(req, &field.form_field_name, TempFileError::FileIo(err))
+            })?;
 
-            let mut file_async =
-                tokio::fs::File::from_std(file.reopen().map_err(|err| {
-                    config.map_error(req, &field_name, TempFileError::FileIo(err))
-                })?);
+            let mut file_async = tokio::fs::File::from_std(file.reopen().map_err(|err| {
+                config.map_error(req, &field.form_field_name, TempFileError::FileIo(err))
+            })?);
 
             while let Some(chunk) = field.try_next().await? {
                 limits.try_consume_limits(chunk.len(), false)?;
                 size += chunk.len();
                 file_async.write_all(chunk.as_ref()).await.map_err(|err| {
-                    config.map_error(req, &field_name, TempFileError::FileIo(err))
+                    config.map_error(req, &field.form_field_name, TempFileError::FileIo(err))
                 })?;
             }
 
-            file_async
-                .flush()
-                .await
-                .map_err(|err| config.map_error(req, &field_name, TempFileError::FileIo(err)))?;
+            file_async.flush().await.map_err(|err| {
+                config.map_error(req, &field.form_field_name, TempFileError::FileIo(err))
+            })?;
 
             Ok(TempFile {
                 file,
                 content_type: field.content_type().map(ToOwned::to_owned),
                 file_name: field
                     .content_disposition()
+                    .expect("multipart form fields should have a content-disposition header")
                     .get_filename()
-                    .map(str::to_owned),
+                    .map(ToOwned::to_owned),
                 size,
             })
         })
@@ -137,7 +135,7 @@ impl TempFileConfig {
         };
 
         MultipartError::Field {
-            field_name: field_name.to_owned(),
+            name: field_name.to_owned(),
             source,
         }
     }

--- a/actix-multipart/src/form/text.rs
+++ b/actix-multipart/src/form/text.rs
@@ -36,7 +36,6 @@ where
     fn read_field(req: &'t HttpRequest, field: Field, limits: &'t mut Limits) -> Self::Future {
         Box::pin(async move {
             let config = TextConfig::from_req(req);
-            let field_name = field.name().to_owned();
 
             if config.validate_content_type {
                 let valid = if let Some(mime) = field.content_type() {
@@ -49,22 +48,24 @@ where
 
                 if !valid {
                     return Err(MultipartError::Field {
-                        field_name,
+                        name: field.form_field_name,
                         source: config.map_error(req, TextError::ContentType),
                     });
                 }
             }
 
+            let form_field_name = field.form_field_name.clone();
+
             let bytes = Bytes::read_field(req, field, limits).await?;
 
             let text = str::from_utf8(&bytes.data).map_err(|err| MultipartError::Field {
-                field_name: field_name.clone(),
+                name: form_field_name.clone(),
                 source: config.map_error(req, TextError::Utf8Error(err)),
             })?;
 
             Ok(Text(serde_plain::from_str(text).map_err(|err| {
                 MultipartError::Field {
-                    field_name,
+                    name: form_field_name,
                     source: config.map_error(req, TextError::Deserialize(err)),
                 }
             })?))

--- a/actix-multipart/src/lib.rs
+++ b/actix-multipart/src/lib.rs
@@ -5,7 +5,7 @@
 //! ```no_run
 //! use actix_web::{post, App, HttpServer, Responder};
 //!
-//! use actix_multipart::form::{json::Json as MPJson, tempfile::TempFile, MultipartForm};
+//! use actix_multipart::form::{json::Json as MpJson, tempfile::TempFile, MultipartForm};
 //! use serde::Deserialize;
 //!
 //! #[derive(Debug, Deserialize)]
@@ -17,7 +17,7 @@
 //! struct UploadForm {
 //!     #[multipart(limit = "100MB")]
 //!     file: TempFile,
-//!     json: MPJson<Metadata>,
+//!     json: MpJson<Metadata>,
 //! }
 //!
 //! #[post("/videos")]
@@ -35,6 +35,15 @@
 //!         .run()
 //!         .await
 //! }
+//! ```
+//!
+//! cURL request:
+//!
+//! ```sh
+//! curl -v --request POST \
+//!   --url http://localhost:8080/videos \
+//!   -F 'json={"name": "Cargo.lock"};type=application/json' \
+//!   -F file=@./Cargo.lock
 //! ```
 
 #![deny(rust_2018_idioms, nonstandard_style)]
@@ -57,7 +66,4 @@ pub mod test;
 pub use self::{
     error::MultipartError,
     server::{Field, Multipart},
-    test::{
-        create_form_data_payload_and_headers, create_form_data_payload_and_headers_with_boundary,
-    },
 };

--- a/actix-multipart/src/test.rs
+++ b/actix-multipart/src/test.rs
@@ -1,3 +1,5 @@
+//! Multipart testing utilities.
+
 use actix_web::http::header::{self, HeaderMap};
 use bytes::{BufMut as _, Bytes, BytesMut};
 use mime::Mime;

--- a/actix-web/src/http/header/content_disposition.rs
+++ b/actix-web/src/http/header/content_disposition.rs
@@ -154,7 +154,7 @@ impl DispositionParam {
     #[inline]
     pub fn as_name(&self) -> Option<&str> {
         match self {
-            DispositionParam::Name(ref name) => Some(name.as_str()),
+            DispositionParam::Name(name) => Some(name.as_str()),
             _ => None,
         }
     }
@@ -163,7 +163,7 @@ impl DispositionParam {
     #[inline]
     pub fn as_filename(&self) -> Option<&str> {
         match self {
-            DispositionParam::Filename(ref filename) => Some(filename.as_str()),
+            DispositionParam::Filename(filename) => Some(filename.as_str()),
             _ => None,
         }
     }
@@ -172,7 +172,7 @@ impl DispositionParam {
     #[inline]
     pub fn as_filename_ext(&self) -> Option<&ExtendedValue> {
         match self {
-            DispositionParam::FilenameExt(ref value) => Some(value),
+            DispositionParam::FilenameExt(value) => Some(value),
             _ => None,
         }
     }


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type

<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->

Fix

## PR Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.

## Overview

<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

Content-Disposition + name parameter is only _required_ on multipart/form data requests.

This PR makes the multipart parser more flexible by once again allowing `Field` access to other kinds of multipart requests like `multipart/mixed` and `multipart/related`.

The `MutlipartForm` extractor docs have been updated to state that only `form-data` requests are supported.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->

closes #3193 