### PR TITLE
chore(awc): fix the issue where the code in the awc example cannot run

### DIFF
--- a/awc/examples/client.rs
+++ b/awc/examples/client.rs
@@ -1,6 +1,8 @@
 use std::error::Error as StdError;
 
-#[tokio::main]
+/// If we want to make requests to addresses starting with `https`, we need to enable the rustls feature of awc
+/// `awc = { version = "3.5.0", features = ["rustls"] }`
+#[actix_rt::main]
 async fn main() -> Result<(), Box<dyn StdError>> {
     env_logger::init_from_env(env_logger::Env::new().default_filter_or("info"));
 


### PR DESCRIPTION
## PR Type
Bug Fix

## PR Checklist

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.

## Overview
https://github.com/actix/actix-web/issues/3420
I hope to be able to directly use `cargo run --example` client to run `awc`.

Closes #3420
