### PR TITLE
Ensure incompatible versions of time are not allowed

### DIFF
--- a/actix-web/Cargo.toml
+++ b/actix-web/Cargo.toml
@@ -164,7 +164,7 @@ serde_json = "1.0"
 serde_urlencoded = "0.7"
 smallvec = "1.6.1"
 socket2 = "0.5"
-time = { version = "0.3", default-features = false, features = ["formatting"] }
+time = { version = "0.3.36", default-features = false, features = ["formatting"] }
 url = "2.1"
 
 [dev-dependencies]


### PR DESCRIPTION

## PR Type

Other

## Overview

Rust 1.80 [broke compatibility with many versions of the `time 0.3` crate](https://github.com/rust-lang/rust/issues/127343). `actix-web` is one of the most popular crates using it, so bumping it here may help users avoid ever getting a broken `time` version, even if they have an older lockfile.