### PR TITLE
fix(files): Permit serving .well-known directories

### DIFF
--- a/actix-files/CHANGES.md
+++ b/actix-files/CHANGES.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Minimum supported Rust version (MSRV) is now 1.75.
+- Permit serving `.well-known` files when serving dotfiles is otherwise disallowed.
 
 ## 0.6.6
 

--- a/actix-files/CHANGES.md
+++ b/actix-files/CHANGES.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Minimum supported Rust version (MSRV) is now 1.75.
-- Permit serving `.well-known` files when serving dotfiles is otherwise disallowed.
+- Allow serving `.well-known` files when serving dotfiles is otherwise disallowed.
 
 ## 0.6.6
 

--- a/actix-files/src/path_buf.rs
+++ b/actix-files/src/path_buf.rs
@@ -44,7 +44,7 @@ impl PathBufWrap {
             if segment == ".." {
                 segment_count -= 1;
                 buf.pop();
-            } else if !hidden_files && segment.starts_with('.') {
+            } else if segment != ".well-known" && !hidden_files && segment.starts_with('.') {
                 return Err(UriSegmentError::BadStart('.'));
             } else if segment.starts_with('*') {
                 return Err(UriSegmentError::BadStart('*'));
@@ -106,6 +106,10 @@ mod tests {
             Err(UriSegmentError::BadStart('.'))
         );
         assert_eq!(
+            PathBufWrap::from_str("/.well-known/test/.tt").map(|t| t.0),
+            Err(UriSegmentError::BadStart('.'))
+        );
+        assert_eq!(
             PathBufWrap::from_str("/test/*tt").map(|t| t.0),
             Err(UriSegmentError::BadStart('*'))
         );
@@ -141,6 +145,33 @@ mod tests {
         assert_eq!(
             PathBufWrap::parse_path("/test/.tt", true).unwrap().0,
             PathBuf::from_iter(vec!["test", ".tt"])
+        );
+    }
+
+    #[test]
+    fn test_parse_well_known() {
+        assert_eq!(
+            PathBufWrap::parse_path("/.well-known/test/.tt", false).map(|t| t.0),
+            Err(UriSegmentError::BadStart('.'))
+        );
+        assert_eq!(
+            PathBufWrap::parse_path("/.well-known/test/foo", false)
+                .unwrap()
+                .0,
+            PathBuf::from_iter(vec![".well-known", "test", "foo"])
+        );
+
+        assert_eq!(
+            PathBufWrap::parse_path("/.well-known/test/.tt", true)
+                .unwrap()
+                .0,
+            PathBuf::from_iter(vec![".well-known", "test", ".tt"])
+        );
+        assert_eq!(
+            PathBufWrap::parse_path("/.well-known/test/foo", true)
+                .unwrap()
+                .0,
+            PathBuf::from_iter(vec![".well-known", "test", "foo"])
         );
     }
 

--- a/actix-files/src/path_buf.rs
+++ b/actix-files/src/path_buf.rs
@@ -40,6 +40,7 @@ impl PathBufWrap {
             return Err(UriSegmentError::BadChar('/'));
         }
 
+        // disallow invalid or suspicious path segments
         for segment in path.split('/') {
             if segment == ".." {
                 segment_count -= 1;

--- a/actix-web/CHANGES.md
+++ b/actix-web/CHANGES.md
@@ -5,6 +5,7 @@
 - On Windows, an error is now returned from `HttpServer::bind()` (or TLS variants) when binding to a socket that's already in use.
 - Update `brotli` dependency to `7`.
 - Minimum supported Rust version (MSRV) is now 1.75.
+- Allow serving `.well-known` files when serving dotfiles is otherwise disallowed.
 
 ## 4.9.0
 


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type

<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->

Bug Fix

## PR Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.

## Overview

<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

Previously, when hidden files are disallowed, the `.well-known` directory is also disallowed. There are [several cases](https://en.wikipedia.org/wiki/Well-known_URI#List_of_well-known_URIs) where a webserver might serve one or more static files from that directory, so actix-files should permit that behavior without needing to allow reading all hidden files.

With this change, segments that match `".well-known"` are exempt from the hidden-files check.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
