### PR TITLE
Implements log_level for Logger middleware

### DIFF
--- a/actix-web/CHANGES.md
+++ b/actix-web/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add `Logger::log_level()` method.
+
 ## 4.10.2
 
 - No significant changes since `4.10.1`.

--- a/actix-web/src/middleware/logger.rs
+++ b/actix-web/src/middleware/logger.rs
@@ -16,7 +16,7 @@ use actix_service::{Service, Transform};
 use actix_utils::future::{ready, Ready};
 use bytes::Bytes;
 use futures_core::ready;
-use log::{debug, warn};
+use log::{debug, warn, Level};
 use pin_project_lite::pin_project;
 #[cfg(feature = "unicode")]
 use regex::Regex;
@@ -92,6 +92,7 @@ struct Inner {
     exclude: HashSet<String>,
     exclude_regex: Vec<Regex>,
     log_target: Cow<'static, str>,
+    log_level: Level,
 }
 
 impl Logger {
@@ -102,6 +103,7 @@ impl Logger {
             exclude: HashSet::new(),
             exclude_regex: Vec::new(),
             log_target: Cow::Borrowed(module_path!()),
+            log_level: Level::Info,
         }))
     }
 
@@ -136,6 +138,23 @@ impl Logger {
     pub fn log_target(mut self, target: impl Into<Cow<'static, str>>) -> Self {
         let inner = Rc::get_mut(&mut self.0).unwrap();
         inner.log_target = target.into();
+        self
+    }
+
+    /// Sets the log level to `level`.
+    ///
+    /// By default, the log level is `Level::Info`.
+    ///
+    /// # Examples
+    /// Using `.log_level(Level::Debug)` would have this effect on request logs:
+    /// ```diff
+    /// - [2015-10-21T07:28:00Z INFO  actix_web::middleware::logger] 127.0.0.1 "GET / HTTP/1.1" 200 88 "-" "dmc/1.0" 0.001985
+    /// + [2015-10-21T07:28:00Z DEBUG  actix_web::middleware::logger] 127.0.0.1 "GET / HTTP/1.1" 200 88 "-" "dmc/1.0" 0.001985
+    ///                         ^^^^^^
+    /// ```
+    pub fn log_level(mut self, level: log::Level) -> Self {
+        let inner = Rc::get_mut(&mut self.0).unwrap();
+        inner.log_level = level;
         self
     }
 
@@ -242,6 +261,7 @@ impl Default for Logger {
             exclude: HashSet::new(),
             exclude_regex: Vec::new(),
             log_target: Cow::Borrowed(module_path!()),
+            log_level: Level::Info,
         }))
     }
 }
@@ -312,6 +332,7 @@ where
                 format: None,
                 time: OffsetDateTime::now_utc(),
                 log_target: Cow::Borrowed(""),
+                log_level: self.inner.log_level,
                 _phantom: PhantomData,
             }
         } else {
@@ -327,6 +348,7 @@ where
                 format: Some(format),
                 time: now,
                 log_target: self.inner.log_target.clone(),
+                log_level: self.inner.log_level,
                 _phantom: PhantomData,
             }
         }
@@ -344,6 +366,7 @@ pin_project! {
         time: OffsetDateTime,
         format: Option<Format>,
         log_target: Cow<'static, str>,
+        log_level: Level,
         _phantom: PhantomData<B>,
     }
 }
@@ -390,6 +413,7 @@ where
         let time = *this.time;
         let format = this.format.take();
         let log_target = this.log_target.clone();
+        let log_level = this.log_level.clone();
 
         Poll::Ready(Ok(res.map_body(move |_, body| StreamLog {
             body,
@@ -397,6 +421,7 @@ where
             format,
             size: 0,
             log_target,
+            log_level,
         })))
     }
 }
@@ -409,6 +434,7 @@ pin_project! {
         size: usize,
         time: OffsetDateTime,
         log_target: Cow<'static, str>,
+        log_level: Level
     }
 
     impl<B> PinnedDrop for StreamLog<B> {
@@ -421,8 +447,9 @@ pin_project! {
                     Ok(())
                 };
 
-                log::info!(
+                log::log!(
                     target: this.log_target.as_ref(),
+                    this.log_level,
                     "{}", FormatDisplay(&render)
                 );
             }

--- a/actix-web/src/middleware/logger.rs
+++ b/actix-web/src/middleware/logger.rs
@@ -413,7 +413,7 @@ where
         let time = *this.time;
         let format = this.format.take();
         let log_target = this.log_target.clone();
-        let log_level = this.log_level.clone();
+        let log_level = *this.log_level;
 
         Poll::Ready(Ok(res.map_body(move |_, body| StreamLog {
             body,


### PR DESCRIPTION
## PR Type

Feature

## PR Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.

## Overview

Adds a log_level method to the Logger middleware to allow middleware log level to be specified.

Defaults to INFO so no change is not breaking.

Closes #3604 
