### PR TITLE
build(deps): update derive_more to v1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ homepage = "https://actix.rs"
 repository = "https://github.com/actix/actix-web"
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.72"
+rust-version = "1.75"
 
 [profile.dev]
 # Disabling debug info speeds up builds a bunch and we don't rely on it for debugging that much.

--- a/actix-files/CHANGES.md
+++ b/actix-files/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Update `derive_more` dependency to `1.0`.
+- Minimum supported Rust version (MSRV) is now 1.75.
+
 ## 0.6.6
 
 - Update `tokio-uring` dependency to `0.4`.

--- a/actix-files/CHANGES.md
+++ b/actix-files/CHANGES.md
@@ -2,7 +2,6 @@
 
 ## Unreleased
 
-- Update `derive_more` dependency to `1.0`.
 - Minimum supported Rust version (MSRV) is now 1.75.
 
 ## 0.6.6

--- a/actix-files/Cargo.toml
+++ b/actix-files/Cargo.toml
@@ -33,7 +33,7 @@ actix-web = { version = "4", default-features = false }
 
 bitflags = "2"
 bytes = "1"
-derive_more = { version = "1.0", features = ["display", "error", "from"] }
+derive_more = { version = "1", features = ["display", "error", "from"] }
 futures-core = { version = "0.3.17", default-features = false, features = ["alloc"] }
 http-range = "0.1.4"
 log = "0.4"

--- a/actix-files/Cargo.toml
+++ b/actix-files/Cargo.toml
@@ -33,7 +33,7 @@ actix-web = { version = "4", default-features = false }
 
 bitflags = "2"
 bytes = "1"
-derive_more = "0.99.5"
+derive_more = { version = "1.0", features = ["display", "error", "from"] }
 futures-core = { version = "0.3.17", default-features = false, features = ["alloc"] }
 http-range = "0.1.4"
 log = "0.4"

--- a/actix-files/src/error.rs
+++ b/actix-files/src/error.rs
@@ -6,11 +6,11 @@ use derive_more::Display;
 pub enum FilesError {
     /// Path is not a directory.
     #[allow(dead_code)]
-    #[display(fmt = "path is not a directory. Unable to serve static files")]
+    #[display("path is not a directory. Unable to serve static files")]
     IsNotDirectory,
 
     /// Cannot render directory.
-    #[display(fmt = "unable to render directory without index file")]
+    #[display("unable to render directory without index file")]
     IsDirectory,
 }
 
@@ -25,19 +25,19 @@ impl ResponseError for FilesError {
 #[non_exhaustive]
 pub enum UriSegmentError {
     /// Segment started with the wrapped invalid character.
-    #[display(fmt = "segment started with invalid character: ('{_0}')")]
+    #[display("segment started with invalid character: ('{_0}')")]
     BadStart(char),
 
     /// Segment contained the wrapped invalid character.
-    #[display(fmt = "segment contained invalid character ('{_0}')")]
+    #[display("segment contained invalid character ('{_0}')")]
     BadChar(char),
 
     /// Segment ended with the wrapped invalid character.
-    #[display(fmt = "segment ended with invalid character: ('{_0}')")]
+    #[display("segment ended with invalid character: ('{_0}')")]
     BadEnd(char),
 
     /// Path is not a valid UTF-8 string after percent-decoding.
-    #[display(fmt = "path is not a valid UTF-8 string after percent-decoding")]
+    #[display("path is not a valid UTF-8 string after percent-decoding")]
     NotValidUtf8,
 }
 

--- a/actix-files/src/error.rs
+++ b/actix-files/src/error.rs
@@ -1,5 +1,5 @@
 use actix_web::{http::StatusCode, ResponseError};
-use derive_more::Display;
+use derive_more::derive::Display;
 
 /// Errors which can occur when serving static files.
 #[derive(Debug, PartialEq, Eq, Display)]

--- a/actix-files/src/named.rs
+++ b/actix-files/src/named.rs
@@ -21,7 +21,7 @@ use actix_web::{
     Error, HttpMessage, HttpRequest, HttpResponse, Responder,
 };
 use bitflags::bitflags;
-use derive_more::{Deref, DerefMut};
+use derive_more::derive::{Deref, DerefMut};
 use futures_core::future::LocalBoxFuture;
 use mime::Mime;
 

--- a/actix-files/src/range.rs
+++ b/actix-files/src/range.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use derive_more::Error;
+use derive_more::derive::Error;
 
 /// Copy of `http_range::HttpRangeParseError`.
 #[derive(Debug, Clone)]

--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -2,7 +2,6 @@
 
 ## Unreleased
 
-- Update `derive_more` dependency to `1.0`.
 - Minimum supported Rust version (MSRV) is now 1.75.
 
 ## 3.9.0

--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Update `derive_more` dependency to `1.0`.
+- Minimum supported Rust version (MSRV) is now 1.75.
+
 ## 3.9.0
 
 ### Added

--- a/actix-http/Cargo.toml
+++ b/actix-http/Cargo.toml
@@ -110,7 +110,7 @@ ahash = "0.8"
 bitflags = "2"
 bytes = "1"
 bytestring = "1"
-derive_more = { version = "1.0", features = ["deref", "deref_mut", "display", "error", "from", "as_ref"] }
+derive_more = { version = "1", features = ["as_ref", "deref", "deref_mut", "display", "error", "from"] }
 encoding_rs = "0.8"
 futures-core = { version = "0.3.17", default-features = false, features = ["alloc"] }
 http = "0.2.7"
@@ -160,7 +160,7 @@ rcgen = "0.13"
 regex = "1.3"
 rustversion = "1"
 rustls-pemfile = "2"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
 static_assertions = "1"
 tls-openssl = { package = "openssl", version = "0.10.55" }

--- a/actix-http/Cargo.toml
+++ b/actix-http/Cargo.toml
@@ -110,7 +110,7 @@ ahash = "0.8"
 bitflags = "2"
 bytes = "1"
 bytestring = "1"
-derive_more = "0.99.5"
+derive_more = { version = "1.0", features = ["deref", "deref_mut", "display", "error", "from", "as_ref"] }
 encoding_rs = "0.8"
 futures-core = { version = "0.3.17", default-features = false, features = ["alloc"] }
 http = "0.2.7"

--- a/actix-http/src/body/body_stream.rs
+++ b/actix-http/src/body/body_stream.rs
@@ -75,7 +75,7 @@ mod tests {
         time::{sleep, Sleep},
     };
     use actix_utils::future::poll_fn;
-    use derive_more::{Display, Error};
+    use derive_more::derive::{Display, Error};
     use futures_core::ready;
     use futures_util::{stream, FutureExt as _};
     use pin_project_lite::pin_project;

--- a/actix-http/src/body/body_stream.rs
+++ b/actix-http/src/body/body_stream.rs
@@ -131,7 +131,7 @@ mod tests {
         assert_eq!(to_bytes(body).await.ok(), Some(Bytes::from("12")));
     }
     #[derive(Debug, Display, Error)]
-    #[display(fmt = "stream error")]
+    #[display("stream error")]
     struct StreamErr;
 
     #[actix_rt::test]

--- a/actix-http/src/body/utils.rs
+++ b/actix-http/src/body/utils.rs
@@ -3,7 +3,7 @@ use std::task::Poll;
 use actix_rt::pin;
 use actix_utils::future::poll_fn;
 use bytes::{Bytes, BytesMut};
-use derive_more::{Display, Error};
+use derive_more::derive::{Display, Error};
 use futures_core::ready;
 
 use super::{BodySize, MessageBody};

--- a/actix-http/src/body/utils.rs
+++ b/actix-http/src/body/utils.rs
@@ -38,7 +38,7 @@ pub async fn to_bytes<B: MessageBody>(body: B) -> Result<Bytes, B::Error> {
 
 /// Error type returned from [`to_bytes_limited`] when body produced exceeds limit.
 #[derive(Debug, Display, Error)]
-#[display(fmt = "limit exceeded while collecting body bytes")]
+#[display("limit exceeded while collecting body bytes")]
 #[non_exhaustive]
 pub struct BodyLimitExceeded;
 

--- a/actix-http/src/encoding/encoder.rs
+++ b/actix-http/src/encoding/encoder.rs
@@ -10,7 +10,7 @@ use std::{
 
 use actix_rt::task::{spawn_blocking, JoinHandle};
 use bytes::Bytes;
-use derive_more::Display;
+use derive_more::derive::Display;
 #[cfg(feature = "compress-gzip")]
 use flate2::write::{GzEncoder, ZlibEncoder};
 use futures_core::ready;

--- a/actix-http/src/encoding/encoder.rs
+++ b/actix-http/src/encoding/encoder.rs
@@ -415,11 +415,11 @@ fn new_brotli_compressor() -> Box<brotli::CompressorWriter<Writer>> {
 #[non_exhaustive]
 pub enum EncoderError {
     /// Wrapped body stream error.
-    #[display(fmt = "body")]
+    #[display("body")]
     Body(Box<dyn StdError>),
 
     /// Generic I/O error.
-    #[display(fmt = "io")]
+    #[display("io")]
     Io(io::Error),
 }
 

--- a/actix-http/src/error.rs
+++ b/actix-http/src/error.rs
@@ -2,7 +2,7 @@
 
 use std::{error::Error as StdError, fmt, io, str::Utf8Error, string::FromUtf8Error};
 
-use derive_more::{Display, Error, From};
+use derive_more::{Display, Error as DeriveError, From};
 pub use http::{status::InvalidStatusCode, Error as HttpError};
 use http::{uri::InvalidUri, StatusCode};
 
@@ -80,28 +80,28 @@ impl From<Error> for Response<BoxBody> {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Display)]
 pub(crate) enum Kind {
-    #[display(fmt = "error processing HTTP")]
+    #[display("error processing HTTP")]
     Http,
 
-    #[display(fmt = "error parsing HTTP message")]
+    #[display("error parsing HTTP message")]
     Parse,
 
-    #[display(fmt = "request payload read error")]
+    #[display("request payload read error")]
     Payload,
 
-    #[display(fmt = "response body write error")]
+    #[display("response body write error")]
     Body,
 
-    #[display(fmt = "send response error")]
+    #[display("send response error")]
     SendResponse,
 
-    #[display(fmt = "error in WebSocket process")]
+    #[display("error in WebSocket process")]
     Ws,
 
-    #[display(fmt = "connection error")]
+    #[display("connection error")]
     Io,
 
-    #[display(fmt = "encoder error")]
+    #[display("encoder error")]
     Encoder,
 }
 
@@ -156,48 +156,48 @@ impl From<crate::ws::ProtocolError> for Error {
 }
 
 /// A set of errors that can occur during parsing HTTP streams.
-#[derive(Debug, Display, Error)]
+#[derive(Debug, Display, DeriveError)]
 #[non_exhaustive]
 pub enum ParseError {
     /// An invalid `Method`, such as `GE.T`.
-    #[display(fmt = "invalid method specified")]
+    #[display("invalid method specified")]
     Method,
 
     /// An invalid `Uri`, such as `exam ple.domain`.
-    #[display(fmt = "URI error: {}", _0)]
+    #[display("URI error: {}", _0)]
     Uri(InvalidUri),
 
     /// An invalid `HttpVersion`, such as `HTP/1.1`
-    #[display(fmt = "invalid HTTP version specified")]
+    #[display("invalid HTTP version specified")]
     Version,
 
     /// An invalid `Header`.
-    #[display(fmt = "invalid Header provided")]
+    #[display("invalid Header provided")]
     Header,
 
     /// A message head is too large to be reasonable.
-    #[display(fmt = "message head is too large")]
+    #[display("message head is too large")]
     TooLarge,
 
     /// A message reached EOF, but is not complete.
-    #[display(fmt = "message is incomplete")]
+    #[display("message is incomplete")]
     Incomplete,
 
     /// An invalid `Status`, such as `1337 ELITE`.
-    #[display(fmt = "invalid status provided")]
+    #[display("invalid status provided")]
     Status,
 
     /// A timeout occurred waiting for an IO event.
     #[allow(dead_code)]
-    #[display(fmt = "timeout")]
+    #[display("timeout")]
     Timeout,
 
     /// An I/O error that occurred while trying to read or write to a network stream.
-    #[display(fmt = "I/O error: {}", _0)]
+    #[display("I/O error: {}", _0)]
     Io(io::Error),
 
     /// Parsing a field as string failed.
-    #[display(fmt = "UTF-8 error: {}", _0)]
+    #[display("UTF-8 error: {}", _0)]
     Utf8(Utf8Error),
 }
 
@@ -256,28 +256,28 @@ impl From<ParseError> for Response<BoxBody> {
 #[non_exhaustive]
 pub enum PayloadError {
     /// A payload reached EOF, but is not complete.
-    #[display(fmt = "payload reached EOF before completing: {:?}", _0)]
+    #[display("payload reached EOF before completing: {:?}", _0)]
     Incomplete(Option<io::Error>),
 
     /// Content encoding stream corruption.
-    #[display(fmt = "can not decode content-encoding")]
+    #[display("can not decode content-encoding")]
     EncodingCorrupted,
 
     /// Payload reached size limit.
-    #[display(fmt = "payload reached size limit")]
+    #[display("payload reached size limit")]
     Overflow,
 
     /// Payload length is unknown.
-    #[display(fmt = "payload length is unknown")]
+    #[display("payload length is unknown")]
     UnknownLength,
 
     /// HTTP/2 payload error.
     #[cfg(feature = "http2")]
-    #[display(fmt = "{}", _0)]
+    #[display("{}", _0)]
     Http2Payload(::h2::Error),
 
     /// Generic I/O error.
-    #[display(fmt = "{}", _0)]
+    #[display("{}", _0)]
     Io(io::Error),
 }
 
@@ -326,44 +326,44 @@ impl From<PayloadError> for Error {
 #[non_exhaustive]
 pub enum DispatchError {
     /// Service error.
-    #[display(fmt = "service error")]
+    #[display("service error")]
     Service(Response<BoxBody>),
 
     /// Body streaming error.
-    #[display(fmt = "body error: {}", _0)]
+    #[display("body error: {}", _0)]
     Body(Box<dyn StdError>),
 
     /// Upgrade service error.
-    #[display(fmt = "upgrade error")]
+    #[display("upgrade error")]
     Upgrade,
 
     /// An `io::Error` that occurred while trying to read or write to a network stream.
-    #[display(fmt = "I/O error: {}", _0)]
+    #[display("I/O error: {}", _0)]
     Io(io::Error),
 
     /// Request parse error.
-    #[display(fmt = "request parse error: {}", _0)]
+    #[display("request parse error: {}", _0)]
     Parse(ParseError),
 
     /// HTTP/2 error.
-    #[display(fmt = "{}", _0)]
+    #[display("{}", _0)]
     #[cfg(feature = "http2")]
     H2(h2::Error),
 
     /// The first request did not complete within the specified timeout.
-    #[display(fmt = "request did not complete within the specified timeout")]
+    #[display("request did not complete within the specified timeout")]
     SlowRequestTimeout,
 
     /// Disconnect timeout. Makes sense for TLS streams.
-    #[display(fmt = "connection shutdown timeout")]
+    #[display("connection shutdown timeout")]
     DisconnectTimeout,
 
     /// Handler dropped payload before reading EOF.
-    #[display(fmt = "handler dropped payload before reading EOF")]
+    #[display("handler dropped payload before reading EOF")]
     HandlerDroppedPayload,
 
     /// Internal error.
-    #[display(fmt = "internal error")]
+    #[display("internal error")]
     InternalError,
 }
 
@@ -384,16 +384,16 @@ impl StdError for DispatchError {
 }
 
 /// A set of error that can occur during parsing content type.
-#[derive(Debug, Display, Error)]
+#[derive(Debug, Display, DeriveError)]
 #[cfg_attr(test, derive(PartialEq, Eq))]
 #[non_exhaustive]
 pub enum ContentTypeError {
     /// Can not parse content type.
-    #[display(fmt = "could not parse content type")]
+    #[display("could not parse content type")]
     ParseError,
 
     /// Unknown content encoding.
-    #[display(fmt = "unknown content encoding")]
+    #[display("unknown content encoding")]
     UnknownEncoding,
 }
 

--- a/actix-http/src/error.rs
+++ b/actix-http/src/error.rs
@@ -2,7 +2,7 @@
 
 use std::{error::Error as StdError, fmt, io, str::Utf8Error, string::FromUtf8Error};
 
-use derive_more::{Display, Error as DeriveError, From};
+use derive_more::derive::{Display, Error, From};
 pub use http::{status::InvalidStatusCode, Error as HttpError};
 use http::{uri::InvalidUri, StatusCode};
 
@@ -156,7 +156,7 @@ impl From<crate::ws::ProtocolError> for Error {
 }
 
 /// A set of errors that can occur during parsing HTTP streams.
-#[derive(Debug, Display, DeriveError)]
+#[derive(Debug, Display, Error)]
 #[non_exhaustive]
 pub enum ParseError {
     /// An invalid `Method`, such as `GE.T`.
@@ -384,7 +384,7 @@ impl StdError for DispatchError {
 }
 
 /// A set of error that can occur during parsing content type.
-#[derive(Debug, Display, DeriveError)]
+#[derive(Debug, Display, Error)]
 #[cfg_attr(test, derive(PartialEq, Eq))]
 #[non_exhaustive]
 pub enum ContentTypeError {

--- a/actix-http/src/header/shared/content_encoding.rs
+++ b/actix-http/src/header/shared/content_encoding.rs
@@ -11,7 +11,7 @@ use crate::{
 
 /// Error returned when a content encoding is unknown.
 #[derive(Debug, Display, Error)]
-#[display(fmt = "unsupported content encoding")]
+#[display("unsupported content encoding")]
 pub struct ContentEncodingParseError;
 
 /// Represents a supported content encoding.

--- a/actix-http/src/header/shared/content_encoding.rs
+++ b/actix-http/src/header/shared/content_encoding.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 
-use derive_more::{Display, Error};
+use derive_more::derive::{Display, Error};
 use http::header::InvalidHeaderValue;
 
 use crate::{

--- a/actix-http/src/header/shared/quality.rs
+++ b/actix-http/src/header/shared/quality.rs
@@ -125,7 +125,7 @@ pub fn itoa_fmt<W: fmt::Write, V: itoa::Integer>(mut wr: W, value: V) -> fmt::Re
 }
 
 #[derive(Debug, Clone, Display, Error)]
-#[display(fmt = "quality out of bounds")]
+#[display("quality out of bounds")]
 #[non_exhaustive]
 pub struct QualityOutOfBounds;
 

--- a/actix-http/src/header/shared/quality.rs
+++ b/actix-http/src/header/shared/quality.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use derive_more::{Display, Error};
+use derive_more::derive::{Display, Error};
 
 const MAX_QUALITY_INT: u16 = 1000;
 const MAX_QUALITY_FLOAT: f32 = 1.0;

--- a/actix-http/src/ws/mod.rs
+++ b/actix-http/src/ws/mod.rs
@@ -5,7 +5,7 @@
 
 use std::io;
 
-use derive_more::{Display, Error, From};
+use derive_more::derive::{Display, Error, From};
 use http::{header, Method, StatusCode};
 
 use crate::{body::BoxBody, header::HeaderValue, RequestHead, Response, ResponseBuilder};

--- a/actix-http/src/ws/mod.rs
+++ b/actix-http/src/ws/mod.rs
@@ -27,43 +27,43 @@ pub use self::{
 #[derive(Debug, Display, Error, From)]
 pub enum ProtocolError {
     /// Received an unmasked frame from client.
-    #[display(fmt = "received an unmasked frame from client")]
+    #[display("received an unmasked frame from client")]
     UnmaskedFrame,
 
     /// Received a masked frame from server.
-    #[display(fmt = "received a masked frame from server")]
+    #[display("received a masked frame from server")]
     MaskedFrame,
 
     /// Encountered invalid opcode.
-    #[display(fmt = "invalid opcode ({})", _0)]
+    #[display("invalid opcode ({})", _0)]
     InvalidOpcode(#[error(not(source))] u8),
 
     /// Invalid control frame length
-    #[display(fmt = "invalid control frame length ({})", _0)]
+    #[display("invalid control frame length ({})", _0)]
     InvalidLength(#[error(not(source))] usize),
 
     /// Bad opcode.
-    #[display(fmt = "bad opcode")]
+    #[display("bad opcode")]
     BadOpCode,
 
     /// A payload reached size limit.
-    #[display(fmt = "payload reached size limit")]
+    #[display("payload reached size limit")]
     Overflow,
 
     /// Continuation has not started.
-    #[display(fmt = "continuation has not started")]
+    #[display("continuation has not started")]
     ContinuationNotStarted,
 
     /// Received new continuation but it is already started.
-    #[display(fmt = "received new continuation but it has already started")]
+    #[display("received new continuation but it has already started")]
     ContinuationStarted,
 
     /// Unknown continuation fragment.
-    #[display(fmt = "unknown continuation fragment: {}", _0)]
+    #[display("unknown continuation fragment: {}", _0)]
     ContinuationFragment(#[error(not(source))] OpCode),
 
     /// I/O error.
-    #[display(fmt = "I/O error: {}", _0)]
+    #[display("I/O error: {}", _0)]
     Io(io::Error),
 }
 
@@ -71,27 +71,27 @@ pub enum ProtocolError {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Display, Error)]
 pub enum HandshakeError {
     /// Only get method is allowed.
-    #[display(fmt = "method not allowed")]
+    #[display("method not allowed")]
     GetMethodRequired,
 
     /// Upgrade header if not set to WebSocket.
-    #[display(fmt = "WebSocket upgrade is expected")]
+    #[display("WebSocket upgrade is expected")]
     NoWebsocketUpgrade,
 
     /// Connection header is not set to upgrade.
-    #[display(fmt = "connection upgrade is expected")]
+    #[display("connection upgrade is expected")]
     NoConnectionUpgrade,
 
     /// WebSocket version header is not set.
-    #[display(fmt = "WebSocket version header is required")]
+    #[display("WebSocket version header is required")]
     NoVersionHeader,
 
     /// Unsupported WebSocket version.
-    #[display(fmt = "unsupported WebSocket version")]
+    #[display("unsupported WebSocket version")]
     UnsupportedVersion,
 
     /// WebSocket key is not set or wrong.
-    #[display(fmt = "unknown WebSocket key")]
+    #[display("unknown WebSocket key")]
     BadWebsocketKey,
 }
 

--- a/actix-http/tests/test_client.rs
+++ b/actix-http/tests/test_client.rs
@@ -94,7 +94,7 @@ async fn with_query_parameter() {
 }
 
 #[derive(Debug, Display, Error)]
-#[display(fmt = "expect failed")]
+#[display("expect failed")]
 struct ExpectFailed;
 
 impl From<ExpectFailed> for Response<BoxBody> {

--- a/actix-http/tests/test_client.rs
+++ b/actix-http/tests/test_client.rs
@@ -5,7 +5,7 @@ use actix_http_test::test_server;
 use actix_service::ServiceFactoryExt;
 use actix_utils::future;
 use bytes::Bytes;
-use derive_more::{Display, Error};
+use derive_more::derive::{Display, Error};
 use futures_util::StreamExt as _;
 
 const STR: &str = "Hello World Hello World Hello World Hello World Hello World \

--- a/actix-http/tests/test_openssl.rs
+++ b/actix-http/tests/test_openssl.rs
@@ -14,7 +14,7 @@ use actix_http_test::test_server;
 use actix_service::{fn_service, ServiceFactoryExt};
 use actix_utils::future::{err, ok, ready};
 use bytes::{Bytes, BytesMut};
-use derive_more::{Display, Error};
+use derive_more::{Display, Error as DeriveError};
 use futures_core::Stream;
 use futures_util::{stream::once, StreamExt as _};
 use openssl::{
@@ -397,8 +397,8 @@ async fn h2_response_http_error_handling() {
     );
 }
 
-#[derive(Debug, Display, Error)]
-#[display(fmt = "error")]
+#[derive(Debug, Display, DeriveError)]
+#[display("error")]
 struct BadRequest;
 
 impl From<BadRequest> for Response<BoxBody> {

--- a/actix-http/tests/test_openssl.rs
+++ b/actix-http/tests/test_openssl.rs
@@ -14,7 +14,7 @@ use actix_http_test::test_server;
 use actix_service::{fn_service, ServiceFactoryExt};
 use actix_utils::future::{err, ok, ready};
 use bytes::{Bytes, BytesMut};
-use derive_more::{Display, Error as DeriveError};
+use derive_more::derive::{Display, Error};
 use futures_core::Stream;
 use futures_util::{stream::once, StreamExt as _};
 use openssl::{
@@ -397,7 +397,7 @@ async fn h2_response_http_error_handling() {
     );
 }
 
-#[derive(Debug, Display, DeriveError)]
+#[derive(Debug, Display, Error)]
 #[display("error")]
 struct BadRequest;
 

--- a/actix-http/tests/test_rustls.rs
+++ b/actix-http/tests/test_rustls.rs
@@ -23,7 +23,7 @@ use actix_service::{fn_factory_with_config, fn_service};
 use actix_tls::connect::rustls_0_23::webpki_roots_cert_store;
 use actix_utils::future::{err, ok, poll_fn};
 use bytes::{Bytes, BytesMut};
-use derive_more::{Display, Error};
+use derive_more::{Display, Error as DeriveError};
 use futures_core::{ready, Stream};
 use futures_util::stream::once;
 use rustls::{pki_types::ServerName, ServerConfig as RustlsServerConfig};
@@ -479,8 +479,8 @@ async fn h2_response_http_error_handling() {
     );
 }
 
-#[derive(Debug, Display, Error)]
-#[display(fmt = "error")]
+#[derive(Debug, Display, DeriveError)]
+#[display("error")]
 struct BadRequest;
 
 impl From<BadRequest> for Response<BoxBody> {

--- a/actix-http/tests/test_rustls.rs
+++ b/actix-http/tests/test_rustls.rs
@@ -23,7 +23,7 @@ use actix_service::{fn_factory_with_config, fn_service};
 use actix_tls::connect::rustls_0_23::webpki_roots_cert_store;
 use actix_utils::future::{err, ok, poll_fn};
 use bytes::{Bytes, BytesMut};
-use derive_more::{Display, Error as DeriveError};
+use derive_more::derive::{Display, Error};
 use futures_core::{ready, Stream};
 use futures_util::stream::once;
 use rustls::{pki_types::ServerName, ServerConfig as RustlsServerConfig};
@@ -479,7 +479,7 @@ async fn h2_response_http_error_handling() {
     );
 }
 
-#[derive(Debug, Display, DeriveError)]
+#[derive(Debug, Display, Error)]
 #[display("error")]
 struct BadRequest;
 

--- a/actix-http/tests/test_server.rs
+++ b/actix-http/tests/test_server.rs
@@ -14,7 +14,7 @@ use actix_rt::{net::TcpStream, time::sleep};
 use actix_service::fn_service;
 use actix_utils::future::{err, ok, ready};
 use bytes::Bytes;
-use derive_more::{Display, Error as DeriveError};
+use derive_more::derive::{Display, Error};
 use futures_util::{stream::once, FutureExt as _, StreamExt as _};
 use regex::Regex;
 
@@ -61,7 +61,7 @@ async fn h1_2() {
     srv.stop().await;
 }
 
-#[derive(Debug, Display, DeriveError)]
+#[derive(Debug, Display, Error)]
 #[display("expect failed")]
 struct ExpectFailed;
 
@@ -722,7 +722,7 @@ async fn h1_response_http_error_handling() {
     srv.stop().await;
 }
 
-#[derive(Debug, Display, DeriveError)]
+#[derive(Debug, Display, Error)]
 #[display("error")]
 struct BadRequest;
 

--- a/actix-http/tests/test_server.rs
+++ b/actix-http/tests/test_server.rs
@@ -14,7 +14,7 @@ use actix_rt::{net::TcpStream, time::sleep};
 use actix_service::fn_service;
 use actix_utils::future::{err, ok, ready};
 use bytes::Bytes;
-use derive_more::{Display, Error};
+use derive_more::{Display, Error as DeriveError};
 use futures_util::{stream::once, FutureExt as _, StreamExt as _};
 use regex::Regex;
 
@@ -61,8 +61,8 @@ async fn h1_2() {
     srv.stop().await;
 }
 
-#[derive(Debug, Display, Error)]
-#[display(fmt = "expect failed")]
+#[derive(Debug, Display, DeriveError)]
+#[display("expect failed")]
 struct ExpectFailed;
 
 impl From<ExpectFailed> for Response<BoxBody> {
@@ -722,8 +722,8 @@ async fn h1_response_http_error_handling() {
     srv.stop().await;
 }
 
-#[derive(Debug, Display, Error)]
-#[display(fmt = "error")]
+#[derive(Debug, Display, DeriveError)]
+#[display("error")]
 struct BadRequest;
 
 impl From<BadRequest> for Response<BoxBody> {

--- a/actix-http/tests/test_ws.rs
+++ b/actix-http/tests/test_ws.rs
@@ -14,7 +14,7 @@ use actix_http::{
 use actix_http_test::test_server;
 use actix_service::{fn_factory, Service};
 use bytes::Bytes;
-use derive_more::{Display, Error as DeriveError, From};
+use derive_more::derive::{Display, Error, From};
 use futures_core::future::LocalBoxFuture;
 use futures_util::{SinkExt as _, StreamExt as _};
 
@@ -35,7 +35,7 @@ impl WsService {
     }
 }
 
-#[derive(Debug, Display, DeriveError, From)]
+#[derive(Debug, Display, Error, From)]
 enum WsServiceError {
     #[display("HTTP error")]
     Http(actix_http::Error),

--- a/actix-http/tests/test_ws.rs
+++ b/actix-http/tests/test_ws.rs
@@ -14,7 +14,7 @@ use actix_http::{
 use actix_http_test::test_server;
 use actix_service::{fn_factory, Service};
 use bytes::Bytes;
-use derive_more::{Display, Error, From};
+use derive_more::{Display, Error as DeriveError, From};
 use futures_core::future::LocalBoxFuture;
 use futures_util::{SinkExt as _, StreamExt as _};
 
@@ -35,18 +35,18 @@ impl WsService {
     }
 }
 
-#[derive(Debug, Display, Error, From)]
+#[derive(Debug, Display, DeriveError, From)]
 enum WsServiceError {
-    #[display(fmt = "HTTP error")]
+    #[display("HTTP error")]
     Http(actix_http::Error),
 
-    #[display(fmt = "WS handshake error")]
+    #[display("WS handshake error")]
     Ws(actix_http::ws::HandshakeError),
 
-    #[display(fmt = "I/O error")]
+    #[display("I/O error")]
     Io(std::io::Error),
 
-    #[display(fmt = "dispatcher error")]
+    #[display("dispatcher error")]
     Dispatcher,
 }
 

--- a/actix-multipart/CHANGES.md
+++ b/actix-multipart/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Update `derive_more` dependency to `1.0`.
+- Minimum supported Rust version (MSRV) is now 1.75.
+
 ## 0.7.2
 
 - Fix re-exported version of `actix-multipart-derive`.

--- a/actix-multipart/CHANGES.md
+++ b/actix-multipart/CHANGES.md
@@ -2,7 +2,6 @@
 
 ## Unreleased
 
-- Update `derive_more` dependency to `1.0`.
 - Minimum supported Rust version (MSRV) is now 1.75.
 
 ## 0.7.2

--- a/actix-multipart/Cargo.toml
+++ b/actix-multipart/Cargo.toml
@@ -42,7 +42,7 @@ actix-multipart-derive = { version = "=0.7.0", optional = true }
 actix-utils = "3"
 actix-web = { version = "4", default-features = false }
 
-derive_more = "0.99.5"
+derive_more = { version = "1.0", features = ["display", "error", "from"] }
 futures-core = { version = "0.3.17", default-features = false, features = ["alloc"] }
 futures-util = { version = "0.3.17", default-features = false, features = ["alloc"] }
 httparse = "1.3"

--- a/actix-multipart/Cargo.toml
+++ b/actix-multipart/Cargo.toml
@@ -42,7 +42,7 @@ actix-multipart-derive = { version = "=0.7.0", optional = true }
 actix-utils = "3"
 actix-web = { version = "4", default-features = false }
 
-derive_more = { version = "1.0", features = ["display", "error", "from"] }
+derive_more = { version = "1", features = ["display", "error", "from"] }
 futures-core = { version = "0.3.17", default-features = false, features = ["alloc"] }
 futures-util = { version = "0.3.17", default-features = false, features = ["alloc"] }
 httparse = "1.3"

--- a/actix-multipart/src/error.rs
+++ b/actix-multipart/src/error.rs
@@ -5,18 +5,18 @@ use actix_web::{
     http::StatusCode,
     ResponseError,
 };
-use derive_more::{Display, Error, From};
+use derive_more::{Display, Error as DeriveError, From};
 
 /// A set of errors that can occur during parsing multipart streams.
-#[derive(Debug, Display, From, Error)]
+#[derive(Debug, Display, From, DeriveError)]
 #[non_exhaustive]
 pub enum Error {
     /// Could not find Content-Type header.
-    #[display(fmt = "Could not find Content-Type header")]
+    #[display("Could not find Content-Type header")]
     ContentTypeMissing,
 
     /// Could not parse Content-Type header.
-    #[display(fmt = "Could not parse Content-Type header")]
+    #[display("Could not parse Content-Type header")]
     ContentTypeParse,
 
     /// Parsed Content-Type did not have "multipart" top-level media type.
@@ -25,11 +25,11 @@ pub enum Error {
     /// "multipart/form-data" media type.
     ///
     /// [`MultipartForm`]: struct@crate::form::MultipartForm
-    #[display(fmt = "Parsed Content-Type did not have "multipart" top-level media type")]
+    #[display("Parsed Content-Type did not have 'multipart' top-level media type")]
     ContentTypeIncompatible,
 
     /// Multipart boundary is not found.
-    #[display(fmt = "Multipart boundary is not found")]
+    #[display("Multipart boundary is not found")]
     BoundaryMissing,
 
     /// Content-Disposition header was not found or not of disposition type "form-data" when parsing
@@ -39,7 +39,7 @@ pub enum Error {
     /// always be present and have a disposition type of "form-data".
     ///
     /// [RFC 7578 §4.2]: https://datatracker.ietf.org/doc/html/rfc7578#section-4.2
-    #[display(fmt = "Content-Disposition header was not found when parsing a \"form-data\" field")]
+    #[display("Content-Disposition header was not found when parsing a \"form-data\" field")]
     ContentDispositionMissing,
 
     /// Content-Disposition name parameter was not found when parsing a "form-data" field.
@@ -48,48 +48,48 @@ pub enum Error {
     /// always include a "name" parameter.
     ///
     /// [RFC 7578 §4.2]: https://datatracker.ietf.org/doc/html/rfc7578#section-4.2
-    #[display(fmt = "Content-Disposition header was not found when parsing a \"form-data\" field")]
+    #[display("Content-Disposition header was not found when parsing a \"form-data\" field")]
     ContentDispositionNameMissing,
 
     /// Nested multipart is not supported.
-    #[display(fmt = "Nested multipart is not supported")]
+    #[display("Nested multipart is not supported")]
     Nested,
 
     /// Multipart stream is incomplete.
-    #[display(fmt = "Multipart stream is incomplete")]
+    #[display("Multipart stream is incomplete")]
     Incomplete,
 
     /// Field parsing failed.
-    #[display(fmt = "Error during field parsing")]
+    #[display("Error during field parsing")]
     Parse(ParseError),
 
     /// HTTP payload error.
-    #[display(fmt = "Payload error")]
+    #[display("Payload error")]
     Payload(PayloadError),
 
     /// Stream is not consumed.
-    #[display(fmt = "Stream is not consumed")]
+    #[display("Stream is not consumed")]
     NotConsumed,
 
     /// Form field handler raised error.
-    #[display(fmt = "An error occurred processing field: {name}")]
+    #[display("An error occurred processing field: {name}")]
     Field {
         name: String,
         source: actix_web::Error,
     },
 
     /// Duplicate field found (for structure that opted-in to denying duplicate fields).
-    #[display(fmt = "Duplicate field found: {_0}")]
+    #[display("Duplicate field found: {_0}")]
     #[from(ignore)]
     DuplicateField(#[error(not(source))] String),
 
     /// Required field is missing.
-    #[display(fmt = "Required field is missing: {_0}")]
+    #[display("Required field is missing: {_0}")]
     #[from(ignore)]
     MissingField(#[error(not(source))] String),
 
     /// Unknown field (for structure that opted-in to denying unknown fields).
-    #[display(fmt = "Unknown field: {_0}")]
+    #[display("Unknown field: {_0}")]
     #[from(ignore)]
     UnknownField(#[error(not(source))] String),
 }

--- a/actix-multipart/src/error.rs
+++ b/actix-multipart/src/error.rs
@@ -5,10 +5,10 @@ use actix_web::{
     http::StatusCode,
     ResponseError,
 };
-use derive_more::{Display, Error as DeriveError, From};
+use derive_more::derive::{Display, Error, From};
 
 /// A set of errors that can occur during parsing multipart streams.
-#[derive(Debug, Display, From, DeriveError)]
+#[derive(Debug, Display, From, Error)]
 #[non_exhaustive]
 pub enum Error {
     /// Could not find Content-Type header.

--- a/actix-multipart/src/field.rs
+++ b/actix-multipart/src/field.rs
@@ -13,7 +13,7 @@ use actix_web::{
     http::header::{self, ContentDisposition, HeaderMap},
     web::{Bytes, BytesMut},
 };
-use derive_more::{Display, Error as DeriveError};
+use derive_more::derive::{Display, Error};
 use futures_core::Stream;
 use mime::Mime;
 
@@ -24,7 +24,7 @@ use crate::{
 };
 
 /// Error type returned from [`Field::bytes()`] when field data is larger than limit.
-#[derive(Debug, Display, DeriveError)]
+#[derive(Debug, Display, Error)]
 #[display("size limit exceeded while collecting field data")]
 #[non_exhaustive]
 pub struct LimitExceeded;

--- a/actix-multipart/src/field.rs
+++ b/actix-multipart/src/field.rs
@@ -13,7 +13,7 @@ use actix_web::{
     http::header::{self, ContentDisposition, HeaderMap},
     web::{Bytes, BytesMut},
 };
-use derive_more::{Display, Error};
+use derive_more::{Display, Error as DeriveError};
 use futures_core::Stream;
 use mime::Mime;
 
@@ -24,8 +24,8 @@ use crate::{
 };
 
 /// Error type returned from [`Field::bytes()`] when field data is larger than limit.
-#[derive(Debug, Display, Error)]
-#[display(fmt = "size limit exceeded while collecting field data")]
+#[derive(Debug, Display, DeriveError)]
+#[display("size limit exceeded while collecting field data")]
 #[non_exhaustive]
 pub struct LimitExceeded;
 

--- a/actix-multipart/src/form/json.rs
+++ b/actix-multipart/src/form/json.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use actix_web::{http::StatusCode, web, Error, HttpRequest, ResponseError};
-use derive_more::{Deref, DerefMut, Display, Error};
+use derive_more::{Deref, DerefMut, Display, Error as DeriveError};
 use futures_core::future::LocalBoxFuture;
 use serde::de::DeserializeOwned;
 
@@ -62,15 +62,15 @@ where
     }
 }
 
-#[derive(Debug, Display, Error)]
+#[derive(Debug, Display, DeriveError)]
 #[non_exhaustive]
 pub enum JsonFieldError {
     /// Deserialize error.
-    #[display(fmt = "Json deserialize error: {}", _0)]
+    #[display("Json deserialize error: {}", _0)]
     Deserialize(serde_json::Error),
 
     /// Content type error.
-    #[display(fmt = "Content type error")]
+    #[display("Content type error")]
     ContentType,
 }
 

--- a/actix-multipart/src/form/json.rs
+++ b/actix-multipart/src/form/json.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use actix_web::{http::StatusCode, web, Error, HttpRequest, ResponseError};
-use derive_more::{Deref, DerefMut, Display, Error as DeriveError};
+use derive_more::derive::{Deref, DerefMut, Display, Error};
 use futures_core::future::LocalBoxFuture;
 use serde::de::DeserializeOwned;
 
@@ -62,7 +62,7 @@ where
     }
 }
 
-#[derive(Debug, Display, DeriveError)]
+#[derive(Debug, Display, Error)]
 #[non_exhaustive]
 pub enum JsonFieldError {
     /// Deserialize error.

--- a/actix-multipart/src/form/mod.rs
+++ b/actix-multipart/src/form/mod.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use actix_web::{dev, error::PayloadError, web, Error, FromRequest, HttpRequest};
-use derive_more::{Deref, DerefMut};
+use derive_more::derive::{Deref, DerefMut};
 use futures_core::future::LocalBoxFuture;
 use futures_util::{TryFutureExt as _, TryStreamExt as _};
 

--- a/actix-multipart/src/form/tempfile.rs
+++ b/actix-multipart/src/form/tempfile.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use actix_web::{http::StatusCode, web, Error, HttpRequest, ResponseError};
-use derive_more::{Display, Error as DeriveError};
+use derive_more::derive::{Display, Error};
 use futures_core::future::LocalBoxFuture;
 use futures_util::TryStreamExt as _;
 use mime::Mime;
@@ -78,7 +78,7 @@ impl<'t> FieldReader<'t> for TempFile {
     }
 }
 
-#[derive(Debug, Display, DeriveError)]
+#[derive(Debug, Display, Error)]
 #[non_exhaustive]
 pub enum TempFileError {
     /// File I/O Error

--- a/actix-multipart/src/form/tempfile.rs
+++ b/actix-multipart/src/form/tempfile.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use actix_web::{http::StatusCode, web, Error, HttpRequest, ResponseError};
-use derive_more::{Display, Error};
+use derive_more::{Display, Error as DeriveError};
 use futures_core::future::LocalBoxFuture;
 use futures_util::TryStreamExt as _;
 use mime::Mime;
@@ -78,11 +78,11 @@ impl<'t> FieldReader<'t> for TempFile {
     }
 }
 
-#[derive(Debug, Display, Error)]
+#[derive(Debug, Display, DeriveError)]
 #[non_exhaustive]
 pub enum TempFileError {
     /// File I/O Error
-    #[display(fmt = "File I/O error: {}", _0)]
+    #[display("File I/O error: {}", _0)]
     FileIo(std::io::Error),
 }
 

--- a/actix-multipart/src/form/text.rs
+++ b/actix-multipart/src/form/text.rs
@@ -3,7 +3,7 @@
 use std::{str, sync::Arc};
 
 use actix_web::{http::StatusCode, web, Error, HttpRequest, ResponseError};
-use derive_more::{Deref, DerefMut, Display, Error};
+use derive_more::{Deref, DerefMut, Display, Error as DeriveError};
 use futures_core::future::LocalBoxFuture;
 use serde::de::DeserializeOwned;
 
@@ -73,19 +73,19 @@ where
     }
 }
 
-#[derive(Debug, Display, Error)]
+#[derive(Debug, Display, DeriveError)]
 #[non_exhaustive]
 pub enum TextError {
     /// UTF-8 decoding error.
-    #[display(fmt = "UTF-8 decoding error: {}", _0)]
+    #[display("UTF-8 decoding error: {}", _0)]
     Utf8Error(str::Utf8Error),
 
     /// Deserialize error.
-    #[display(fmt = "Plain text deserialize error: {}", _0)]
+    #[display("Plain text deserialize error: {}", _0)]
     Deserialize(serde_plain::Error),
 
     /// Content type error.
-    #[display(fmt = "Content type error")]
+    #[display("Content type error")]
     ContentType,
 }
 

--- a/actix-multipart/src/form/text.rs
+++ b/actix-multipart/src/form/text.rs
@@ -3,7 +3,7 @@
 use std::{str, sync::Arc};
 
 use actix_web::{http::StatusCode, web, Error, HttpRequest, ResponseError};
-use derive_more::{Deref, DerefMut, Display, Error as DeriveError};
+use derive_more::derive::{Deref, DerefMut, Display, Error};
 use futures_core::future::LocalBoxFuture;
 use serde::de::DeserializeOwned;
 
@@ -73,7 +73,7 @@ where
     }
 }
 
-#[derive(Debug, Display, DeriveError)]
+#[derive(Debug, Display, Error)]
 #[non_exhaustive]
 pub enum TextError {
     /// UTF-8 decoding error.

--- a/actix-web/CHANGES.md
+++ b/actix-web/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Update `derive_more` dependency to `1.0`.
+- Minimum supported Rust version (MSRV) is now 1.75.
+
 ## 4.9.0
 
 ### Added

--- a/actix-web/CHANGES.md
+++ b/actix-web/CHANGES.md
@@ -2,7 +2,6 @@
 
 ## Unreleased
 
-- Update `derive_more` dependency to `1.0`.
 - Minimum supported Rust version (MSRV) is now 1.75.
 
 ## 4.9.0

--- a/actix-web/Cargo.toml
+++ b/actix-web/Cargo.toml
@@ -146,7 +146,7 @@ bytes = "1"
 bytestring = "1"
 cfg-if = "1"
 cookie = { version = "0.16", features = ["percent-encode"], optional = true }
-derive_more = "0.99.8"
+derive_more = { version = "1.0", features = ["display", "error", "from"] }
 encoding_rs = "0.8"
 futures-core = { version = "0.3.17", default-features = false }
 futures-util = { version = "0.3.17", default-features = false }

--- a/actix-web/Cargo.toml
+++ b/actix-web/Cargo.toml
@@ -146,7 +146,7 @@ bytes = "1"
 bytestring = "1"
 cfg-if = "1"
 cookie = { version = "0.16", features = ["percent-encode"], optional = true }
-derive_more = { version = "1.0", features = ["display", "error", "from"] }
+derive_more = { version = "1", features = ["display", "error", "from"] }
 encoding_rs = "0.8"
 futures-core = { version = "0.3.17", default-features = false }
 futures-util = { version = "0.3.17", default-features = false }
@@ -182,7 +182,7 @@ futures-util = { version = "0.3.17", default-features = false, features = ["std"
 rand = "0.8"
 rcgen = "0.13"
 rustls-pemfile = "2"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
 static_assertions = "1"
 tls-openssl = { package = "openssl", version = "0.10.55" }
 tls-rustls = { package = "rustls", version = "0.23" }

--- a/actix-web/src/error/mod.rs
+++ b/actix-web/src/error/mod.rs
@@ -6,7 +6,7 @@
 //
 // See <https://github.com/rust-lang/rust/issues/83375>
 pub use actix_http::error::{ContentTypeError, DispatchError, HttpError, ParseError, PayloadError};
-use derive_more::{Display, Error, From};
+use derive_more::{Display, Error as DeriveError, From};
 use serde_json::error::Error as JsonError;
 use serde_urlencoded::{de::Error as FormDeError, ser::Error as FormError};
 use url::ParseError as UrlParseError;
@@ -28,70 +28,70 @@ pub use self::{error::Error, internal::*, response_error::ResponseError};
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// An error representing a problem running a blocking task on a thread pool.
-#[derive(Debug, Display, Error)]
-#[display(fmt = "Blocking thread pool is shut down unexpectedly")]
+#[derive(Debug, Display, DeriveError)]
+#[display("Blocking thread pool is shut down unexpectedly")]
 #[non_exhaustive]
 pub struct BlockingError;
 
 impl ResponseError for crate::error::BlockingError {}
 
 /// Errors which can occur when attempting to generate resource uri.
-#[derive(Debug, PartialEq, Eq, Display, Error, From)]
+#[derive(Debug, PartialEq, Eq, Display, DeriveError, From)]
 #[non_exhaustive]
 pub enum UrlGenerationError {
     /// Resource not found.
-    #[display(fmt = "Resource not found")]
+    #[display("Resource not found")]
     ResourceNotFound,
 
     /// Not all URL parameters covered.
-    #[display(fmt = "Not all URL parameters covered")]
+    #[display("Not all URL parameters covered")]
     NotEnoughElements,
 
     /// URL parse error.
-    #[display(fmt = "{}", _0)]
+    #[display("{}", _0)]
     ParseError(UrlParseError),
 }
 
 impl ResponseError for UrlGenerationError {}
 
 /// A set of errors that can occur during parsing urlencoded payloads
-#[derive(Debug, Display, Error, From)]
+#[derive(Debug, Display, DeriveError, From)]
 #[non_exhaustive]
 pub enum UrlencodedError {
     /// Can not decode chunked transfer encoding.
-    #[display(fmt = "Can not decode chunked transfer encoding.")]
+    #[display("Can not decode chunked transfer encoding.")]
     Chunked,
 
     /// Payload size is larger than allowed. (default limit: 256kB).
     #[display(
-        fmt = "URL encoded payload is larger ({} bytes) than allowed (limit: {} bytes).",
+        "URL encoded payload is larger ({} bytes) than allowed (limit: {} bytes).",
         size,
         limit
     )]
     Overflow { size: usize, limit: usize },
 
     /// Payload size is now known.
-    #[display(fmt = "Payload size is now known.")]
+    #[display("Payload size is now known.")]
     UnknownLength,
 
     /// Content type error.
-    #[display(fmt = "Content type error.")]
+    #[display("Content type error.")]
     ContentType,
 
     /// Parse error.
-    #[display(fmt = "Parse error: {}.", _0)]
+    #[display("Parse error: {}.", _0)]
     Parse(FormDeError),
 
     /// Encoding error.
-    #[display(fmt = "Encoding error.")]
+    #[display("Encoding error.")]
     Encoding,
 
     /// Serialize error.
-    #[display(fmt = "Serialize error: {}.", _0)]
+    #[display("Serialize error: {}.", _0)]
     Serialize(FormError),
 
     /// Payload error.
-    #[display(fmt = "Error that occur during reading payload: {}.", _0)]
+    #[display("Error that occur during reading payload: {}.", _0)]
     Payload(PayloadError),
 }
 
@@ -108,35 +108,35 @@ impl ResponseError for UrlencodedError {
 }
 
 /// A set of errors that can occur during parsing json payloads
-#[derive(Debug, Display, Error)]
+#[derive(Debug, Display, DeriveError)]
 #[non_exhaustive]
 pub enum JsonPayloadError {
     /// Payload size is bigger than allowed & content length header set. (default: 2MB)
     #[display(
-        fmt = "JSON payload ({} bytes) is larger than allowed (limit: {} bytes).",
+        "JSON payload ({} bytes) is larger than allowed (limit: {} bytes).",
         length,
         limit
     )]
     OverflowKnownLength { length: usize, limit: usize },
 
     /// Payload size is bigger than allowed but no content length header set. (default: 2MB)
-    #[display(fmt = "JSON payload has exceeded limit ({} bytes).", limit)]
+    #[display("JSON payload has exceeded limit ({} bytes).", limit)]
     Overflow { limit: usize },
 
     /// Content type error
-    #[display(fmt = "Content type error")]
+    #[display("Content type error")]
     ContentType,
 
     /// Deserialize error
-    #[display(fmt = "Json deserialize error: {}", _0)]
+    #[display("Json deserialize error: {}", _0)]
     Deserialize(JsonError),
 
     /// Serialize error
-    #[display(fmt = "Json serialize error: {}", _0)]
+    #[display("Json serialize error: {}", _0)]
     Serialize(JsonError),
 
     /// Payload error
-    #[display(fmt = "Error that occur during reading payload: {}", _0)]
+    #[display("Error that occur during reading payload: {}", _0)]
     Payload(PayloadError),
 }
 
@@ -162,11 +162,11 @@ impl ResponseError for JsonPayloadError {
 }
 
 /// A set of errors that can occur during parsing request paths
-#[derive(Debug, Display, Error)]
+#[derive(Debug, Display, DeriveError)]
 #[non_exhaustive]
 pub enum PathError {
     /// Deserialize error
-    #[display(fmt = "Path deserialize error: {}", _0)]
+    #[display("Path deserialize error: {}", _0)]
     Deserialize(serde::de::value::Error),
 }
 
@@ -178,11 +178,11 @@ impl ResponseError for PathError {
 }
 
 /// A set of errors that can occur during parsing query strings.
-#[derive(Debug, Display, Error, From)]
+#[derive(Debug, Display, DeriveError, From)]
 #[non_exhaustive]
 pub enum QueryPayloadError {
     /// Query deserialize error.
-    #[display(fmt = "Query deserialize error: {}", _0)]
+    #[display("Query deserialize error: {}", _0)]
     Deserialize(serde::de::value::Error),
 }
 
@@ -193,23 +193,23 @@ impl ResponseError for QueryPayloadError {
 }
 
 /// Error type returned when reading body as lines.
-#[derive(Debug, Display, Error, From)]
+#[derive(Debug, Display, DeriveError, From)]
 #[non_exhaustive]
 pub enum ReadlinesError {
-    #[display(fmt = "Encoding error")]
+    #[display("Encoding error")]
     /// Payload size is bigger than allowed. (default: 256kB)
     EncodingError,
 
     /// Payload error.
-    #[display(fmt = "Error that occur during reading payload: {}", _0)]
+    #[display("Error that occur during reading payload: {}", _0)]
     Payload(PayloadError),
 
     /// Line limit exceeded.
-    #[display(fmt = "Line limit exceeded")]
+    #[display("Line limit exceeded")]
     LimitOverflow,
 
     /// ContentType error.
-    #[display(fmt = "Content-type error")]
+    #[display("Content-type error")]
     ContentTypeError(ContentTypeError),
 }
 

--- a/actix-web/src/error/mod.rs
+++ b/actix-web/src/error/mod.rs
@@ -6,7 +6,7 @@
 //
 // See <https://github.com/rust-lang/rust/issues/83375>
 pub use actix_http::error::{ContentTypeError, DispatchError, HttpError, ParseError, PayloadError};
-use derive_more::{Display, Error as DeriveError, From};
+use derive_more::derive::{Display, Error, From};
 use serde_json::error::Error as JsonError;
 use serde_urlencoded::{de::Error as FormDeError, ser::Error as FormError};
 use url::ParseError as UrlParseError;
@@ -28,7 +28,7 @@ pub use self::{error::Error, internal::*, response_error::ResponseError};
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// An error representing a problem running a blocking task on a thread pool.
-#[derive(Debug, Display, DeriveError)]
+#[derive(Debug, Display, Error)]
 #[display("Blocking thread pool is shut down unexpectedly")]
 #[non_exhaustive]
 pub struct BlockingError;
@@ -36,7 +36,7 @@ pub struct BlockingError;
 impl ResponseError for crate::error::BlockingError {}
 
 /// Errors which can occur when attempting to generate resource uri.
-#[derive(Debug, PartialEq, Eq, Display, DeriveError, From)]
+#[derive(Debug, PartialEq, Eq, Display, Error, From)]
 #[non_exhaustive]
 pub enum UrlGenerationError {
     /// Resource not found.
@@ -55,7 +55,7 @@ pub enum UrlGenerationError {
 impl ResponseError for UrlGenerationError {}
 
 /// A set of errors that can occur during parsing urlencoded payloads
-#[derive(Debug, Display, DeriveError, From)]
+#[derive(Debug, Display, Error, From)]
 #[non_exhaustive]
 pub enum UrlencodedError {
     /// Can not decode chunked transfer encoding.
@@ -108,7 +108,7 @@ impl ResponseError for UrlencodedError {
 }
 
 /// A set of errors that can occur during parsing json payloads
-#[derive(Debug, Display, DeriveError)]
+#[derive(Debug, Display, Error)]
 #[non_exhaustive]
 pub enum JsonPayloadError {
     /// Payload size is bigger than allowed & content length header set. (default: 2MB)
@@ -162,7 +162,7 @@ impl ResponseError for JsonPayloadError {
 }
 
 /// A set of errors that can occur during parsing request paths
-#[derive(Debug, Display, DeriveError)]
+#[derive(Debug, Display, Error)]
 #[non_exhaustive]
 pub enum PathError {
     /// Deserialize error
@@ -178,7 +178,7 @@ impl ResponseError for PathError {
 }
 
 /// A set of errors that can occur during parsing query strings.
-#[derive(Debug, Display, DeriveError, From)]
+#[derive(Debug, Display, Error, From)]
 #[non_exhaustive]
 pub enum QueryPayloadError {
     /// Query deserialize error.
@@ -193,7 +193,7 @@ impl ResponseError for QueryPayloadError {
 }
 
 /// Error type returned when reading body as lines.
-#[derive(Debug, Display, DeriveError, From)]
+#[derive(Debug, Display, Error, From)]
 #[non_exhaustive]
 pub enum ReadlinesError {
     #[display("Encoding error")]

--- a/actix-web/src/http/header/content_length.rs
+++ b/actix-web/src/http/header/content_length.rs
@@ -1,6 +1,6 @@
 use std::{convert::Infallible, str};
 
-use derive_more::{Deref, DerefMut};
+use derive_more::derive::{Deref, DerefMut};
 
 use crate::{
     error::ParseError,

--- a/actix-web/src/info.rs
+++ b/actix-web/src/info.rs
@@ -235,7 +235,7 @@ impl FromRequest for ConnectionInfo {
 /// # let _svc = actix_web::web::to(handler);
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Display)]
-#[display(fmt = "{}", _0)]
+#[display("{}", _0)]
 pub struct PeerAddr(pub SocketAddr);
 
 impl PeerAddr {
@@ -247,7 +247,7 @@ impl PeerAddr {
 
 #[derive(Debug, Display, Error)]
 #[non_exhaustive]
-#[display(fmt = "Missing peer address")]
+#[display("Missing peer address")]
 pub struct MissingPeerAddr;
 
 impl ResponseError for MissingPeerAddr {}

--- a/actix-web/src/info.rs
+++ b/actix-web/src/info.rs
@@ -1,7 +1,7 @@
 use std::{convert::Infallible, net::SocketAddr};
 
 use actix_utils::future::{err, ok, Ready};
-use derive_more::{Display, Error};
+use derive_more::derive::{Display, Error};
 
 use crate::{
     dev::{AppConfig, Payload, RequestHead},

--- a/actix-web/src/types/path.rs
+++ b/actix-web/src/types/path.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use actix_router::PathDeserializer;
 use actix_utils::future::{ready, Ready};
-use derive_more::{AsRef, Deref, DerefMut, Display, From};
+use derive_more::derive::{AsRef, Deref, DerefMut, Display, From};
 use serde::de;
 
 use crate::{
@@ -152,7 +152,7 @@ impl PathConfig {
 #[cfg(test)]
 mod tests {
     use actix_router::ResourceDef;
-    use derive_more::Display;
+    use derive_more::derive::Display;
     use serde::Deserialize;
 
     use super::*;

--- a/actix-web/src/types/path.rs
+++ b/actix-web/src/types/path.rs
@@ -159,7 +159,7 @@ mod tests {
     use crate::{error, http, test::TestRequest, HttpResponse};
 
     #[derive(Deserialize, Debug, Display)]
-    #[display(fmt = "MyStruct({}, {})", key, value)]
+    #[display("MyStruct({}, {})", key, value)]
     struct MyStruct {
         key: String,
         value: String,

--- a/actix-web/src/types/query.rs
+++ b/actix-web/src/types/query.rs
@@ -187,7 +187,7 @@ impl QueryConfig {
 #[cfg(test)]
 mod tests {
     use actix_http::StatusCode;
-    use derive_more::Display;
+    use derive_more::derive::Display;
     use serde::Deserialize;
 
     use super::*;

--- a/awc/CHANGES.md
+++ b/awc/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Update `derive_more` dependency to `1.0`.
+- Minimum supported Rust version (MSRV) is now 1.75.
+
 ## 3.5.1
 
 - Fix WebSocket `Host` request header value when using a non-default port.

--- a/awc/CHANGES.md
+++ b/awc/CHANGES.md
@@ -2,7 +2,6 @@
 
 ## Unreleased
 
-- Update `derive_more` dependency to `1.0`.
 - Minimum supported Rust version (MSRV) is now 1.75.
 
 ## 3.5.1

--- a/awc/Cargo.toml
+++ b/awc/Cargo.toml
@@ -106,7 +106,7 @@ actix-utils = "3"
 base64 = "0.22"
 bytes = "1"
 cfg-if = "1"
-derive_more = "0.99.5"
+derive_more = { version = "1.0", features = ["display", "error", "from"] }
 futures-core = { version = "0.3.17", default-features = false, features = ["alloc"] }
 futures-util = { version = "0.3.17", default-features = false, features = ["alloc", "sink"] }
 h2 = "0.3.26"

--- a/awc/Cargo.toml
+++ b/awc/Cargo.toml
@@ -106,7 +106,7 @@ actix-utils = "3"
 base64 = "0.22"
 bytes = "1"
 cfg-if = "1"
-derive_more = { version = "1.0", features = ["display", "error", "from"] }
+derive_more = { version = "1", features = ["display", "error", "from"] }
 futures-core = { version = "0.3.17", default-features = false, features = ["alloc"] }
 futures-util = { version = "0.3.17", default-features = false, features = ["alloc", "sink"] }
 h2 = "0.3.26"

--- a/awc/src/client/error.rs
+++ b/awc/src/client/error.rs
@@ -12,40 +12,40 @@ use crate::BoxError;
 #[non_exhaustive]
 pub enum ConnectError {
     /// SSL feature is not enabled
-    #[display(fmt = "SSL is not supported")]
+    #[display("SSL is not supported")]
     SslIsNotSupported,
 
     /// SSL error
     #[cfg(feature = "openssl")]
-    #[display(fmt = "{}", _0)]
+    #[display("{}", _0)]
     SslError(OpensslError),
 
     /// Failed to resolve the hostname
-    #[display(fmt = "Failed resolving hostname: {}", _0)]
+    #[display("Failed resolving hostname: {}", _0)]
     Resolver(Box<dyn std::error::Error>),
 
     /// No dns records
-    #[display(fmt = "No DNS records found for the input")]
+    #[display("No DNS records found for the input")]
     NoRecords,
 
     /// Http2 error
-    #[display(fmt = "{}", _0)]
+    #[display("{}", _0)]
     H2(h2::Error),
 
     /// Connecting took too long
-    #[display(fmt = "Timeout while establishing connection")]
+    #[display("Timeout while establishing connection")]
     Timeout,
 
     /// Connector has been disconnected
-    #[display(fmt = "Internal error: connector has been disconnected")]
+    #[display("Internal error: connector has been disconnected")]
     Disconnected,
 
     /// Unresolved host name
-    #[display(fmt = "Connector received `Connect` method with unresolved host")]
+    #[display("Connector received `Connect` method with unresolved host")]
     Unresolved,
 
     /// Connection io error
-    #[display(fmt = "{}", _0)]
+    #[display("{}", _0)]
     Io(io::Error),
 }
 
@@ -66,16 +66,16 @@ impl From<actix_tls::connect::ConnectError> for ConnectError {
 #[derive(Debug, Display, From)]
 #[non_exhaustive]
 pub enum InvalidUrl {
-    #[display(fmt = "Missing URL scheme")]
+    #[display("Missing URL scheme")]
     MissingScheme,
 
-    #[display(fmt = "Unknown URL scheme")]
+    #[display("Unknown URL scheme")]
     UnknownScheme,
 
-    #[display(fmt = "Missing host name")]
+    #[display("Missing host name")]
     MissingHost,
 
-    #[display(fmt = "URL parse error: {}", _0)]
+    #[display("URL parse error: {}", _0)]
     HttpError(http::Error),
 }
 
@@ -86,11 +86,11 @@ impl std::error::Error for InvalidUrl {}
 #[non_exhaustive]
 pub enum SendRequestError {
     /// Invalid URL
-    #[display(fmt = "Invalid URL: {}", _0)]
+    #[display("Invalid URL: {}", _0)]
     Url(InvalidUrl),
 
     /// Failed to connect to host
-    #[display(fmt = "Failed to connect to host: {}", _0)]
+    #[display("Failed to connect to host: {}", _0)]
     Connect(ConnectError),
 
     /// Error sending request
@@ -100,26 +100,26 @@ pub enum SendRequestError {
     Response(ParseError),
 
     /// Http error
-    #[display(fmt = "{}", _0)]
+    #[display("{}", _0)]
     Http(HttpError),
 
     /// Http2 error
-    #[display(fmt = "{}", _0)]
+    #[display("{}", _0)]
     H2(h2::Error),
 
     /// Response took too long
-    #[display(fmt = "Timeout while waiting for response")]
+    #[display("Timeout while waiting for response")]
     Timeout,
 
     /// Tunnels are not supported for HTTP/2 connection
-    #[display(fmt = "Tunnels are not supported for http2 connection")]
+    #[display("Tunnels are not supported for http2 connection")]
     TunnelNotSupported,
 
     /// Error sending request body
     Body(BoxError),
 
     /// Other errors that can occur after submitting a request.
-    #[display(fmt = "{:?}: {}", _1, _0)]
+    #[display("{:?}: {}", _1, _0)]
     Custom(BoxError, Box<dyn fmt::Debug>),
 }
 
@@ -130,15 +130,15 @@ impl std::error::Error for SendRequestError {}
 #[non_exhaustive]
 pub enum FreezeRequestError {
     /// Invalid URL
-    #[display(fmt = "Invalid URL: {}", _0)]
+    #[display("Invalid URL: {}", _0)]
     Url(InvalidUrl),
 
     /// HTTP error
-    #[display(fmt = "{}", _0)]
+    #[display("{}", _0)]
     Http(HttpError),
 
     /// Other errors that can occur after submitting a request.
-    #[display(fmt = "{:?}: {}", _1, _0)]
+    #[display("{:?}: {}", _1, _0)]
     Custom(BoxError, Box<dyn fmt::Debug>),
 }
 

--- a/awc/src/client/error.rs
+++ b/awc/src/client/error.rs
@@ -3,7 +3,7 @@ use std::{fmt, io};
 use actix_http::error::{HttpError, ParseError};
 #[cfg(feature = "openssl")]
 use actix_tls::accept::openssl::reexports::Error as OpensslError;
-use derive_more::{Display, From};
+use derive_more::derive::{Display, From};
 
 use crate::BoxError;
 

--- a/awc/src/error.rs
+++ b/awc/src/error.rs
@@ -18,35 +18,35 @@ pub use crate::client::{ConnectError, FreezeRequestError, InvalidUrl, SendReques
 #[derive(Debug, Display, From)]
 pub enum WsClientError {
     /// Invalid response status
-    #[display(fmt = "Invalid response status")]
+    #[display("Invalid response status")]
     InvalidResponseStatus(StatusCode),
 
     /// Invalid upgrade header
-    #[display(fmt = "Invalid upgrade header")]
+    #[display("Invalid upgrade header")]
     InvalidUpgradeHeader,
 
     /// Invalid connection header
-    #[display(fmt = "Invalid connection header")]
+    #[display("Invalid connection header")]
     InvalidConnectionHeader(HeaderValue),
 
     /// Missing Connection header
-    #[display(fmt = "Missing Connection header")]
+    #[display("Missing Connection header")]
     MissingConnectionHeader,
 
     /// Missing Sec-Websocket-Accept header
-    #[display(fmt = "Missing Sec-Websocket-Accept header")]
+    #[display("Missing Sec-Websocket-Accept header")]
     MissingWebSocketAcceptHeader,
 
     /// Invalid challenge response
-    #[display(fmt = "Invalid challenge response")]
+    #[display("Invalid challenge response")]
     InvalidChallengeResponse([u8; 28], HeaderValue),
 
     /// Protocol error
-    #[display(fmt = "{}", _0)]
+    #[display("{}", _0)]
     Protocol(WsProtocolError),
 
     /// Send request error
-    #[display(fmt = "{}", _0)]
+    #[display("{}", _0)]
     SendRequest(SendRequestError),
 }
 
@@ -68,13 +68,13 @@ impl From<HttpError> for WsClientError {
 #[derive(Debug, Display, From)]
 pub enum JsonPayloadError {
     /// Content type error
-    #[display(fmt = "Content type error")]
+    #[display("Content type error")]
     ContentType,
     /// Deserialize error
-    #[display(fmt = "Json deserialize error: {}", _0)]
+    #[display("Json deserialize error: {}", _0)]
     Deserialize(JsonError),
     /// Payload error
-    #[display(fmt = "Error that occur during reading payload: {}", _0)]
+    #[display("Error that occur during reading payload: {}", _0)]
     Payload(PayloadError),
 }
 

--- a/awc/src/error.rs
+++ b/awc/src/error.rs
@@ -7,7 +7,7 @@ pub use actix_http::{
     ws::{HandshakeError as WsHandshakeError, ProtocolError as WsProtocolError},
     StatusCode,
 };
-use derive_more::{Display, From};
+use derive_more::derive::{Display, From};
 use serde_json::error::Error as JsonError;
 
 pub use crate::client::{ConnectError, FreezeRequestError, InvalidUrl, SendRequestError};

--- a/awc/src/sender.rs
+++ b/awc/src/sender.rs
@@ -17,7 +17,7 @@ use actix_http::{
 use actix_http::{encoding::Decoder, header::ContentEncoding, Payload};
 use actix_rt::time::{sleep, Sleep};
 use bytes::Bytes;
-use derive_more::From;
+use derive_more::derive::From;
 use futures_core::Stream;
 use serde::Serialize;
 


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type

Other

## PR Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.

## Overview

- Update `derive_more` dependency to `1.0`.
- Minimum supported Rust version (MSRV) is now 1.75.
