### PR TITLE
feat(awc): allow to configure connector per request

### DIFF
--- a/awc/CHANGES.md
+++ b/awc/CHANGES.md
@@ -5,6 +5,7 @@
 - Update `brotli` dependency to `7`.
 - Prevent panics on connection pool drop when Tokio runtime is shutdown early.
 - Minimum supported Rust version (MSRV) is now 1.75.
+- Allow to set a specific SNI hostname on the request for TLS connections.
 
 ## 3.5.1
 

--- a/awc/src/builder.rs
+++ b/awc/src/builder.rs
@@ -3,7 +3,6 @@ use std::{fmt, net::IpAddr, rc::Rc, time::Duration};
 use actix_http::{
     error::HttpError,
     header::{self, HeaderMap, HeaderName, TryIntoHeaderPair},
-    Uri,
 };
 use actix_rt::net::{ActixStream, TcpStream};
 use actix_service::{boxed, Service};
@@ -11,7 +10,8 @@ use base64::prelude::*;
 
 use crate::{
     client::{
-        ClientConfig, ConnectInfo, Connector, ConnectorService, TcpConnectError, TcpConnection,
+        ClientConfig, ConnectInfo, Connector, ConnectorService, HostnameWithSni, TcpConnectError,
+        TcpConnection,
     },
     connect::DefaultConnector,
     error::SendRequestError,
@@ -46,8 +46,8 @@ impl ClientBuilder {
     #[allow(clippy::new_ret_no_self)]
     pub fn new() -> ClientBuilder<
         impl Service<
-                ConnectInfo<Uri>,
-                Response = TcpConnection<Uri, TcpStream>,
+                ConnectInfo<HostnameWithSni>,
+                Response = TcpConnection<HostnameWithSni, TcpStream>,
                 Error = TcpConnectError,
             > + Clone,
         (),
@@ -69,16 +69,22 @@ impl ClientBuilder {
 
 impl<S, Io, M> ClientBuilder<S, M>
 where
-    S: Service<ConnectInfo<Uri>, Response = TcpConnection<Uri, Io>, Error = TcpConnectError>
-        + Clone
+    S: Service<
+            ConnectInfo<HostnameWithSni>,
+            Response = TcpConnection<HostnameWithSni, Io>,
+            Error = TcpConnectError,
+        > + Clone
         + 'static,
     Io: ActixStream + fmt::Debug + 'static,
 {
     /// Use custom connector service.
     pub fn connector<S1, Io1>(self, connector: Connector<S1>) -> ClientBuilder<S1, M>
     where
-        S1: Service<ConnectInfo<Uri>, Response = TcpConnection<Uri, Io1>, Error = TcpConnectError>
-            + Clone
+        S1: Service<
+                ConnectInfo<HostnameWithSni>,
+                Response = TcpConnection<HostnameWithSni, Io1>,
+                Error = TcpConnectError,
+            > + Clone
             + 'static,
         Io1: ActixStream + fmt::Debug + 'static,
     {

--- a/awc/src/client/config.rs
+++ b/awc/src/client/config.rs
@@ -3,29 +3,33 @@ use std::{net::IpAddr, time::Duration};
 const DEFAULT_H2_CONN_WINDOW: u32 = 1024 * 1024 * 2; // 2MB
 const DEFAULT_H2_STREAM_WINDOW: u32 = 1024 * 1024; // 1MB
 
-/// Connector configuration
-#[derive(Clone)]
-pub(crate) struct ConnectorConfig {
+/// Connect configuration
+#[derive(Clone, Hash, Eq, PartialEq)]
+pub struct ConnectConfig {
     pub(crate) timeout: Duration,
     pub(crate) handshake_timeout: Duration,
     pub(crate) conn_lifetime: Duration,
     pub(crate) conn_keep_alive: Duration,
-    pub(crate) disconnect_timeout: Option<Duration>,
-    pub(crate) limit: usize,
     pub(crate) conn_window_size: u32,
     pub(crate) stream_window_size: u32,
     pub(crate) local_address: Option<IpAddr>,
 }
 
-impl Default for ConnectorConfig {
+/// Connector configuration
+#[derive(Clone)]
+pub struct ConnectorConfig {
+    pub(crate) default_connect_config: ConnectConfig,
+    pub(crate) disconnect_timeout: Option<Duration>,
+    pub(crate) limit: usize,
+}
+
+impl Default for ConnectConfig {
     fn default() -> Self {
         Self {
             timeout: Duration::from_secs(5),
             handshake_timeout: Duration::from_secs(5),
             conn_lifetime: Duration::from_secs(75),
             conn_keep_alive: Duration::from_secs(15),
-            disconnect_timeout: Some(Duration::from_millis(3000)),
-            limit: 100,
             conn_window_size: DEFAULT_H2_CONN_WINDOW,
             stream_window_size: DEFAULT_H2_STREAM_WINDOW,
             local_address: None,
@@ -33,10 +37,88 @@ impl Default for ConnectorConfig {
     }
 }
 
+impl Default for ConnectorConfig {
+    fn default() -> Self {
+        Self {
+            default_connect_config: ConnectConfig::default(),
+            disconnect_timeout: Some(Duration::from_millis(3000)),
+            limit: 100,
+        }
+    }
+}
+
 impl ConnectorConfig {
-    pub(crate) fn no_disconnect_timeout(&self) -> Self {
+    pub fn no_disconnect_timeout(&self) -> Self {
         let mut res = self.clone();
         res.disconnect_timeout = None;
         res
+    }
+}
+
+impl ConnectConfig {
+    /// Sets TCP connection timeout.
+    ///
+    /// This is the max time allowed to connect to remote host, including DNS name resolution.
+    ///
+    /// By default, the timeout is 5 seconds.
+    pub fn timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout;
+        self
+    }
+
+    /// Sets TLS handshake timeout.
+    ///
+    /// This is the max time allowed to perform the TLS handshake with remote host after TCP
+    /// connection is established.
+    ///
+    /// By default, the timeout is 5 seconds.
+    pub fn handshake_timeout(mut self, timeout: Duration) -> Self {
+        self.handshake_timeout = timeout;
+        self
+    }
+
+    /// Sets the initial window size (in bytes) for HTTP/2 stream-level flow control for received
+    /// data.
+    ///
+    /// The default value is 65,535 and is good for APIs, but not for big objects.
+    pub fn initial_window_size(mut self, size: u32) -> Self {
+        self.stream_window_size = size;
+        self
+    }
+
+    /// Sets the initial window size (in bytes) for HTTP/2 connection-level flow control for
+    /// received data.
+    ///
+    /// The default value is 65,535 and is good for APIs, but not for big objects.
+    pub fn initial_connection_window_size(mut self, size: u32) -> Self {
+        self.conn_window_size = size;
+        self
+    }
+
+    /// Set keep-alive period for opened connection.
+    ///
+    /// Keep-alive period is the period between connection usage. If
+    /// the delay between repeated usages of the same connection
+    /// exceeds this period, the connection is closed.
+    /// Default keep-alive period is 15 seconds.
+    pub fn conn_keep_alive(mut self, dur: Duration) -> Self {
+        self.conn_keep_alive = dur;
+        self
+    }
+
+    /// Set max lifetime period for connection.
+    ///
+    /// Connection lifetime is max lifetime of any opened connection
+    /// until it is closed regardless of keep-alive period.
+    /// Default lifetime period is 75 seconds.
+    pub fn conn_lifetime(mut self, dur: Duration) -> Self {
+        self.conn_lifetime = dur;
+        self
+    }
+
+    /// Set local IP Address the connector would use for establishing connection.
+    pub fn local_address(mut self, addr: IpAddr) -> Self {
+        self.local_address = Some(addr);
+        self
     }
 }

--- a/awc/src/client/h2proto.rs
+++ b/awc/src/client/h2proto.rs
@@ -19,7 +19,6 @@ use http::{
 use log::trace;
 
 use super::{
-    config::ConnectorConfig,
     connection::{ConnectionIo, H2Connection},
     error::SendRequestError,
 };
@@ -186,12 +185,13 @@ where
 
 pub(crate) fn handshake<Io: ConnectionIo>(
     io: Io,
-    config: &ConnectorConfig,
+    stream_window_size: u32,
+    conn_window_size: u32,
 ) -> impl Future<Output = Result<(SendRequest<Bytes>, Connection<Io, Bytes>), h2::Error>> {
     let mut builder = Builder::new();
     builder
-        .initial_window_size(config.stream_window_size)
-        .initial_connection_window_size(config.conn_window_size)
+        .initial_window_size(stream_window_size)
+        .initial_connection_window_size(conn_window_size)
         .enable_push(false);
     builder.handshake(io)
 }

--- a/awc/src/client/mod.rs
+++ b/awc/src/client/mod.rs
@@ -20,6 +20,7 @@ mod h2proto;
 mod pool;
 
 pub use self::{
+    config::ConnectConfig,
     connection::{Connection, ConnectionIo},
     connector::{Connector, ConnectorService, HostnameWithSni},
     error::{ConnectError, FreezeRequestError, InvalidUrl, SendRequestError},
@@ -49,6 +50,7 @@ pub struct Connect {
     pub port: u16,
     pub tls: bool,
     pub addr: Option<std::net::SocketAddr>,
+    pub config: Option<Rc<ConnectConfig>>,
 }
 
 /// An asynchronous HTTP and WebSocket client.

--- a/awc/src/client/mod.rs
+++ b/awc/src/client/mod.rs
@@ -1,6 +1,6 @@
 //! HTTP client.
 
-use std::{rc::Rc, time::Duration};
+use std::{ops::Deref, rc::Rc, time::Duration};
 
 use actix_http::{error::HttpError, header::HeaderMap, Method, RequestHead, Uri};
 use actix_rt::net::TcpStream;
@@ -21,13 +21,33 @@ mod pool;
 
 pub use self::{
     connection::{Connection, ConnectionIo},
-    connector::{Connector, ConnectorService},
+    connector::{Connector, ConnectorService, HostnameWithSni},
     error::{ConnectError, FreezeRequestError, InvalidUrl, SendRequestError},
 };
 
-#[derive(Clone)]
+#[derive(Clone, Hash, PartialEq, Eq)]
+pub enum ServerName {
+    Owned(String),
+    Borrowed(Rc<String>),
+}
+
+impl Deref for ServerName {
+    type Target = str;
+
+    fn deref(&self) -> &str {
+        match self {
+            ServerName::Owned(ref s) => s,
+            ServerName::Borrowed(ref s) => s,
+        }
+    }
+}
+
+#[derive(Clone, Hash, PartialEq, Eq)]
 pub struct Connect {
-    pub uri: Uri,
+    pub hostname: String,
+    pub sni_host: Option<ServerName>,
+    pub port: u16,
+    pub tls: bool,
     pub addr: Option<std::net::SocketAddr>,
 }
 
@@ -79,8 +99,8 @@ impl Client {
     /// This function is equivalent of `ClientBuilder::new()`.
     pub fn builder() -> ClientBuilder<
         impl Service<
-                ConnectInfo<Uri>,
-                Response = TcpConnection<Uri, TcpStream>,
+                ConnectInfo<HostnameWithSni>,
+                Response = TcpConnection<HostnameWithSni, TcpStream>,
                 Error = TcpConnectError,
             > + Clone,
     > {

--- a/awc/src/frozen.rs
+++ b/awc/src/frozen.rs
@@ -11,7 +11,7 @@ use futures_core::Stream;
 use serde::Serialize;
 
 use crate::{
-    client::ClientConfig,
+    client::{ClientConfig, ServerName},
     sender::{RequestSender, SendClientRequest},
     BoxError,
 };
@@ -26,6 +26,7 @@ pub struct FrozenClientRequest {
     pub(crate) response_decompress: bool,
     pub(crate) timeout: Option<Duration>,
     pub(crate) config: ClientConfig,
+    pub(crate) sni_host: Option<ServerName>,
 }
 
 impl FrozenClientRequest {
@@ -54,6 +55,7 @@ impl FrozenClientRequest {
             self.response_decompress,
             self.timeout,
             &self.config,
+            self.sni_host.clone(),
             body,
         )
     }
@@ -65,6 +67,7 @@ impl FrozenClientRequest {
             self.response_decompress,
             self.timeout,
             &self.config,
+            self.sni_host.clone(),
             value,
         )
     }
@@ -76,6 +79,7 @@ impl FrozenClientRequest {
             self.response_decompress,
             self.timeout,
             &self.config,
+            self.sni_host.clone(),
             value,
         )
     }
@@ -91,6 +95,7 @@ impl FrozenClientRequest {
             self.response_decompress,
             self.timeout,
             &self.config,
+            self.sni_host.clone(),
             stream,
         )
     }
@@ -102,6 +107,7 @@ impl FrozenClientRequest {
             self.response_decompress,
             self.timeout,
             &self.config,
+            self.sni_host.clone(),
         )
     }
 
@@ -156,6 +162,7 @@ impl FrozenSendBuilder {
             self.req.response_decompress,
             self.req.timeout,
             &self.req.config,
+            self.req.sni_host.clone(),
             body,
         )
     }
@@ -171,6 +178,7 @@ impl FrozenSendBuilder {
             self.req.response_decompress,
             self.req.timeout,
             &self.req.config,
+            self.req.sni_host.clone(),
             value,
         )
     }
@@ -186,6 +194,7 @@ impl FrozenSendBuilder {
             self.req.response_decompress,
             self.req.timeout,
             &self.req.config,
+            self.req.sni_host.clone(),
             value,
         )
     }
@@ -205,6 +214,7 @@ impl FrozenSendBuilder {
             self.req.response_decompress,
             self.req.timeout,
             &self.req.config,
+            self.req.sni_host.clone(),
             stream,
         )
     }
@@ -220,6 +230,7 @@ impl FrozenSendBuilder {
             self.req.response_decompress,
             self.req.timeout,
             &self.req.config,
+            self.req.sni_host.clone(),
         )
     }
 }

--- a/awc/src/frozen.rs
+++ b/awc/src/frozen.rs
@@ -11,7 +11,7 @@ use futures_core::Stream;
 use serde::Serialize;
 
 use crate::{
-    client::{ClientConfig, ServerName},
+    client::{ClientConfig, ConnectConfig, ServerName},
     sender::{RequestSender, SendClientRequest},
     BoxError,
 };
@@ -27,6 +27,7 @@ pub struct FrozenClientRequest {
     pub(crate) timeout: Option<Duration>,
     pub(crate) config: ClientConfig,
     pub(crate) sni_host: Option<ServerName>,
+    pub(crate) connect_config: Option<Rc<ConnectConfig>>,
 }
 
 impl FrozenClientRequest {
@@ -56,6 +57,7 @@ impl FrozenClientRequest {
             self.timeout,
             &self.config,
             self.sni_host.clone(),
+            self.connect_config.clone(),
             body,
         )
     }
@@ -68,6 +70,7 @@ impl FrozenClientRequest {
             self.timeout,
             &self.config,
             self.sni_host.clone(),
+            self.connect_config.clone(),
             value,
         )
     }
@@ -80,6 +83,7 @@ impl FrozenClientRequest {
             self.timeout,
             &self.config,
             self.sni_host.clone(),
+            self.connect_config.clone(),
             value,
         )
     }
@@ -96,6 +100,7 @@ impl FrozenClientRequest {
             self.timeout,
             &self.config,
             self.sni_host.clone(),
+            self.connect_config.clone(),
             stream,
         )
     }
@@ -108,6 +113,7 @@ impl FrozenClientRequest {
             self.timeout,
             &self.config,
             self.sni_host.clone(),
+            self.connect_config.clone(),
         )
     }
 
@@ -163,6 +169,7 @@ impl FrozenSendBuilder {
             self.req.timeout,
             &self.req.config,
             self.req.sni_host.clone(),
+            self.req.connect_config,
             body,
         )
     }
@@ -179,6 +186,7 @@ impl FrozenSendBuilder {
             self.req.timeout,
             &self.req.config,
             self.req.sni_host.clone(),
+            self.req.connect_config,
             value,
         )
     }
@@ -195,6 +203,7 @@ impl FrozenSendBuilder {
             self.req.timeout,
             &self.req.config,
             self.req.sni_host.clone(),
+            self.req.connect_config,
             value,
         )
     }
@@ -215,6 +224,7 @@ impl FrozenSendBuilder {
             self.req.timeout,
             &self.req.config,
             self.req.sni_host.clone(),
+            self.req.connect_config,
             stream,
         )
     }
@@ -231,6 +241,7 @@ impl FrozenSendBuilder {
             self.req.timeout,
             &self.req.config,
             self.req.sni_host.clone(),
+            self.req.connect_config,
         )
     }
 }

--- a/awc/src/middleware/redirect.rs
+++ b/awc/src/middleware/redirect.rs
@@ -73,13 +73,13 @@ where
 
     fn call(&self, req: ConnectRequest) -> Self::Future {
         match req {
-            ConnectRequest::Tunnel(head, addr, sni_host) => {
+            ConnectRequest::Tunnel(head, addr, sni_host, config) => {
                 let fut = self
                     .connector
-                    .call(ConnectRequest::Tunnel(head, addr, sni_host));
+                    .call(ConnectRequest::Tunnel(head, addr, sni_host, config));
                 RedirectServiceFuture::Tunnel { fut }
             }
-            ConnectRequest::Client(head, body, addr, sni_host) => {
+            ConnectRequest::Client(head, body, addr, sni_host, config) => {
                 let connector = Rc::clone(&self.connector);
                 let max_redirect_times = self.max_redirect_times;
 
@@ -98,7 +98,8 @@ where
                     _ => None,
                 };
 
-                let fut = connector.call(ConnectRequest::Client(head, body, addr, sni_host));
+                let fut =
+                    connector.call(ConnectRequest::Client(head, body, addr, sni_host, config));
 
                 RedirectServiceFuture::Client {
                     fut,
@@ -223,8 +224,8 @@ where
                         let fut = connector
                             .as_ref()
                             .unwrap()
-                            // @TODO find a way to get sni host
-                            .call(ConnectRequest::Client(head, body_new, addr, None));
+                            // @TODO find a way to get sni host and config
+                            .call(ConnectRequest::Client(head, body_new, addr, None, None));
 
                         self.set(RedirectServiceFuture::Client {
                             fut,

--- a/awc/src/middleware/redirect.rs
+++ b/awc/src/middleware/redirect.rs
@@ -73,11 +73,13 @@ where
 
     fn call(&self, req: ConnectRequest) -> Self::Future {
         match req {
-            ConnectRequest::Tunnel(head, addr) => {
-                let fut = self.connector.call(ConnectRequest::Tunnel(head, addr));
+            ConnectRequest::Tunnel(head, addr, sni_host) => {
+                let fut = self
+                    .connector
+                    .call(ConnectRequest::Tunnel(head, addr, sni_host));
                 RedirectServiceFuture::Tunnel { fut }
             }
-            ConnectRequest::Client(head, body, addr) => {
+            ConnectRequest::Client(head, body, addr, sni_host) => {
                 let connector = Rc::clone(&self.connector);
                 let max_redirect_times = self.max_redirect_times;
 
@@ -96,7 +98,7 @@ where
                     _ => None,
                 };
 
-                let fut = connector.call(ConnectRequest::Client(head, body, addr));
+                let fut = connector.call(ConnectRequest::Client(head, body, addr, sni_host));
 
                 RedirectServiceFuture::Client {
                     fut,
@@ -221,7 +223,8 @@ where
                         let fut = connector
                             .as_ref()
                             .unwrap()
-                            .call(ConnectRequest::Client(head, body_new, addr));
+                            // @TODO find a way to get sni host
+                            .call(ConnectRequest::Client(head, body_new, addr, None));
 
                         self.set(RedirectServiceFuture::Client {
                             fut,

--- a/awc/src/request.rs
+++ b/awc/src/request.rs
@@ -14,7 +14,7 @@ use serde::Serialize;
 #[cfg(feature = "cookies")]
 use crate::cookie::{Cookie, CookieJar};
 use crate::{
-    client::ClientConfig,
+    client::{ClientConfig, ServerName},
     error::{FreezeRequestError, InvalidUrl},
     frozen::FrozenClientRequest,
     sender::{PrepForSendingError, RequestSender, SendClientRequest},
@@ -48,6 +48,7 @@ pub struct ClientRequest {
     response_decompress: bool,
     timeout: Option<Duration>,
     config: ClientConfig,
+    sni_host: Option<ServerName>,
 
     #[cfg(feature = "cookies")]
     cookies: Option<CookieJar>,
@@ -69,6 +70,7 @@ impl ClientRequest {
             cookies: None,
             timeout: None,
             response_decompress: true,
+            sni_host: None,
         }
         .method(method)
         .uri(uri)
@@ -306,6 +308,12 @@ impl ClientRequest {
         Ok(self)
     }
 
+    /// Set SNI (Server Name Indication) host for this request.
+    pub fn sni_host(mut self, host: impl Into<String>) -> Self {
+        self.sni_host = Some(ServerName::Owned(host.into()));
+        self
+    }
+
     /// Freeze request builder and construct `FrozenClientRequest`,
     /// which could be used for sending same request multiple times.
     pub fn freeze(self) -> Result<FrozenClientRequest, FreezeRequestError> {
@@ -320,6 +328,10 @@ impl ClientRequest {
             response_decompress: slf.response_decompress,
             timeout: slf.timeout,
             config: slf.config,
+            sni_host: slf.sni_host.map(|v| match v {
+                ServerName::Borrowed(r) => ServerName::Borrowed(r),
+                ServerName::Owned(o) => ServerName::Borrowed(Rc::new(o)),
+            }),
         };
 
         Ok(request)
@@ -340,6 +352,7 @@ impl ClientRequest {
             slf.response_decompress,
             slf.timeout,
             &slf.config,
+            slf.sni_host,
             body,
         )
     }
@@ -356,6 +369,7 @@ impl ClientRequest {
             slf.response_decompress,
             slf.timeout,
             &slf.config,
+            slf.sni_host,
             value,
         )
     }
@@ -374,6 +388,7 @@ impl ClientRequest {
             slf.response_decompress,
             slf.timeout,
             &slf.config,
+            slf.sni_host,
             value,
         )
     }
@@ -394,6 +409,7 @@ impl ClientRequest {
             slf.response_decompress,
             slf.timeout,
             &slf.config,
+            slf.sni_host,
             stream,
         )
     }
@@ -410,6 +426,7 @@ impl ClientRequest {
             slf.response_decompress,
             slf.timeout,
             &slf.config,
+            slf.sni_host,
         )
     }
 

--- a/awc/src/ws.rs
+++ b/awc/src/ws.rs
@@ -26,7 +26,7 @@
 //! }
 //! ```
 
-use std::{fmt, net::SocketAddr, str};
+use std::{fmt, net::SocketAddr, rc::Rc, str};
 
 use actix_codec::Framed;
 pub use actix_http::ws::{CloseCode, CloseReason, Codec, Frame, Message};
@@ -38,7 +38,7 @@ use base64::prelude::*;
 #[cfg(feature = "cookies")]
 use crate::cookie::{Cookie, CookieJar};
 use crate::{
-    client::{ClientConfig, ServerName},
+    client::{ClientConfig, ConnectConfig, ServerName},
     connect::{BoxedSocket, ConnectRequest},
     error::{HttpError, InvalidUrl, SendRequestError, WsClientError},
     http::{
@@ -59,6 +59,7 @@ pub struct WebsocketsRequest {
     server_mode: bool,
     config: ClientConfig,
     sni_host: Option<ServerName>,
+    connect_config: Option<ConnectConfig>,
 
     #[cfg(feature = "cookies")]
     cookies: Option<CookieJar>,
@@ -98,6 +99,7 @@ impl WebsocketsRequest {
             #[cfg(feature = "cookies")]
             cookies: None,
             sni_host: None,
+            connect_config: None,
         }
     }
 
@@ -107,6 +109,15 @@ impl WebsocketsRequest {
     /// provided url's host name get resolved.
     pub fn address(mut self, addr: SocketAddr) -> Self {
         self.addr = Some(addr);
+        self
+    }
+
+    /// Set specific connector configuration for this request.
+    ///
+    /// Not all config may be applied to the request, it depends on the connector and also
+    /// if there is already a connection established.
+    pub fn connector_config(mut self, config: ConnectConfig) -> Self {
+        self.connect_config = Some(config);
         self
     }
 
@@ -346,7 +357,12 @@ impl WebsocketsRequest {
         let max_size = self.max_size;
         let server_mode = self.server_mode;
 
-        let req = ConnectRequest::Tunnel(head, self.addr, self.sni_host);
+        let req = ConnectRequest::Tunnel(
+            head,
+            self.addr,
+            self.sni_host,
+            self.connect_config.map(Rc::new),
+        );
 
         let fut = self.config.connector.call(req);
 


### PR DESCRIPTION
## PR Type

Feature

## PR Checklist

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [ ] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.

## Overview

Goal of this PR is to allow configure some connector options per request instead of needed different clients 

It's not finished but i'm wondering how far this should go.

Since it's based on #3522 it allow to have a different pool on different conn life time or other config (like h2 windows size) which will be better as it ensure proper connection option.

