### PR TITLE
Fix order of template arguments in Handler documentation example

### DIFF
--- a/actix-web/src/handler.rs
+++ b/actix-web/src/handler.rs
@@ -70,7 +70,7 @@ use crate::{
 /// This is the source code for the 2-parameter implementation of `Handler` to help illustrate the
 /// bounds of the handler call after argument extraction:
 /// ```ignore
-/// impl<Func, Arg1, Arg2, Fut> Handler<(Arg1, Arg2)> for Func
+/// impl<Func, Fut, Arg1, Arg2> Handler<(Arg1, Arg2)> for Func
 /// where
 ///     Func: Fn(Arg1, Arg2) -> Fut + Clone + 'static,
 ///     Fut: Future,


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type

Documentation fix

<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->

## PR Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.

## Overview

Before this change, the illustrative code example for the [`Handler` trait](https://github.com/actix/actix-web/blob/master/actix-web/src/handler.rs#L73-L84) did not match the order of template arguments in the [`Handler` implementation](https://github.com/actix/actix-web/blob/master/actix-web/src/handler.rs#L132).
