### PR TITLE
Add from_bytes/u8_bytes to dev::Payload

### DIFF
--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -6,7 +6,8 @@
 
 - Add `header::CLEAR_SITE_DATA` constant.
 - Add `Extensions::get_or_insert[_with]()` methods.
-- Add `dev::Payload::from_[bytes/u8_bytes]()` methods.
+- Implement `From<Bytes>` for `Payload`.
+- Implement `From<Vec<u8>>` for `Payload`.
 
 ### Changed
 

--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -6,6 +6,7 @@
 
 - Add `header::CLEAR_SITE_DATA` constant.
 - Add `Extensions::get_or_insert[_with]()` methods.
+- Add `dev::Payload::from_[bytes/u8_bytes]()` methods.
 
 ### Changed
 

--- a/actix-http/src/payload.rs
+++ b/actix-http/src/payload.rs
@@ -69,6 +69,21 @@ impl From<BoxedPayloadStream> for Payload {
 }
 
 impl<S> Payload<S> {
+    /// Create Payload from bytes::Bytes
+    pub fn from_bytes(bytes: bytes::Bytes) -> Payload<S> {
+        let (_, mut pl) = crate::h1::Payload::create(true);
+        pl.unread_data(bytes);
+        self::Payload::from(pl)
+    }
+
+    /// Create Payload from `Vec<u8>` bytes
+    pub fn from_u8_bytes(u8_bytes: Vec<u8>) -> Payload<S> {
+        let (_, mut pl) = crate::h1::Payload::create(true);
+        let bytes = bytes::Bytes::from(u8_bytes);
+        pl.unread_data(bytes);
+        self::Payload::from(pl)
+    }
+
     /// Takes current payload and replaces it with `None` value
     pub fn take(&mut self) -> Payload<S> {
         mem::replace(self, Payload::None)


### PR DESCRIPTION
## PR Type

Feature

## PR Checklist

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.

## Overview

<!-- Describe the current and new behavior. -->
Currently one needs to add the `actix-http` crate and write the fn `bytes_to_payload`
```rust
let bytes_to_payload =
    |buf: web::Bytes| -> dev::Payload {
        let (_, mut pl) =
            actix_http::h1::Payload::create(true);
        pl.unread_data(buf);
        dev::Payload::from(pl)
    };

req.set_payload(bytes_to_payload(
     web::Bytes::from(login_req_body)
));
```
to be able to create a `Payload` from `bytes::Bytes` or `Vec<u8>` bytes but with the added `from_bytes` and `from_u8_bytes` this becomes

```rust
req.set_payload(dev::Payload::from_u8_bytes(
    login_req_body
));
```

This allows convenient construction of Payload from bytes which is very useful in middlewares.


closes actix/actix-web#3589
