### PR TITLE
feat(awc): allow to retrieve request head in client response

### DIFF
--- a/actix-http/src/h1/client.rs
+++ b/actix-http/src/h1/client.rs
@@ -188,16 +188,16 @@ impl Decoder for ClientPayloadCodec {
     }
 }
 
-impl Encoder<Message<(RequestHeadType, BodySize)>> for ClientCodec {
+impl Encoder<Message<(&mut RequestHeadType, BodySize)>> for ClientCodec {
     type Error = io::Error;
 
     fn encode(
         &mut self,
-        item: Message<(RequestHeadType, BodySize)>,
+        item: Message<(&mut RequestHeadType, BodySize)>,
         dst: &mut BytesMut,
     ) -> Result<(), Self::Error> {
         match item {
-            Message::Item((mut head, length)) => {
+            Message::Item((head, length)) => {
                 let inner = &mut self.inner;
                 inner.version = head.as_ref().version;
                 inner
@@ -219,7 +219,7 @@ impl Encoder<Message<(RequestHeadType, BodySize)>> for ClientCodec {
 
                 inner.encoder.encode(
                     dst,
-                    &mut head,
+                    head,
                     false,
                     false,
                     inner.version,

--- a/awc/CHANGES.md
+++ b/awc/CHANGES.md
@@ -5,6 +5,7 @@
 - Update `brotli` dependency to `7`.
 - Prevent panics on connection pool drop when Tokio runtime is shutdown early.
 - Minimum supported Rust version (MSRV) is now 1.75.
+- Allow to retrieve request head used to send the http request on `ClientResponse`
 
 ## 3.5.1
 

--- a/awc/src/client/connection.rs
+++ b/awc/src/client/connection.rs
@@ -243,7 +243,7 @@ where
         self,
         head: H,
         body: RB,
-    ) -> LocalBoxFuture<'static, Result<(ResponseHead, Payload), SendRequestError>>
+    ) -> LocalBoxFuture<'static, Result<(RequestHeadType, ResponseHead, Payload), SendRequestError>>
     where
         H: Into<RequestHeadType> + 'static,
         RB: MessageBody + 'static,
@@ -273,17 +273,24 @@ where
         head: H,
     ) -> LocalBoxFuture<
         'static,
-        Result<(ResponseHead, Framed<Connection<A, B>, ClientCodec>), SendRequestError>,
+        Result<
+            (
+                RequestHeadType,
+                ResponseHead,
+                Framed<Connection<A, B>, ClientCodec>,
+            ),
+            SendRequestError,
+        >,
     > {
         Box::pin(async move {
             match self {
                 Connection::Tcp(ConnectionType::H1(ref _conn)) => {
-                    let (head, framed) = h1proto::open_tunnel(self, head.into()).await?;
-                    Ok((head, framed))
+                    let (head, res_head, framed) = h1proto::open_tunnel(self, head.into()).await?;
+                    Ok((head, res_head, framed))
                 }
                 Connection::Tls(ConnectionType::H1(ref _conn)) => {
-                    let (head, framed) = h1proto::open_tunnel(self, head.into()).await?;
-                    Ok((head, framed))
+                    let (head, res_head, framed) = h1proto::open_tunnel(self, head.into()).await?;
+                    Ok((head, res_head, framed))
                 }
                 Connection::Tls(ConnectionType::H2(mut conn)) => {
                     conn.release();

--- a/awc/src/client/h2proto.rs
+++ b/awc/src/client/h2proto.rs
@@ -29,7 +29,7 @@ pub(crate) async fn send_request<Io, B>(
     mut io: H2Connection<Io>,
     head: RequestHeadType,
     body: B,
-) -> Result<(ResponseHead, Payload), SendRequestError>
+) -> Result<(RequestHeadType, ResponseHead, Payload), SendRequestError>
 where
     Io: ConnectionIo,
     B: MessageBody,
@@ -129,10 +129,10 @@ where
     let (parts, body) = resp.into_parts();
     let payload = if head_req { Payload::None } else { body.into() };
 
-    let mut head = ResponseHead::new(parts.status);
-    head.version = parts.version;
-    head.headers = parts.headers.into();
-    Ok((head, payload))
+    let mut res_head = ResponseHead::new(parts.status);
+    res_head.version = parts.version;
+    res_head.headers = parts.headers.into();
+    Ok((head, res_head, payload))
 }
 
 async fn send_body<B>(body: B, mut send: SendStream<Bytes>) -> Result<(), SendRequestError>

--- a/awc/src/middleware/redirect.rs
+++ b/awc/src/middleware/redirect.rs
@@ -329,6 +329,7 @@ mod tests {
         let res = client.get(srv.url("/")).send().await.unwrap();
 
         assert_eq!(res.status().as_u16(), 400);
+        assert_eq!(res.req_head().uri.path(), "/test");
     }
 
     #[actix_rt::test]

--- a/awc/src/test.rs
+++ b/awc/src/test.rs
@@ -1,6 +1,8 @@
 //! Test helpers for actix http client to use during testing.
 
-use actix_http::{h1, header::TryIntoHeaderPair, Payload, ResponseHead, StatusCode, Version};
+use actix_http::{
+    h1, header::TryIntoHeaderPair, Payload, RequestHead, ResponseHead, StatusCode, Version,
+};
 use bytes::Bytes;
 
 #[cfg(feature = "cookies")]
@@ -9,6 +11,7 @@ use crate::ClientResponse;
 
 /// Test `ClientResponse` builder
 pub struct TestResponse {
+    req_head: RequestHead,
     head: ResponseHead,
     #[cfg(feature = "cookies")]
     cookies: CookieJar,
@@ -18,6 +21,7 @@ pub struct TestResponse {
 impl Default for TestResponse {
     fn default() -> TestResponse {
         TestResponse {
+            req_head: RequestHead::default(),
             head: ResponseHead::new(StatusCode::OK),
             #[cfg(feature = "cookies")]
             cookies: CookieJar::new(),
@@ -88,10 +92,10 @@ impl TestResponse {
         }
 
         if let Some(pl) = self.payload {
-            ClientResponse::new(head, pl)
+            ClientResponse::new(self.req_head.into(), head, pl)
         } else {
             let (_, payload) = h1::Payload::create(true);
-            ClientResponse::new(head, payload.into())
+            ClientResponse::new(self.req_head.into(), head, payload.into())
         }
     }
 }

--- a/awc/src/ws.rs
+++ b/awc/src/ws.rs
@@ -351,7 +351,7 @@ impl WebsocketsRequest {
             fut.await?
         };
 
-        let (head, framed) = res.into_tunnel_response();
+        let (req_head, head, framed) = res.into_tunnel_response();
 
         // verify response
         if head.status != StatusCode::SWITCHING_PROTOCOLS {
@@ -411,7 +411,7 @@ impl WebsocketsRequest {
 
         // response and ws framed
         Ok((
-            ClientResponse::new(head, Payload::None),
+            ClientResponse::new(req_head, head, Payload::None),
             framed.into_map_codec(|_| {
                 if server_mode {
                     ws::Codec::new().max_size(max_size)


### PR DESCRIPTION
## PR Type

Feat

## PR Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [ ] (Team) Label with affected crates and semver status.

## Overview

This pr will allow to add the request head used to send the request to server into the response, this allow by example retrieving the final url in case of a redirect

(This can also be used by other middleware to log a request / response pair also)

Fix https://github.com/actix/actix-web/issues/3403