### PR TITLE
feat(awc): allow to set a specific sni host on the request

### DIFF
--- a/awc/CHANGES.md
+++ b/awc/CHANGES.md
@@ -5,6 +5,7 @@
 - Update `brotli` dependency to `7`.
 - Prevent panics on connection pool drop when Tokio runtime is shutdown early.
 - Minimum supported Rust version (MSRV) is now 1.75.
+- Allow to set a specific SNI hostname on the request for TLS connections.
 
 ## 3.5.1
 

--- a/awc/src/builder.rs
+++ b/awc/src/builder.rs
@@ -3,7 +3,6 @@ use std::{fmt, net::IpAddr, rc::Rc, time::Duration};
 use actix_http::{
     error::HttpError,
     header::{self, HeaderMap, HeaderName, TryIntoHeaderPair},
-    Uri,
 };
 use actix_rt::net::{ActixStream, TcpStream};
 use actix_service::{boxed, Service};
@@ -11,7 +10,8 @@ use base64::prelude::*;
 
 use crate::{
     client::{
-        ClientConfig, ConnectInfo, Connector, ConnectorService, TcpConnectError, TcpConnection,
+        ClientConfig, ConnectInfo, Connector, ConnectorService, HostnameWithSni, TcpConnectError,
+        TcpConnection,
     },
     connect::DefaultConnector,
     error::SendRequestError,
@@ -46,8 +46,8 @@ impl ClientBuilder {
     #[allow(clippy::new_ret_no_self)]
     pub fn new() -> ClientBuilder<
         impl Service<
-                ConnectInfo<Uri>,
-                Response = TcpConnection<Uri, TcpStream>,
+                ConnectInfo<HostnameWithSni>,
+                Response = TcpConnection<HostnameWithSni, TcpStream>,
                 Error = TcpConnectError,
             > + Clone,
         (),
@@ -69,16 +69,22 @@ impl ClientBuilder {
 
 impl<S, Io, M> ClientBuilder<S, M>
 where
-    S: Service<ConnectInfo<Uri>, Response = TcpConnection<Uri, Io>, Error = TcpConnectError>
-        + Clone
+    S: Service<
+            ConnectInfo<HostnameWithSni>,
+            Response = TcpConnection<HostnameWithSni, Io>,
+            Error = TcpConnectError,
+        > + Clone
         + 'static,
     Io: ActixStream + fmt::Debug + 'static,
 {
     /// Use custom connector service.
     pub fn connector<S1, Io1>(self, connector: Connector<S1>) -> ClientBuilder<S1, M>
     where
-        S1: Service<ConnectInfo<Uri>, Response = TcpConnection<Uri, Io1>, Error = TcpConnectError>
-            + Clone
+        S1: Service<
+                ConnectInfo<HostnameWithSni>,
+                Response = TcpConnection<HostnameWithSni, Io1>,
+                Error = TcpConnectError,
+            > + Clone
             + 'static,
         Io1: ActixStream + fmt::Debug + 'static,
     {

--- a/awc/src/client/mod.rs
+++ b/awc/src/client/mod.rs
@@ -1,6 +1,6 @@
 //! HTTP client.
 
-use std::{rc::Rc, time::Duration};
+use std::{ops::Deref, rc::Rc, time::Duration};
 
 use actix_http::{error::HttpError, header::HeaderMap, Method, RequestHead, Uri};
 use actix_rt::net::TcpStream;
@@ -21,13 +21,33 @@ mod pool;
 
 pub use self::{
     connection::{Connection, ConnectionIo},
-    connector::{Connector, ConnectorService},
+    connector::{Connector, ConnectorService, HostnameWithSni},
     error::{ConnectError, FreezeRequestError, InvalidUrl, SendRequestError},
 };
 
-#[derive(Clone)]
+#[derive(Clone, Hash, PartialEq, Eq)]
+pub enum ServerName {
+    Owned(String),
+    Borrowed(Rc<String>),
+}
+
+impl Deref for ServerName {
+    type Target = str;
+
+    fn deref(&self) -> &str {
+        match self {
+            ServerName::Owned(ref s) => s,
+            ServerName::Borrowed(ref s) => s,
+        }
+    }
+}
+
+#[derive(Clone, Hash, PartialEq, Eq)]
 pub struct Connect {
-    pub uri: Uri,
+    pub hostname: String,
+    pub sni_host: Option<ServerName>,
+    pub port: u16,
+    pub tls: bool,
     pub addr: Option<std::net::SocketAddr>,
 }
 
@@ -79,8 +99,8 @@ impl Client {
     /// This function is equivalent of `ClientBuilder::new()`.
     pub fn builder() -> ClientBuilder<
         impl Service<
-                ConnectInfo<Uri>,
-                Response = TcpConnection<Uri, TcpStream>,
+                ConnectInfo<HostnameWithSni>,
+                Response = TcpConnection<HostnameWithSni, TcpStream>,
                 Error = TcpConnectError,
             > + Clone,
     > {

--- a/awc/src/frozen.rs
+++ b/awc/src/frozen.rs
@@ -11,7 +11,7 @@ use futures_core::Stream;
 use serde::Serialize;
 
 use crate::{
-    client::ClientConfig,
+    client::{ClientConfig, ServerName},
     sender::{RequestSender, SendClientRequest},
     BoxError,
 };
@@ -26,6 +26,7 @@ pub struct FrozenClientRequest {
     pub(crate) response_decompress: bool,
     pub(crate) timeout: Option<Duration>,
     pub(crate) config: ClientConfig,
+    pub(crate) sni_host: Option<ServerName>,
 }
 
 impl FrozenClientRequest {
@@ -54,6 +55,7 @@ impl FrozenClientRequest {
             self.response_decompress,
             self.timeout,
             &self.config,
+            self.sni_host.clone(),
             body,
         )
     }
@@ -65,6 +67,7 @@ impl FrozenClientRequest {
             self.response_decompress,
             self.timeout,
             &self.config,
+            self.sni_host.clone(),
             value,
         )
     }
@@ -76,6 +79,7 @@ impl FrozenClientRequest {
             self.response_decompress,
             self.timeout,
             &self.config,
+            self.sni_host.clone(),
             value,
         )
     }
@@ -91,6 +95,7 @@ impl FrozenClientRequest {
             self.response_decompress,
             self.timeout,
             &self.config,
+            self.sni_host.clone(),
             stream,
         )
     }
@@ -102,6 +107,7 @@ impl FrozenClientRequest {
             self.response_decompress,
             self.timeout,
             &self.config,
+            self.sni_host.clone(),
         )
     }
 
@@ -156,6 +162,7 @@ impl FrozenSendBuilder {
             self.req.response_decompress,
             self.req.timeout,
             &self.req.config,
+            self.req.sni_host.clone(),
             body,
         )
     }
@@ -171,6 +178,7 @@ impl FrozenSendBuilder {
             self.req.response_decompress,
             self.req.timeout,
             &self.req.config,
+            self.req.sni_host.clone(),
             value,
         )
     }
@@ -186,6 +194,7 @@ impl FrozenSendBuilder {
             self.req.response_decompress,
             self.req.timeout,
             &self.req.config,
+            self.req.sni_host.clone(),
             value,
         )
     }
@@ -205,6 +214,7 @@ impl FrozenSendBuilder {
             self.req.response_decompress,
             self.req.timeout,
             &self.req.config,
+            self.req.sni_host.clone(),
             stream,
         )
     }
@@ -220,6 +230,7 @@ impl FrozenSendBuilder {
             self.req.response_decompress,
             self.req.timeout,
             &self.req.config,
+            self.req.sni_host.clone(),
         )
     }
 }

--- a/awc/src/middleware/redirect.rs
+++ b/awc/src/middleware/redirect.rs
@@ -73,11 +73,13 @@ where
 
     fn call(&self, req: ConnectRequest) -> Self::Future {
         match req {
-            ConnectRequest::Tunnel(head, addr) => {
-                let fut = self.connector.call(ConnectRequest::Tunnel(head, addr));
+            ConnectRequest::Tunnel(head, addr, sni_host) => {
+                let fut = self
+                    .connector
+                    .call(ConnectRequest::Tunnel(head, addr, sni_host));
                 RedirectServiceFuture::Tunnel { fut }
             }
-            ConnectRequest::Client(head, body, addr) => {
+            ConnectRequest::Client(head, body, addr, sni_host) => {
                 let connector = Rc::clone(&self.connector);
                 let max_redirect_times = self.max_redirect_times;
 
@@ -96,7 +98,7 @@ where
                     _ => None,
                 };
 
-                let fut = connector.call(ConnectRequest::Client(head, body, addr));
+                let fut = connector.call(ConnectRequest::Client(head, body, addr, sni_host));
 
                 RedirectServiceFuture::Client {
                     fut,
@@ -221,7 +223,8 @@ where
                         let fut = connector
                             .as_ref()
                             .unwrap()
-                            .call(ConnectRequest::Client(head, body_new, addr));
+                            // @TODO find a way to get sni host
+                            .call(ConnectRequest::Client(head, body_new, addr, None));
 
                         self.set(RedirectServiceFuture::Client {
                             fut,

--- a/awc/src/request.rs
+++ b/awc/src/request.rs
@@ -14,7 +14,7 @@ use serde::Serialize;
 #[cfg(feature = "cookies")]
 use crate::cookie::{Cookie, CookieJar};
 use crate::{
-    client::ClientConfig,
+    client::{ClientConfig, ServerName},
     error::{FreezeRequestError, InvalidUrl},
     frozen::FrozenClientRequest,
     sender::{PrepForSendingError, RequestSender, SendClientRequest},
@@ -48,6 +48,7 @@ pub struct ClientRequest {
     response_decompress: bool,
     timeout: Option<Duration>,
     config: ClientConfig,
+    sni_host: Option<ServerName>,
 
     #[cfg(feature = "cookies")]
     cookies: Option<CookieJar>,
@@ -69,6 +70,7 @@ impl ClientRequest {
             cookies: None,
             timeout: None,
             response_decompress: true,
+            sni_host: None,
         }
         .method(method)
         .uri(uri)
@@ -306,6 +308,12 @@ impl ClientRequest {
         Ok(self)
     }
 
+    /// Set SNI (Server Name Indication) host for this request.
+    pub fn sni_host(mut self, host: impl Into<String>) -> Self {
+        self.sni_host = Some(ServerName::Owned(host.into()));
+        self
+    }
+
     /// Freeze request builder and construct `FrozenClientRequest`,
     /// which could be used for sending same request multiple times.
     pub fn freeze(self) -> Result<FrozenClientRequest, FreezeRequestError> {
@@ -320,6 +328,10 @@ impl ClientRequest {
             response_decompress: slf.response_decompress,
             timeout: slf.timeout,
             config: slf.config,
+            sni_host: slf.sni_host.map(|v| match v {
+                ServerName::Borrowed(r) => ServerName::Borrowed(r),
+                ServerName::Owned(o) => ServerName::Borrowed(Rc::new(o)),
+            }),
         };
 
         Ok(request)
@@ -340,6 +352,7 @@ impl ClientRequest {
             slf.response_decompress,
             slf.timeout,
             &slf.config,
+            slf.sni_host,
             body,
         )
     }
@@ -356,6 +369,7 @@ impl ClientRequest {
             slf.response_decompress,
             slf.timeout,
             &slf.config,
+            slf.sni_host,
             value,
         )
     }
@@ -374,6 +388,7 @@ impl ClientRequest {
             slf.response_decompress,
             slf.timeout,
             &slf.config,
+            slf.sni_host,
             value,
         )
     }
@@ -394,6 +409,7 @@ impl ClientRequest {
             slf.response_decompress,
             slf.timeout,
             &slf.config,
+            slf.sni_host,
             stream,
         )
     }
@@ -410,6 +426,7 @@ impl ClientRequest {
             slf.response_decompress,
             slf.timeout,
             &slf.config,
+            slf.sni_host,
         )
     }
 


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type

<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->

Feature

## PR Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [ ] (Team) Label with affected crates and semver status.

## Overview

<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

This PR allow client to set a specific sni host for a request, this can be useful if you want to connect to a specific hostname, but do SSL validation on another one

In order to do that some thing have been changed : 

 * Uri is no longer cloned during connection, instead a specific object is created with only wanted information, it may be better as we don't need all uri information in the connection (only hostname, port and if it should use tls most of the time), so this should also reduce memory consumption on certain case.
 * A new object is used for tcp / tls connection : HostnameWithSni (can be changed to another name), basically it's the host with the optional sni host and a state (to know which host to use given the connector: we use hostname during tcp, for dns resolution if needed, we use sni_host if available during tls connection for server name)
 * The pool now use the connect object for its key of pooled connection, i believe the old way was not adequate (did not do test, since it was only relying on the authority of the uri, if you pass a specific local address by example, after a first request it would not have use the existing pool, and i believe it should not in this case ?)
 
There may be better implementation on some point, as i have done what it's the most pragmatic way as a first step, will be happy to fix those if you have some inputs.
