### PR TITLE
fix(http2): remove host header when using http2

### DIFF
--- a/awc/CHANGES.md
+++ b/awc/CHANGES.md
@@ -5,6 +5,7 @@
 - Update `brotli` dependency to `7`.
 - Prevent panics on connection pool drop when Tokio runtime is shutdown early.
 - Minimum supported Rust version (MSRV) is now 1.75.
+- Do not send `Host` header on HTTP/2 requests, as it is not required, and some web servers may reject it.
 
 ## 3.5.1
 

--- a/awc/src/client/h2proto.rs
+++ b/awc/src/client/h2proto.rs
@@ -12,7 +12,7 @@ use h2::{
     SendStream,
 };
 use http::{
-    header::{HeaderValue, CONNECTION, CONTENT_LENGTH, TRANSFER_ENCODING},
+    header::{HeaderValue, CONNECTION, CONTENT_LENGTH, HOST, TRANSFER_ENCODING},
     request::Request,
     Method, Version,
 };
@@ -97,7 +97,7 @@ where
             // TODO: consider skipping other headers according to:
             //       https://datatracker.ietf.org/doc/html/rfc7540#section-8.1.2.2
             // omit HTTP/1.x only headers
-            CONNECTION | TRANSFER_ENCODING => continue,
+            CONNECTION | TRANSFER_ENCODING | HOST => continue,
             CONTENT_LENGTH if skip_len => continue,
             // DATE => has_date = true,
             _ => {}


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type

<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->

Fix 

## PR Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [X] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.

## Overview

<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

<!-- If this PR fixes or closes an issue, reference it here. -->
Fix https://github.com/actix/actix-web/issues/3495

The host header is not used in http2 as this information should be read from ":authority" pseudo header, so it's safe to ignore this header and will fix nginx returning a 400 bad request response when having this header on a http2 request
