### PR TITLE
Make web::Path innards public

### DIFF
--- a/actix-web-codegen/tests/scopes.rs
+++ b/actix-web-codegen/tests/scopes.rs
@@ -24,7 +24,7 @@ mod scope_module {
 
     #[get("/twice-test/{value}")]
     pub async fn twice(value: web::Path<String>) -> impl actix_web::Responder {
-        let int_value: i32 = value.parse().unwrap_or(0);
+        let int_value: i32 = value.0.parse().unwrap_or(0);
         let doubled = int_value * 2;
         HttpResponse::Ok().body(format!("Twice value: {}", doubled))
     }

--- a/actix-web/CHANGES.md
+++ b/actix-web/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Make contents of `web::Path` public.
+
 ## 4.9.0
 
 ### Added

--- a/actix-web/src/route.rs
+++ b/actix-web/src/route.rs
@@ -173,7 +173,7 @@ impl Route {
     ///
     /// /// extract path info using serde
     /// async fn index(info: web::Path<Info>) -> String {
-    ///     format!("Welcome {}!", info.username)
+    ///     format!("Welcome {}!", info.0.username)
     /// }
     ///
     /// let app = App::new().service(
@@ -199,7 +199,7 @@ impl Route {
     ///     query: web::Query<HashMap<String, String>>,
     ///     body: web::Json<Info>
     /// ) -> String {
-    ///     format!("Welcome {}!", path.username)
+    ///     format!("Welcome {}!", path.0.username)
     /// }
     ///
     /// let app = App::new().service(

--- a/actix-web/src/types/path.rs
+++ b/actix-web/src/types/path.rs
@@ -54,7 +54,7 @@ use crate::{
 /// }
 /// ```
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Deref, DerefMut, AsRef, Display, From)]
-pub struct Path<T>(T);
+pub struct Path<T>(pub T);
 
 impl<T> Path<T> {
     /// Unwrap into inner `T` value.


### PR DESCRIPTION
## PR Type

Other?

## PR Checklist

- [x] Tests for the changes have been added / updated.
- [x] ~Documentation comments have been added / updated~
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.

## Overview

This change allows us to do something like this:
```rust
async fn delete_channel_message(
    web::Path((channel_id, message_id)): web::Path<(Snowflake, Snowflake)>,
) {
  // here channel_id and message_id are Snowflakes,
  // and not web::Path<Snowflake>
}
```

Dunno why other web types are public and this is not.
