### PR TITLE
fix(awc): some request methods incorrectly send body & body-headers

### DIFF
--- a/actix-http/tests/test_client.rs
+++ b/actix-http/tests/test_client.rs
@@ -139,7 +139,7 @@ async fn h1_expect() {
 
     // test expect would fail to continue
     let request = srv
-        .request(http::Method::GET, srv.url("/"))
+        .request(http::Method::POST, srv.url("/"))
         .insert_header(("Expect", "100-continue"));
 
     let response = request.send_body("expect body").await.unwrap();
@@ -147,7 +147,7 @@ async fn h1_expect() {
 
     // test expect would continue
     let request = srv
-        .request(http::Method::GET, srv.url("/"))
+        .request(http::Method::POST, srv.url("/"))
         .insert_header(("Expect", "100-continue"))
         .insert_header(("AUTH", "996"));
 

--- a/actix-http/tests/test_openssl.rs
+++ b/actix-http/tests/test_openssl.rs
@@ -118,7 +118,7 @@ async fn h2_body() -> io::Result<()> {
     })
     .await;
 
-    let response = srv.sget("/").send_body(data.clone()).await.unwrap();
+    let response = srv.spost("/").send_body(data.clone()).await.unwrap();
     assert!(response.status().is_success());
 
     let body = srv.load_body(response).await.unwrap();

--- a/actix-http/tests/test_rustls.rs
+++ b/actix-http/tests/test_rustls.rs
@@ -184,7 +184,7 @@ async fn h2_body1() -> io::Result<()> {
     })
     .await;
 
-    let response = srv.sget("/").send_body(data.clone()).await.unwrap();
+    let response = srv.spost("/").send_body(data.clone()).await.unwrap();
     assert!(response.status().is_success());
 
     let body = srv.load_body(response).await.unwrap();

--- a/awc/CHANGES.md
+++ b/awc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- `GET/HEAD/OPTIONS/TRACE` methods no longer send a request body on request.
+
 ## 3.7.0
 
 - Update `brotli` dependency to `8`.

--- a/awc/src/any_body.rs
+++ b/awc/src/any_body.rs
@@ -4,8 +4,12 @@ use std::{
     task::{Context, Poll},
 };
 
-use actix_http::body::{BodySize, BoxBody, MessageBody};
+use actix_http::{
+    body::{BodySize, BoxBody, MessageBody},
+    RequestHead,
+};
 use bytes::Bytes;
+use http::Method;
 use pin_project_lite::pin_project;
 
 pin_project! {
@@ -75,11 +79,15 @@ where
     /// Converts a [`MessageBody`] type into the best possible representation.
     ///
     /// Checks size for `None` and tries to convert to `Bytes`. Otherwise, uses the `Body` variant.
-    pub fn from_message_body(body: B) -> Self
+    pub fn from_message_body(head: &RequestHead, body: B) -> Self
     where
         B: MessageBody,
     {
-        if matches!(body.size(), BodySize::None) {
+        if matches!(
+            head.method,
+            Method::GET | Method::HEAD | Method::OPTIONS | Method::TRACE
+        ) || matches!(body.size(), BodySize::None)
+        {
             return Self::None;
         }
 

--- a/awc/src/sender.rs
+++ b/awc/src/sender.rs
@@ -189,16 +189,14 @@ impl RequestSender {
         body: impl MessageBody + 'static,
     ) -> SendClientRequest {
         let req = match self {
-            RequestSender::Owned(head) => ConnectRequest::Client(
-                RequestHeadType::Owned(head),
-                AnyBody::from_message_body(body).into_boxed(),
-                addr,
-            ),
-            RequestSender::Rc(head, extra_headers) => ConnectRequest::Client(
-                RequestHeadType::Rc(head, extra_headers),
-                AnyBody::from_message_body(body).into_boxed(),
-                addr,
-            ),
+            RequestSender::Owned(head) => {
+                let body = AnyBody::from_message_body(&head, body).into_boxed();
+                ConnectRequest::Client(RequestHeadType::Owned(head), body, addr)
+            }
+            RequestSender::Rc(head, extra_headers) => {
+                let body = AnyBody::from_message_body(&head, body).into_boxed();
+                ConnectRequest::Client(RequestHeadType::Rc(head, extra_headers), body, addr)
+            }
         };
 
         let fut = config.connector.call(req);

--- a/awc/tests/test_client.rs
+++ b/awc/tests/test_client.rs
@@ -62,10 +62,11 @@ async fn json() {
     });
 
     let request = srv
-        .get("/")
+        .post("/")
         .insert_header(("x-test", "111"))
         .send_json(&"TEST".to_string());
     let response = request.await.unwrap();
+    println!("{response:?}");
     assert!(response.status().is_success());
 }
 

--- a/awc/tests/test_client.rs
+++ b/awc/tests/test_client.rs
@@ -66,7 +66,6 @@ async fn json() {
         .insert_header(("x-test", "111"))
         .send_json(&"TEST".to_string());
     let response = request.await.unwrap();
-    println!("{response:?}");
     assert!(response.status().is_success());
 }
 


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type

Bug Fix

## PR Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [X] Tests for the changes have been added / updated.
- [X] Documentation comments have been added / updated.
- [X] A changelog entry has been made for the appropriate packages.
- [X] Format code with the latest stable rustfmt.
- [X] (Team) Label with affected crates and semver status.

## Overview

The existing implementation for awc incorrectly sends a request-body for http methods that don't support one, such as `GET/HEAD/OPTIONS/TRACE`. This is especially apparent when passing a stream into the request for all methods since it uses chunked content-encoding.

I discovered this whilst implementing a reverse-proxy using actix-web and awc.

Example:

```
GET / HTTP/1.1
transfer-encoding: chunked
accept-encoding: br, gzip, deflate, zstd
host: localhost:8000
date: Thu, 31 Jul 2025 03:51:41 GMT

0
```

You can verify this yourself with a simple script (I'm using netcat to view the request `nc -lvp 8000`):

```rust
use std::{
    pin::Pin,
    task::{Context, Poll},
};

use awc::{error::PayloadError, http::Method};
use bytes::Bytes;
use futures_core::Stream;

struct ReqStream;

impl Stream for ReqStream {
    type Item = Result<Bytes, PayloadError>;
    fn poll_next(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
        Poll::Ready(None)
    }
}

#[actix_rt::main]
async fn main() {
    let client = awc::Client::default();
    let res = client
        .request(Method::GET, "http://localhost:8000")
        .send_stream(ReqStream {})
        .await;
    println!("response: {res:?}");
}
```

The following changes ensure that the body and its associated headers are not included for the standard request methods, resulting in a correct request:

```
GET / HTTP/1.1
accept-encoding: br, gzip, deflate, zstd
host: localhost:8000
date: Thu, 31 Jul 2025 04:00:59 GMT
```