### PR TITLE
build(deps): update url requirement from 2.1 to 2.5.4

### DIFF
--- a/actix-web/Cargo.toml
+++ b/actix-web/Cargo.toml
@@ -166,7 +166,7 @@ smallvec = "1.6.1"
 tracing = "0.1.30"
 socket2 = "0.5"
 time = { version = "0.3", default-features = false, features = ["formatting"] }
-url = "2.1"
+url = "2.5.4"
 
 [dev-dependencies]
 actix-files = "0.6"


### PR DESCRIPTION
## PR Type

Bug Fix

## PR Checklist

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.

## Overview

There is a vulnerability found in idna: https://rustsec.org/advisories/RUSTSEC-2024-0421

This PR updates the version of the "url" package in actix-web/Cargo.toml to 2.5.4, which uses a newer version of the idna package.