### PR TITLE
fix: include content-length with bytes test payload

### DIFF
--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Update `TestRequest::set_payload` to generate "Content-Length" header
+
 ## 3.11.0
 
 - Update `brotli` dependency to `8`.

--- a/actix-http/src/test.rs
+++ b/actix-http/src/test.rs
@@ -98,6 +98,8 @@ impl TestRequest {
     }
 
     /// Set request payload.
+    ///
+    /// This sets the `Content-Length` header with the size of `data`.
     pub fn set_payload(&mut self, data: impl Into<Bytes>) -> &mut Self {
         let mut payload = crate::h1::Payload::empty();
         let bytes = data.into();

--- a/actix-http/src/test.rs
+++ b/actix-http/src/test.rs
@@ -11,7 +11,7 @@ use std::{
 
 use actix_codec::{AsyncRead, AsyncWrite, ReadBuf};
 use bytes::{Bytes, BytesMut};
-use http::{Method, Uri, Version};
+use http::{header, Method, Uri, Version};
 
 use crate::{
     header::{HeaderMap, TryIntoHeaderPair},
@@ -100,7 +100,9 @@ impl TestRequest {
     /// Set request payload.
     pub fn set_payload(&mut self, data: impl Into<Bytes>) -> &mut Self {
         let mut payload = crate::h1::Payload::empty();
-        payload.unread_data(data.into());
+        let bytes = data.into();
+        self.insert_header((header::CONTENT_LENGTH, bytes.len()));
+        payload.unread_data(bytes);
         parts(&mut self.0).payload = Some(payload.into());
         self
     }

--- a/actix-web/src/types/json.rs
+++ b/actix-web/src/types/json.rs
@@ -616,7 +616,7 @@ mod tests {
             }
         ));
 
-        let (req, mut pl) = TestRequest::default()
+        let (mut req, mut pl) = TestRequest::default()
             .insert_header((
                 header::CONTENT_TYPE,
                 header::HeaderValue::from_static("application/json"),
@@ -624,6 +624,7 @@ mod tests {
             .set_payload(Bytes::from_static(&[0u8; 1000]))
             .to_http_parts();
 
+        req.head_mut().headers_mut().remove(header::CONTENT_LENGTH);
         let json = JsonBody::<MyObject>::new(&req, &mut pl, None, true)
             .limit(100)
             .await;


### PR DESCRIPTION
## PR Type

Bug Fix

## PR Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [X] Tests for the changes have been added / updated.
- [X] Documentation comments have been added / updated.
- [X] A changelog entry has been made for the appropriate packages.
- [X] Format code with the latest stable rustfmt.
- [X] (Team) Label with affected crates and semver status.

## Overview

I noticed when writing my own tests for an actix-web service that the "Content-Length" is not sent when using [`TestRequest::set_form`](https://docs.rs/actix-web/latest/actix_web/test/struct.TestRequest.html#method.set_form) and [`TestRequest::set_json`](https://docs.rs/actix-web/latest/actix_web/test/struct.TestRequest.html#method.set_json) methods.

Both call [`HttpTestRequest::set_payload`](https://docs.rs/actix-http/latest/actix_http/test/struct.TestRequest.html#method.set_payload) underneath so this should cover all cases at the root.

Hope this helps, thanks! :)