### PR TITLE
feat(files): remove spawning a thread for each file handling, as it does more harm than actually blocking

### DIFF
--- a/actix-files/CHANGES.md
+++ b/actix-files/CHANGES.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Minimum supported Rust version (MSRV) is now 1.75.
+- Avoid spawning a thread for each file which does more harm than good
 
 ## 0.6.6
 

--- a/actix-files/src/chunked.rs
+++ b/actix-files/src/chunked.rs
@@ -80,22 +80,17 @@ async fn chunked_read_file_callback(
 ) -> Result<(File, Bytes), Error> {
     use io::{Read as _, Seek as _};
 
-    let res = actix_web::web::block(move || {
-        let mut buf = Vec::with_capacity(max_bytes);
+    let mut buf = Vec::with_capacity(max_bytes);
 
-        file.seek(io::SeekFrom::Start(offset))?;
+    file.seek(io::SeekFrom::Start(offset))?;
 
-        let n_bytes = file.by_ref().take(max_bytes as u64).read_to_end(&mut buf)?;
+    let n_bytes = file.by_ref().take(max_bytes as u64).read_to_end(&mut buf)?;
 
-        if n_bytes == 0 {
-            Err(io::Error::from(io::ErrorKind::UnexpectedEof))
-        } else {
-            Ok((file, Bytes::from(buf)))
-        }
-    })
-    .await??;
-
-    Ok(res)
+    if n_bytes == 0 {
+        Err(Error::from(io::Error::from(io::ErrorKind::UnexpectedEof)))
+    } else {
+        Ok((file, Bytes::from(buf)))
+    }
 }
 
 #[cfg(feature = "experimental-io-uring")]


### PR DESCRIPTION
## PR Type

Fix/Feat (not always sure with those kind of patch)

## PR Checklist

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.

## Overview

I was looking at a recent comment that indicates than actix files was having bad perf, after some investigation it seems that using the sync api make it way better, than having to spawn a thread to make it async.

In my local environment i want from 11k req/s to 600k req/s (so roughly a x54 increase of performance)

It may be a problem if you only handle big files with poor fs i/io speed (so all actix web  threads will be blocked).

Maybe we could still spawn this thread if the size of the file is superior to some limit ?
