### PR TITLE
feat(web): add trusted proxies feature

### DIFF
--- a/actix-web/CHANGES.md
+++ b/actix-web/CHANGES.md
@@ -5,6 +5,7 @@
 - On Windows, an error is now returned from `HttpServer::bind()` (or TLS variants) when binding to a socket that's already in use.
 - Update `brotli` dependency to `7`.
 - Minimum supported Rust version (MSRV) is now 1.75.
+- Add trusted proxies features to allow for customizing the list of trusted proxies and headers for determining host, scheme and ip of the `ConnectionInfo` object.
 
 ## 4.9.0
 

--- a/actix-web/Cargo.toml
+++ b/actix-web/Cargo.toml
@@ -152,6 +152,7 @@ futures-core = { version = "0.3.17", default-features = false }
 futures-util = { version = "0.3.17", default-features = false }
 itoa = "1"
 impl-more = "0.1.4"
+ipnet = "2.10.1"
 language-tags = "0.3"
 log = "0.4"
 mime = "0.3"

--- a/actix-web/src/config.rs
+++ b/actix-web/src/config.rs
@@ -14,6 +14,7 @@ use crate::{
         AppServiceFactory, BoxedHttpServiceFactory, HttpServiceFactory, ServiceFactoryWrapper,
         ServiceRequest, ServiceResponse,
     },
+    trusted_proxies::TrustedProxies,
 };
 
 type Guards = Vec<Box<dyn Guard>>;
@@ -112,17 +113,28 @@ pub struct AppConfig {
     secure: bool,
     host: String,
     addr: SocketAddr,
+    trusted_proxies: TrustedProxies,
 }
 
 impl AppConfig {
-    pub(crate) fn new(secure: bool, host: String, addr: SocketAddr) -> Self {
-        AppConfig { secure, host, addr }
+    pub(crate) fn new(
+        secure: bool,
+        host: String,
+        addr: SocketAddr,
+        trusted_proxies: TrustedProxies,
+    ) -> Self {
+        AppConfig {
+            secure,
+            host,
+            addr,
+            trusted_proxies,
+        }
     }
 
     /// Needed in actix-test crate. Semver exempt.
     #[doc(hidden)]
     pub fn __priv_test_new(secure: bool, host: String, addr: SocketAddr) -> Self {
-        AppConfig::new(secure, host, addr)
+        AppConfig::new(secure, host, addr, TrustedProxies::default())
     }
 
     /// Server host name.
@@ -144,6 +156,17 @@ impl AppConfig {
     /// Returns the socket address of the local half of this TCP connection.
     pub fn local_addr(&self) -> SocketAddr {
         self.addr
+    }
+
+    /// Returns the trusted proxies list.
+    pub fn trusted_proxies(&self) -> &TrustedProxies {
+        &self.trusted_proxies
+    }
+
+    /// Set the trusted proxies
+    #[cfg(test)]
+    pub fn set_trusted_proxies(&mut self, proxies: TrustedProxies) {
+        self.trusted_proxies = proxies;
     }
 
     #[cfg(test)]
@@ -168,6 +191,7 @@ impl Default for AppConfig {
             false,
             "localhost:8080".to_owned(),
             "127.0.0.1:8080".parse().unwrap(),
+            TrustedProxies::default(),
         )
     }
 }

--- a/actix-web/src/lib.rs
+++ b/actix-web/src/lib.rs
@@ -105,6 +105,7 @@ mod server;
 mod service;
 pub mod test;
 mod thin_data;
+pub mod trusted_proxies;
 pub(crate) mod types;
 pub mod web;
 

--- a/actix-web/src/middleware/logger.rs
+++ b/actix-web/src/middleware/logger.rs
@@ -898,8 +898,10 @@ mod tests {
     #[actix_rt::test]
     async fn test_remote_addr_format() {
         let mut format = Format::new("%{r}a");
+        let addr = "127.0.0.1:8080".parse().unwrap();
 
         let req = TestRequest::default()
+            .peer_addr(addr)
             .insert_header((
                 header::FORWARDED,
                 header::HeaderValue::from_static("for=192.0.2.60;proto=http;by=203.0.113.43"),

--- a/actix-web/src/test/test_request.rs
+++ b/actix-web/src/test/test_request.rs
@@ -5,6 +5,8 @@ use serde::Serialize;
 
 #[cfg(feature = "cookies")]
 use crate::cookie::{Cookie, CookieJar};
+#[cfg(test)]
+use crate::trusted_proxies::TrustedProxies;
 use crate::{
     app_service::AppInitServiceState,
     config::AppConfig,
@@ -226,6 +228,13 @@ impl TestRequest {
     #[cfg(test)]
     pub(crate) fn rmap(mut self, rmap: ResourceMap) -> Self {
         self.rmap = rmap;
+        self
+    }
+
+    /// Set the trusted proxies for this request.
+    #[cfg(test)]
+    pub fn set_trusted_proxies(mut self, trusted_proxies: TrustedProxies) -> Self {
+        self.config.set_trusted_proxies(trusted_proxies);
         self
     }
 

--- a/actix-web/src/trusted_proxies.rs
+++ b/actix-web/src/trusted_proxies.rs
@@ -1,0 +1,106 @@
+use std::net::IpAddr;
+
+use actix_http::header::{HeaderName, FORWARDED};
+use ipnet::{AddrParseError, IpNet};
+
+/// TrustedProxies is a helper struct to manage trusted proxies and headers
+///
+/// This is used to determine if information from a request can be trusted or not.
+///
+/// By default, it trusts the following:
+///   - IPV4 Loopback
+///   - IPV4 Private Networks
+///   - IPV6 Loopback
+///   - IPV6 Private Networks
+///
+/// It also trusts the `FORWARDED` header by default.
+///
+/// # Example
+/// ```
+/// use actix_web::trusted_proxies::TrustedProxies;
+/// use actix_web::{web, App, HttpResponse, HttpServer};
+///
+/// let mut trusted_proxies = TrustedProxies::new_local();
+/// trusted_proxies.add_trusted_proxy("168.10.0.0/16").unwrap();
+/// trusted_proxies.add_trusted_header("X-Forwarded-For".parse().unwrap());
+///
+/// HttpServer::new(|| {
+///     App::new()
+///         .service(web::resource("/").to(|| async { "hello world" }))
+/// }).trusted_proxies(trusted_proxies);
+/// ```
+#[derive(Debug, Clone)]
+pub struct TrustedProxies(Vec<IpNet>, Vec<HeaderName>);
+
+impl Default for TrustedProxies {
+    fn default() -> Self {
+        Self::new_local()
+    }
+}
+impl TrustedProxies {
+    /// Create a new TrustedProxies instance with no trusted proxies or headers
+    pub fn new() -> Self {
+        Self(vec![], vec![])
+    }
+
+    /// Create a new TrustedProxies instance with local and private networks and FORWARDED header trusted
+    pub fn new_local() -> Self {
+        Self(
+            vec![
+                // IPV4 Loopback
+                "127.0.0.0/8".parse().unwrap(),
+                // IPV4 Private Networks
+                "10.0.0.0/8".parse().unwrap(),
+                "172.16.0.0/12".parse().unwrap(),
+                "192.168.0.0/16".parse().unwrap(),
+                // IPV6 Loopback
+                "::1/128".parse().unwrap(),
+                // IPV6 Private network
+                "fd00::/8".parse().unwrap(),
+            ],
+            vec![FORWARDED],
+        )
+    }
+
+    /// Add a trusted header to the list of trusted headers
+    pub fn add_trusted_header(&mut self, header: HeaderName) {
+        self.1.push(header);
+    }
+
+    /// Add a trusted proxy to the list of trusted proxies
+    ///
+    /// proxy can be an IP address or a CIDR
+    pub fn add_trusted_proxy(&mut self, proxy: &str) -> Result<(), AddrParseError> {
+        match proxy.parse() {
+            Ok(v) => {
+                self.0.push(v);
+
+                Ok(())
+            }
+            Err(e) => match proxy.parse::<IpAddr>() {
+                Ok(v) => {
+                    self.0.push(IpNet::from(v));
+
+                    Ok(())
+                }
+                _ => Err(e),
+            },
+        }
+    }
+
+    /// Check if a remote address is trusted given the list of trusted proxies
+    pub fn trust_ip(&self, remote_addr: &IpAddr) -> bool {
+        for proxy in &self.0 {
+            if proxy.contains(remote_addr) {
+                return true;
+            }
+        }
+
+        false
+    }
+
+    /// Check if a header is trusted
+    pub fn trust_header(&self, header: &HeaderName) -> bool {
+        self.1.contains(header)
+    }
+}


### PR DESCRIPTION
## PR Type

Feature

## PR Checklist

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.

## Overview

This PR aims to add the possibility for end user to correctly trust information from the `ConnectInfo` object : host, scheme and real ip of end user.

Actually everything is trusted which can be a security risk if some endpoint need to check the ip of end user as someone may forge a request with a `Forwarded` or `X-Forwarded-*` headers and then expose sensitive data to this person.

Even if the doc clearly state that it can be a security risk trusting this, you have to implement this logic by yourself, i do believe proposing a correct implementation for trusting ip and other headers has its place under actix also this enforce better security by default.

Current default will trust
  * IpV4 loopback address
  * IpV4 private networks
  * IpV6 loopback address
  * IpV6 private networks
  * `Forwarded` header
  
Which means that if this is merged other headers will not be trusted anymore, i'm wondering if this should be considered as a BC break then (since user may not have the same information as before given their network / proxy configuration in front of their actix web server)

