### PR TITLE
chore(ci): don't use variables to install rust nightly

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -71,10 +71,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Rust (${{ vars.RUST_VERSION_EXTERNAL_TYPES }})
+      - name: Install Rust nightly
         uses: actions-rust-lang/setup-rust-toolchain@v1.10.1
         with:
-          toolchain: ${{ vars.RUST_VERSION_EXTERNAL_TYPES }}
+          toolchain: nightly-2024-10-18
 
       - name: Install just
         uses: taiki-e/install-action@v2.45.6
@@ -87,7 +87,7 @@ jobs:
           tool: cargo-check-external-types
 
       - name: check external types
-        run: just check-external-types-all +${{ vars.RUST_VERSION_EXTERNAL_TYPES }}
+        run: just check-external-types-all +nightly-2024-10-18
 
   public-api-diff:
     runs-on: ubuntu-latest
@@ -100,10 +100,10 @@ jobs:
       - name: Checkout PR branch
         uses: actions/checkout@v4
 
-      - name: Install Rust (${{ vars.RUST_VERSION_API_DIFF }})
+      - name: Install Rust nightly
         uses: actions-rust-lang/setup-rust-toolchain@v1.10.1
         with:
-          toolchain: ${{ vars.RUST_VERSION_API_DIFF }}
+          toolchain: nightly-2024-10-18
 
       - name: Install cargo-public-api
         uses: taiki-e/install-action@v2.45.6


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type

<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->

Fix

## PR Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [ ] Format code with the latest stable rustfmt.
- [ ] (Team) Label with affected crates and semver status.

## Overview

See https://github.com/actix/actix-web/pull/3526#issuecomment-2532152530

This remove the variables from github action as external contributors / forks cannot access them
