### PR TITLE
Added serde derive to close reason and close code

### DIFF
--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -6,6 +6,7 @@
 
 - Add `header::CLEAR_SITE_DATA` constant.
 - Add `Extensions::get_or_insert[_with]()` methods.
+- Add feature-gated `serde::Serialize` and `serde::Deserialize` implementations for `CloseCode` and `CloseReason`
 
 ### Changed
 

--- a/actix-http/Cargo.toml
+++ b/actix-http/Cargo.toml
@@ -69,6 +69,8 @@ ws = [
     "dep:sha1",
 ]
 
+serde = ["dep:serde"]
+
 # TLS via OpenSSL
 openssl = ["__tls", "actix-tls/accept", "actix-tls/openssl"]
 
@@ -121,6 +123,7 @@ language-tags = "0.3"
 mime = "0.3.4"
 percent-encoding = "2.1"
 pin-project-lite = "0.2"
+serde = { version = "1", features = ["derive"], optional = true }
 smallvec = "1.6.1"
 tokio = { version = "1.24.2", features = [] }
 tokio-util = { version = "0.7", features = ["io", "codec"] }

--- a/actix-http/src/ws/proto.rs
+++ b/actix-http/src/ws/proto.rs
@@ -83,6 +83,7 @@ impl From<u8> for OpCode {
 
 /// Status code used to indicate why an endpoint is closing the WebSocket connection.
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum CloseCode {
     /// Indicates a normal closure, meaning that the purpose for which the connection was
     /// established has been fulfilled.
@@ -195,6 +196,7 @@ impl From<u16> for CloseCode {
 }
 
 #[derive(Debug, Eq, PartialEq, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// Reason for closing the connection
 pub struct CloseReason {
     /// Exit code


### PR DESCRIPTION
## PR Type

Feature

## PR Checklist

- [x] ~Tests for the changes have been added / updated.~
- [x] ~Documentation comments have been added / updated.~
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.

## Overview

Added feature-gated support for `serde::Serialize` and `serde::Deserialize` to `CloseReason` and `CloseCode`

Closes  #3578