### PR TITLE
fix(actix-http): wake before return pending when read half disconnect and need to shutdown

### DIFF
--- a/actix-http/src/h1/dispatcher.rs
+++ b/actix-http/src/h1/dispatcher.rs
@@ -1182,7 +1182,7 @@ where
                     let state_is_none = inner_p.state.is_none();
 
                     // read half is closed; we do not process any responses
-                    if inner_p.flags.contains(Flags::READ_DISCONNECT) && state_is_none {
+                    if inner_p.flags.contains(Flags::READ_DISCONNECT) {
                         trace!("read half closed; start shutdown");
                         inner_p.flags.insert(Flags::SHUTDOWN);
                     }
@@ -1216,6 +1216,9 @@ where
                         inner_p.shutdown_timer,
                     );
 
+                    if inner_p.flags.contains(Flags::SHUTDOWN) {
+                        cx.waker().wake_by_ref();
+                    }
                     Poll::Pending
                 };
 


### PR DESCRIPTION
## PR Type

Bug Fix

## PR Checklist

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.

## Overview

Closes #1313

In our application, we use actix-web to forward websocket data to another service. During runtime, we discovered that when the browser closes the connection, actix-web cannot detect this event, causing tokio's io::copy call to block indefinitely. Through testing, we found that in the Dispatcher's poll method, there are the following two issues:

Because inner_p.state is not None, READ_DISCONNECT cannot be detected
After returning Poll::Pending, the Dispatcher will not be polled again

This PR resolves the above two issues, allowing the client disconnect event to be properly detected and the process to exit normally.
