### PR TITLE
Consume complete message body even on error

### DIFF
--- a/actix-web/CHANGES.md
+++ b/actix-web/CHANGES.md
@@ -23,6 +23,7 @@
 - Always remove port from return value of `ConnectionInfo::realip_remote_addr()` when handling IPv6 addresses. from the `Forwarded` header.
 - The `UrlencodedError::ContentType` variant (relevant to the `Form` extractor) now uses the 415 (Media Type Unsupported) status code in it's `ResponseError` implementation.
 - Apply `HttpServer::max_connection_rate()` setting when using rustls v0.22 or v0.23.
+- Always consume complete HTTP message body, even on error
 
 ## 4.7.0
 


### PR DESCRIPTION
## PR Type

Bug Fix

## PR Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.

## Overview

Currently, if there is an error during an HTTP request, the message body is not completely consumed in `actix-web/src/types/payload.rs`. In cases where HTTP keep-alive is enabled, this causes the connection to hang in the `CLOSE-WAIT` state, with the TCP receive queue still containing some bytes that need to be consumed. This PR modifies the `Future` implementation for `HttpMessageBody` to always consume all available data and return with success or error at the end. Besides issue #3182, there might be similar issues that are resolved by this PR.

Closes #3182

