### PR TITLE
Set `SO_REUSEADDR` only non-Windows platforms

### DIFF
--- a/actix-web/CHANGES.md
+++ b/actix-web/CHANGES.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Minimum supported Rust version (MSRV) is now 1.75.
+- On Windows platforms, produce an error when invoking `HttpServer::bind` on a socket that's already in use. See [issue 2958](https://github.com/actix/actix-web/issues/2958).
 
 ## 4.9.0
 

--- a/actix-web/src/server.rs
+++ b/actix-web/src/server.rs
@@ -1085,7 +1085,10 @@ fn create_tcp_listener(addr: net::SocketAddr, backlog: u32) -> io::Result<net::T
     use socket2::{Domain, Protocol, Socket, Type};
     let domain = Domain::for_address(addr);
     let socket = Socket::new(domain, Type::STREAM, Some(Protocol::TCP))?;
-    socket.set_reuse_address(true)?;
+    #[cfg(not(windows))]
+    {
+        socket.set_reuse_address(true)?;
+    }
     socket.bind(&addr.into())?;
     // clamp backlog to max u32 that fits in i32 range
     let backlog = cmp::min(backlog, i32::MAX as u32) as i32;

--- a/actix-web/tests/test_httpserver.rs
+++ b/actix-web/tests/test_httpserver.rs
@@ -1,10 +1,8 @@
 #[cfg(feature = "openssl")]
 extern crate tls_openssl as openssl;
 
-use {
-    actix_web::{web, App, HttpResponse, HttpServer},
-    std::{sync::mpsc, thread, time::Duration},
-};
+use actix_web::{web, App, HttpResponse, HttpServer};
+use std::{sync::mpsc, thread, time::Duration};
 
 #[actix_rt::test]
 async fn test_start() {

--- a/actix-web/tests/test_httpserver.rs
+++ b/actix-web/tests/test_httpserver.rs
@@ -1,13 +1,11 @@
 #[cfg(feature = "openssl")]
 extern crate tls_openssl as openssl;
 
-#[cfg(any(unix, feature = "openssl"))]
 use {
     actix_web::{web, App, HttpResponse, HttpServer},
     std::{sync::mpsc, thread, time::Duration},
 };
 
-#[cfg(unix)]
 #[actix_rt::test]
 async fn test_start() {
     let addr = actix_test::unused_addr();
@@ -52,6 +50,27 @@ async fn test_start() {
     let host = format!("http://{}", addr);
     let response = client.get(host.clone()).send().await.unwrap();
     assert!(response.status().is_success());
+
+    // Attempt to start a second server using the same address.
+    let result = HttpServer::new(|| {
+        App::new().service(
+            web::resource("/").route(web::to(|| async { HttpResponse::Ok().body("test") })),
+        )
+    })
+    .workers(1)
+    .backlog(1)
+    .max_connections(10)
+    .max_connection_rate(10)
+    .keep_alive(Duration::from_secs(10))
+    .client_request_timeout(Duration::from_secs(5))
+    .client_disconnect_timeout(Duration::ZERO)
+    .server_hostname("localhost")
+    .system_exit()
+    .disable_signals()
+    .bind(format!("{}", addr));
+
+    // This should fail: the address is in use.
+    assert!(result.is_err());
 
     srv.stop(false).await;
 }

--- a/actix-web/tests/test_httpserver.rs
+++ b/actix-web/tests/test_httpserver.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "openssl")]
 extern crate tls_openssl as openssl;
 
+
 use actix_web::{web, App, HttpResponse, HttpServer};
 use std::{sync::mpsc, thread, time::Duration};
 

--- a/actix-web/tests/test_httpserver.rs
+++ b/actix-web/tests/test_httpserver.rs
@@ -1,9 +1,9 @@
 #[cfg(feature = "openssl")]
 extern crate tls_openssl as openssl;
 
+use std::{sync::mpsc, thread, time::Duration};
 
 use actix_web::{web, App, HttpResponse, HttpServer};
-use std::{sync::mpsc, thread, time::Duration};
 
 #[actix_rt::test]
 async fn test_start() {


### PR DESCRIPTION
**Warning**: This is a draft PR -- expect rapid changes here until tests pass.

<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type

<!-- What kind of change does this PR make? -->
This PR follows the discussion in #2958, providing the fix suggested by @imor. Per that issue, it also fixes #1335 and #1913.

<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
This PR is a bug fix.

## PR Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.

## Overview
The behavior on non-Windows platforms is unaffected by this PR. It only affects Windows platforms.

<!-- Describe the current and new behavior. -->
### Current behavior
On Windows, invoking `HttpServer::bind` on a socket that's already in use succeeds, producing an undefined split of requests and responses between both servers.

### New behavior
On Windows, invoking `HttpServer::bind` on a socket that's already in use fails, preventing this odd behavior.

<!-- Emphasize any breaking changes. -->
### Breaking changes
On Windows, the server can no longer bind to a socket that's already in use.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
Closes #2958, #1335, #1913.
