### PR TITLE
fix: close connection after receiving GO_AWAY from remote

### DIFF
--- a/awc/src/client/h2proto.rs
+++ b/awc/src/client/h2proto.rs
@@ -121,7 +121,7 @@ where
             fut.await.map_err(SendRequestError::from)?
         }
         Err(err) => {
-            io.on_release(err.is_io());
+            io.on_release(err.is_io() || (err.is_go_away() && err.is_remote()));
             return Err(err.into());
         }
     };


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type

Bug Fix

PR_TYPE

## PR Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [ ] (Team) Label with affected crates and semver status.

## Overview

<!-- Describe the current and new behavior. -->
If the remote gracefully shuts down a HTTP/2 connection by sending GO_AWAY, the corresponding h2 error is returned.
Before this change, the connection remained in the pool and using it again results in the same h2 error.
With this change the connection is released from the pool as intended by the remote.
<!-- Emphasize any breaking changes. -->

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
