### PR TITLE
refactor: replace ahash with foldhash

### DIFF
--- a/actix-http/Cargo.toml
+++ b/actix-http/Cargo.toml
@@ -106,12 +106,12 @@ actix-codec = "0.5"
 actix-utils = "3"
 actix-rt = { version = "2.2", default-features = false }
 
-ahash = "0.8"
 bitflags = "2"
 bytes = "1"
 bytestring = "1"
 derive_more = { version = "1", features = ["as_ref", "deref", "deref_mut", "display", "error", "from"] }
 encoding_rs = "0.8"
+foldhash = "0.1"
 futures-core = { version = "0.3.17", default-features = false, features = ["alloc"] }
 http = "0.2.7"
 httparse = "1.5.1"

--- a/actix-http/src/extensions.rs
+++ b/actix-http/src/extensions.rs
@@ -31,7 +31,7 @@ impl Hasher for NoOpHasher {
 /// All entries into this map must be owned types (or static references).
 #[derive(Default)]
 pub struct Extensions {
-    /// Use AHasher with a std HashMap with for faster lookups on the small `TypeId` keys.
+    // use no-op hasher with a std HashMap with for faster lookups on the small `TypeId` keys
     map: HashMap<TypeId, Box<dyn Any>, BuildHasherDefault<NoOpHasher>>,
 }
 

--- a/actix-http/src/header/map.rs
+++ b/actix-http/src/header/map.rs
@@ -1,8 +1,12 @@
 //! A multi-value [`HeaderMap`] and its iterators.
 
-use std::{borrow::Cow, collections::hash_map, iter, ops};
+use std::{
+    borrow::Cow,
+    collections::{hash_map, HashMap},
+    iter, ops,
+};
 
-use ahash::AHashMap;
+use foldhash::HashMap as FoldHashMap;
 use http::header::{HeaderName, HeaderValue};
 use smallvec::{smallvec, SmallVec};
 
@@ -47,7 +51,7 @@ use super::AsHeaderName;
 /// ```
 #[derive(Debug, Clone, Default)]
 pub struct HeaderMap {
-    pub(crate) inner: AHashMap<HeaderName, Value>,
+    pub(crate) inner: FoldHashMap<HeaderName, Value>,
 }
 
 /// A bespoke non-empty list for HeaderMap values.
@@ -116,7 +120,10 @@ impl HeaderMap {
     /// ```
     pub fn with_capacity(capacity: usize) -> Self {
         HeaderMap {
-            inner: AHashMap::with_capacity(capacity),
+            inner: HashMap::with_capacity_and_hasher(
+                capacity,
+                foldhash::fast::RandomState::default(),
+            ),
         }
     }
 

--- a/actix-http/src/header/map.rs
+++ b/actix-http/src/header/map.rs
@@ -1,12 +1,8 @@
 //! A multi-value [`HeaderMap`] and its iterators.
 
-use std::{
-    borrow::Cow,
-    collections::{hash_map, HashMap},
-    iter, ops,
-};
+use std::{borrow::Cow, collections::hash_map, iter, ops};
 
-use foldhash::HashMap as FoldHashMap;
+use foldhash::{HashMap as FoldHashMap, HashMapExt as _};
 use http::header::{HeaderName, HeaderValue};
 use smallvec::{smallvec, SmallVec};
 
@@ -120,10 +116,7 @@ impl HeaderMap {
     /// ```
     pub fn with_capacity(capacity: usize) -> Self {
         HeaderMap {
-            inner: HashMap::with_capacity_and_hasher(
-                capacity,
-                foldhash::fast::RandomState::default(),
-            ),
+            inner: FoldHashMap::with_capacity(capacity),
         }
     }
 

--- a/actix-web/Cargo.toml
+++ b/actix-web/Cargo.toml
@@ -141,13 +141,13 @@ actix-http = { version = "3.7", features = ["ws"] }
 actix-router = { version = "0.5.3", default-features = false, features = ["http"] }
 actix-web-codegen = { version = "4.3", optional = true, default-features = false }
 
-ahash = "0.8"
 bytes = "1"
 bytestring = "1"
 cfg-if = "1"
 cookie = { version = "0.16", features = ["percent-encode"], optional = true }
 derive_more = { version = "1", features = ["display", "error", "from"] }
 encoding_rs = "0.8"
+foldhash = "0.1"
 futures-core = { version = "0.3.17", default-features = false }
 futures-util = { version = "0.3.17", default-features = false }
 itoa = "1"

--- a/actix-web/src/middleware/err_handlers.rs
+++ b/actix-web/src/middleware/err_handlers.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use actix_service::{Service, Transform};
-use ahash::AHashMap;
+use foldhash::HashMap as FoldHashMap;
 use futures_core::{future::LocalBoxFuture, ready};
 use pin_project_lite::pin_project;
 
@@ -185,7 +185,7 @@ pub struct ErrorHandlers<B> {
     handlers: Handlers<B>,
 }
 
-type Handlers<B> = Rc<AHashMap<StatusCode, Box<ErrorHandler<B>>>>;
+type Handlers<B> = Rc<FoldHashMap<StatusCode, Box<ErrorHandler<B>>>>;
 
 impl<B> Default for ErrorHandlers<B> {
     fn default() -> Self {

--- a/actix-web/src/rmap.rs
+++ b/actix-web/src/rmap.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use actix_router::ResourceDef;
-use ahash::AHashMap;
+use foldhash::HashMap as FoldHashMap;
 use url::Url;
 
 use crate::{error::UrlGenerationError, request::HttpRequest};
@@ -19,7 +19,7 @@ pub struct ResourceMap {
 
     /// Named resources within the tree or, for external resources, it points to isolated nodes
     /// outside the tree.
-    named: AHashMap<String, Rc<ResourceMap>>,
+    named: FoldHashMap<String, Rc<ResourceMap>>,
 
     parent: RefCell<Weak<ResourceMap>>,
 
@@ -32,7 +32,7 @@ impl ResourceMap {
     pub fn new(root: ResourceDef) -> Self {
         ResourceMap {
             pattern: root,
-            named: AHashMap::default(),
+            named: FoldHashMap::default(),
             parent: RefCell::new(Weak::new()),
             nodes: Some(Vec::new()),
         }
@@ -86,7 +86,7 @@ impl ResourceMap {
         } else {
             let new_node = Rc::new(ResourceMap {
                 pattern: pattern.clone(),
-                named: AHashMap::default(),
+                named: FoldHashMap::default(),
                 parent: RefCell::new(Weak::new()),
                 nodes: None,
             });


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type

<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->

Dependency

## PR Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.

## Overview

Switch out ahash with foldhash for use cases where CSPRNGs are not required in hash maps.
