### PR TITLE
Improve worker_max_blocking_threads documentation

### DIFF
--- a/actix-web/src/server.rs
+++ b/actix-web/src/server.rs
@@ -193,7 +193,7 @@ where
     ///
     /// One thread pool is set up **per worker**; not shared across workers.
     ///
-    /// By default set to 512 divided by the number of workers.
+    /// By default set to 512 divided by [`std::thread::available_parallelism()`].
     pub fn worker_max_blocking_threads(mut self, num: usize) -> Self {
         self.builder = self.builder.worker_max_blocking_threads(num);
         self

--- a/actix-web/src/server.rs
+++ b/actix-web/src/server.rs
@@ -193,7 +193,7 @@ where
     ///
     /// One thread pool is set up **per worker**; not shared across workers.
     ///
-    /// By default set to 512 divided by [`std::thread::available_parallelism()`].
+    /// By default, set to 512 divided by [available parallelism](std::thread::available_parallelism()).
     pub fn worker_max_blocking_threads(mut self, num: usize) -> Self {
         self.builder = self.builder.worker_max_blocking_threads(num);
         self


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type

<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->

Documentation

## PR Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [X] Tests for the changes have been added / updated.
- [X] Documentation comments have been added / updated.
- [X] A changelog entry has been made for the appropriate packages.
- [X] Format code with the latest stable rustfmt.
- [X] (Team) Label with affected crates and semver status.

## Overview
The current documentation for `HttpServer::worker_max_blocking_threads` says that the default number of blocking threads is "512 divided by the number of workers." However, this could lead someone to believe that the default value depends on the number of workers set in `HttpServer`, when it actually depends on the system's `available_parallelism`.
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
