### PR TITLE
fix: increase total limit in multipart example

### DIFF
--- a/actix-multipart-derive/src/lib.rs
+++ b/actix-multipart-derive/src/lib.rs
@@ -105,7 +105,7 @@ struct ParsedField<'t> {
 /// You can use the `#[multipart(limit = "<size>")]` attribute to set field level limits. The limit
 /// string is parsed using [`bytesize`].
 ///
-/// Note: the form is also subject to the global limits configured using `MultipartFormConfig`.
+/// Note: the form is also subject to the global limits configured using [`MultipartFormConfig`](crate::form::MultipartFormConfig).
 ///
 /// ```
 /// use actix_multipart::form::{tempfile::TempFile, text::Text, MultipartForm};

--- a/actix-multipart-derive/src/lib.rs
+++ b/actix-multipart-derive/src/lib.rs
@@ -105,7 +105,7 @@ struct ParsedField<'t> {
 /// You can use the `#[multipart(limit = "<size>")]` attribute to set field level limits. The limit
 /// string is parsed using [`bytesize`].
 ///
-/// Note: the form is also subject to the global limits configured using [`MultipartFormConfig`](crate::form::MultipartFormConfig).
+/// Note: the form is also subject to the global limits configured using `MultipartFormConfig`.
 ///
 /// ```
 /// use actix_multipart::form::{tempfile::TempFile, text::Text, MultipartForm};

--- a/actix-multipart/README.md
+++ b/actix-multipart/README.md
@@ -37,6 +37,7 @@ struct Metadata {
 
 #[derive(Debug, MultipartForm)]
 struct UploadForm {
+    // Note: the form is also subject to the global limits configured using `MultipartFormConfig`.
     #[multipart(limit = "100MB")]
     file: TempFile,
     json: MpJson<Metadata>,
@@ -60,6 +61,7 @@ async fn main() -> std::io::Result<()> {
         App::new()
             .service(post_video)
             .wrap(Logger::default())
+            // Also increase the global total limit to 100MiB.
             .app_data(MultipartFormConfig::default().total_limit(100 * 1024 * 1024))
     })
     .workers(2)

--- a/actix-multipart/examples/form.rs
+++ b/actix-multipart/examples/form.rs
@@ -1,4 +1,6 @@
-use actix_multipart::form::{json::Json as MpJson, tempfile::TempFile, MultipartForm};
+use actix_multipart::form::{
+    json::Json as MpJson, tempfile::TempFile, MultipartForm, MultipartFormConfig,
+};
 use actix_web::{middleware::Logger, post, App, HttpServer, Responder};
 use serde::Deserialize;
 
@@ -28,9 +30,14 @@ async fn post_video(MultipartForm(form): MultipartForm<UploadForm>) -> impl Resp
 async fn main() -> std::io::Result<()> {
     env_logger::init_from_env(env_logger::Env::new().default_filter_or("info"));
 
-    HttpServer::new(move || App::new().service(post_video).wrap(Logger::default()))
-        .workers(2)
-        .bind(("127.0.0.1", 8080))?
-        .run()
-        .await
+    HttpServer::new(move || {
+        App::new()
+            .service(post_video)
+            .wrap(Logger::default())
+            .app_data(MultipartFormConfig::default().total_limit(100 * 1024 * 1024))
+    })
+    .workers(2)
+    .bind(("127.0.0.1", 8080))?
+    .run()
+    .await
 }

--- a/actix-multipart/examples/form.rs
+++ b/actix-multipart/examples/form.rs
@@ -11,6 +11,7 @@ struct Metadata {
 
 #[derive(Debug, MultipartForm)]
 struct UploadForm {
+    // Note: the form is also subject to the global limits configured using `MultipartFormConfig`.
     #[multipart(limit = "100MB")]
     file: TempFile,
     json: MpJson<Metadata>,
@@ -34,6 +35,7 @@ async fn main() -> std::io::Result<()> {
         App::new()
             .service(post_video)
             .wrap(Logger::default())
+            // Also increase the global total limit to 100MiB.
             .app_data(MultipartFormConfig::default().total_limit(100 * 1024 * 1024))
     })
     .workers(2)

--- a/actix-multipart/src/lib.rs
+++ b/actix-multipart/src/lib.rs
@@ -13,7 +13,7 @@
 //! ```no_run
 //! use actix_web::{post, App, HttpServer, Responder};
 //!
-//! use actix_multipart::form::{json::Json as MpJson, tempfile::TempFile, MultipartForm};
+//! use actix_multipart::form::{json::Json as MpJson, tempfile::TempFile, MultipartForm, MultipartFormConfig};
 //! use serde::Deserialize;
 //!
 //! #[derive(Debug, Deserialize)]
@@ -23,6 +23,7 @@
 //!
 //! #[derive(Debug, MultipartForm)]
 //! struct UploadForm {
+//!     // Note: the form is also subject to the global limits configured using `MultipartFormConfig`.
 //!     #[multipart(limit = "100MB")]
 //!     file: TempFile,
 //!     json: MpJson<Metadata>,
@@ -38,10 +39,15 @@
 //!
 //! #[actix_web::main]
 //! async fn main() -> std::io::Result<()> {
-//!     HttpServer::new(move || App::new().service(post_video))
-//!         .bind(("127.0.0.1", 8080))?
-//!         .run()
-//!         .await
+//!     HttpServer::new(move || {
+//!         App::new()
+//!             .service(post_video)
+//!             // Also increase the global total limit to 100MiB.
+//!             .app_data(MultipartFormConfig::default().total_limit(100 * 1024 * 1024))
+//!     })
+//!     .bind(("127.0.0.1", 8080))?
+//!     .run()
+//!     .await
 //! }
 //! ```
 //!


### PR DESCRIPTION
## PR Type

Bug Fix

## PR Checklist

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.

## Overview

Now example in multipart has a new total limit of 100 MiB, which fix the error when uploading file bigger than 50 MiB (default)

Closes #3549