### PR TITLE
Fix HttpRequest::peer_addr documentation

### DIFF
--- a/actix-web/src/info.rs
+++ b/actix-web/src/info.rs
@@ -158,7 +158,7 @@ impl ConnectionInfo {
     /// The address is resolved through the following, in order:
     /// - `Forwarded` header
     /// - `X-Forwarded-For` header
-    /// - peer address of opened socket (same as [`remote_addr`](Self::remote_addr))
+    /// - peer address of opened socket (same as [`peer_addr`](Self::peer_addr))
     ///
     /// # Security
     /// Do not use this function for security purposes unless you can be sure that the `Forwarded`

--- a/actix-web/src/request.rs
+++ b/actix-web/src/request.rs
@@ -264,7 +264,7 @@ impl HttpRequest {
     ///
     /// For expanded client connection information, use [`connection_info`] instead.
     ///
-    /// Will only return None when called in unit tests unless [`TestRequest::peer_addr`] is used.
+    /// Will return None when server listens on UDS socket or when called in unit tests unless [`TestRequest::peer_addr`] is used.
     ///
     /// [`TestRequest::peer_addr`]: crate::test::TestRequest::peer_addr
     /// [`connection_info`]: Self::connection_info


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type

<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->

Other

## PR Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.

## Overview

<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

In my tests, `HttpRequest::peer_addr` returns `None` when server listens on an unix socket. This was not documented.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
