### PR TITLE
fix: update h2 and http crates and use workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,3 +59,7 @@ nonstandard_style = { level = "deny" }
 
 [workspace.lints.clippy]
 # clone_on_ref_ptr = { level = "deny" }
+
+[workspace.dependencies]
+http = "1.1.0"
+h2 = "0.4.7"

--- a/actix-http-test/CHANGES.md
+++ b/actix-http-test/CHANGES.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 - Minimum supported Rust version (MSRV) is now 1.72.
+- Update `h2` to `0.4.7`
+- Update `http` to `1.1.0`
 
 ## 3.2.0
 

--- a/actix-http-test/Cargo.toml
+++ b/actix-http-test/Cargo.toml
@@ -47,7 +47,7 @@ awc = { version = "3", default-features = false }
 
 bytes = "1"
 futures-core = { version = "0.3.17", default-features = false }
-http = "0.2.7"
+http = { workspace = true }
 log = "0.4"
 socket2 = "0.5"
 serde = "1"

--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -5,6 +5,8 @@
 ### Added
 
 - Add `header::CLEAR_SITE_DATA` constant.
+- Update `h2` to `0.4.7`
+- Update `http` to `1.1.0`
 
 ### Changed
 

--- a/actix-http/Cargo.toml
+++ b/actix-http/Cargo.toml
@@ -113,7 +113,7 @@ bytestring = "1"
 derive_more = { version = "1", features = ["as_ref", "deref", "deref_mut", "display", "error", "from"] }
 encoding_rs = "0.8"
 futures-core = { version = "0.3.17", default-features = false, features = ["alloc"] }
-http = "0.2.7"
+http = { workspace = true }
 httparse = "1.5.1"
 httpdate = "1.0.1"
 itoa = "1"
@@ -127,7 +127,7 @@ tokio-util = { version = "0.7", features = ["io", "codec"] }
 tracing = { version = "0.1.30", default-features = false, features = ["log"] }
 
 # http2
-h2 = { version = "0.3.26", optional = true }
+h2 = { workspace = true, optional = true }
 
 # websockets
 local-channel = { version = "0.1", optional = true }

--- a/actix-router/CHANGES.md
+++ b/actix-router/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Update `h2` to `0.4.7`
+- Update `http` to `1.1.0`
+
 ## 0.5.3
 
 - Add `unicode` crate feature (on-by-default) to switch between `regex` and `regex-lite` as a trade-off between full unicode support and binary size.

--- a/actix-router/Cargo.toml
+++ b/actix-router/Cargo.toml
@@ -26,7 +26,7 @@ unicode = ["dep:regex"]
 [dependencies]
 bytestring = ">=0.1.5, <2"
 cfg-if = "1"
-http = { version = "0.2.7", optional = true }
+http = { workspace = true, optional = true }
 regex = { version = "1.5", optional = true }
 regex-lite = "0.1"
 serde = "1"
@@ -34,7 +34,7 @@ tracing = { version = "0.1.30", default-features = false, features = ["log"] }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
-http = "0.2.7"
+http = { workspace = true }
 serde = { version = "1", features = ["derive"] }
 percent-encoding = "2.1"
 

--- a/awc/CHANGES.md
+++ b/awc/CHANGES.md
@@ -5,6 +5,8 @@
 - Update `brotli` dependency to `7`.
 - Prevent panics on connection pool drop when Tokio runtime is shutdown early.
 - Minimum supported Rust version (MSRV) is now 1.75.
+- Update `h2` to `0.4.7`
+- Update `http` to `1.1.0`
 
 ## 3.5.1
 

--- a/awc/Cargo.toml
+++ b/awc/Cargo.toml
@@ -109,8 +109,8 @@ cfg-if = "1"
 derive_more = { version = "1", features = ["display", "error", "from"] }
 futures-core = { version = "0.3.17", default-features = false, features = ["alloc"] }
 futures-util = { version = "0.3.17", default-features = false, features = ["alloc", "sink"] }
-h2 = "0.3.26"
-http = "0.2.7"
+h2 = { workspace = true }
+http = { workspace = true }
 itoa = "1"
 log =" 0.4"
 mime = "0.3"


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
Update h2 and http crates and add them to workspace dependencies for easy management. 
We can use this method for all share dependencies.

## PR Checklist


- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.

## Overview
