### PR TITLE
fix: eof hanging bodies on streamed requests

### DIFF
--- a/actix-http/src/h1/dispatcher.rs
+++ b/actix-http/src/h1/dispatcher.rs
@@ -20,18 +20,18 @@ use tokio_util::codec::{Decoder as _, Encoder as _};
 use tracing::{error, trace};
 
 use super::{
-    Message, MessageType,
     codec::Codec,
     decoder::MAX_BUFFER_SIZE,
     payload::{Payload, PayloadSender, PayloadStatus},
     timer::TimerState,
+    Message, MessageType,
 };
 use crate::{
-    Error, Extensions, OnConnectData, Request, Response, StatusCode,
     body::{BodySize, BoxBody, MessageBody},
     config::ServiceConfig,
     error::{DispatchError, ParseError, PayloadError},
     service::HttpFlow,
+    Error, Extensions, OnConnectData, Request, Response, StatusCode,
 };
 
 const LW_BUFFER_SIZE: usize = 1024;
@@ -236,12 +236,16 @@ enum PollResponse {
 impl<T, S, B, X, U> Dispatcher<T, S, B, X, U>
 where
     T: AsyncRead + AsyncWrite + Unpin,
+
     S: Service<Request>,
     S::Error: Into<Response<BoxBody>>,
     S::Response: Into<Response<B>>,
+
     B: MessageBody,
+
     X: Service<Request, Response = Request>,
     X::Error: Into<Response<BoxBody>>,
+
     U: Service<(Request, Framed<T, Codec>), Response = ()>,
     U::Error: fmt::Display,
 {
@@ -287,12 +291,16 @@ where
 impl<T, S, B, X, U> InnerDispatcher<T, S, B, X, U>
 where
     T: AsyncRead + AsyncWrite + Unpin,
+
     S: Service<Request>,
     S::Error: Into<Response<BoxBody>>,
     S::Response: Into<Response<B>>,
+
     B: MessageBody,
+
     X: Service<Request, Response = Request>,
     X::Error: Into<Response<BoxBody>>,
+
     U: Service<(Request, Framed<T, Codec>), Response = ()>,
     U::Error: fmt::Display,
 {
@@ -654,10 +662,6 @@ where
                         // to notify the dispatcher a new state is set and the outer loop
                         // should be continue.
                         Poll::Ready(Ok(res)) => {
-                            let this = self.as_mut().project();
-                            if let Some(mut payload) = this.payload.take() {
-                                payload.feed_eof();
-                            }
                             let (res, body) = res.into().replace_body(());
                             self.as_mut().send_response(res, body)
                         }
@@ -1045,12 +1049,16 @@ where
 impl<T, S, B, X, U> Future for Dispatcher<T, S, B, X, U>
 where
     T: AsyncRead + AsyncWrite + Unpin,
+
     S: Service<Request>,
     S::Error: Into<Response<BoxBody>>,
     S::Response: Into<Response<B>>,
+
     B: MessageBody,
+
     X: Service<Request, Response = Request>,
     X::Error: Into<Response<BoxBody>>,
+
     U: Service<(Request, Framed<T, Codec>), Response = ()>,
     U::Error: fmt::Display,
 {

--- a/actix-http/src/h1/dispatcher.rs
+++ b/actix-http/src/h1/dispatcher.rs
@@ -20,18 +20,18 @@ use tokio_util::codec::{Decoder as _, Encoder as _};
 use tracing::{error, trace};
 
 use super::{
+    Message, MessageType,
     codec::Codec,
     decoder::MAX_BUFFER_SIZE,
     payload::{Payload, PayloadSender, PayloadStatus},
     timer::TimerState,
-    Message, MessageType,
 };
 use crate::{
+    Error, Extensions, OnConnectData, Request, Response, StatusCode,
     body::{BodySize, BoxBody, MessageBody},
     config::ServiceConfig,
     error::{DispatchError, ParseError, PayloadError},
     service::HttpFlow,
-    Error, Extensions, OnConnectData, Request, Response, StatusCode,
 };
 
 const LW_BUFFER_SIZE: usize = 1024;
@@ -236,16 +236,12 @@ enum PollResponse {
 impl<T, S, B, X, U> Dispatcher<T, S, B, X, U>
 where
     T: AsyncRead + AsyncWrite + Unpin,
-
     S: Service<Request>,
     S::Error: Into<Response<BoxBody>>,
     S::Response: Into<Response<B>>,
-
     B: MessageBody,
-
     X: Service<Request, Response = Request>,
     X::Error: Into<Response<BoxBody>>,
-
     U: Service<(Request, Framed<T, Codec>), Response = ()>,
     U::Error: fmt::Display,
 {
@@ -291,16 +287,12 @@ where
 impl<T, S, B, X, U> InnerDispatcher<T, S, B, X, U>
 where
     T: AsyncRead + AsyncWrite + Unpin,
-
     S: Service<Request>,
     S::Error: Into<Response<BoxBody>>,
     S::Response: Into<Response<B>>,
-
     B: MessageBody,
-
     X: Service<Request, Response = Request>,
     X::Error: Into<Response<BoxBody>>,
-
     U: Service<(Request, Framed<T, Codec>), Response = ()>,
     U::Error: fmt::Display,
 {
@@ -654,6 +646,10 @@ where
                         // to notify the dispatcher a new state is set and the outer loop
                         // should be continue.
                         Poll::Ready(Ok(res)) => {
+                            let this = self.as_mut().project();
+                            if let Some(mut payload) = this.payload.take() {
+                                payload.feed_eof();
+                            }
                             let (res, body) = res.into().replace_body(());
                             self.as_mut().send_response(res, body)
                         }
@@ -1036,16 +1032,12 @@ where
 impl<T, S, B, X, U> Future for Dispatcher<T, S, B, X, U>
 where
     T: AsyncRead + AsyncWrite + Unpin,
-
     S: Service<Request>,
     S::Error: Into<Response<BoxBody>>,
     S::Response: Into<Response<B>>,
-
     B: MessageBody,
-
     X: Service<Request, Response = Request>,
     X::Error: Into<Response<BoxBody>>,
-
     U: Service<(Request, Framed<T, Codec>), Response = ()>,
     U::Error: fmt::Display,
 {


### PR DESCRIPTION
Fixes #3715

Not convinced this is a perfect fix so open to suggestions and feedback here. The docs tests seem to be failing on my fork of master here as well so I don't _think_ it's anything I've done here.

There's no tests for this because I cannot for the life of me find a way to reproduce this with a test harness. But #3715 provides a functioning example of the bug.

### Description

This PR introduces a fix for a a timeout issue with streaming proxies like Traefik. 

The bug occurs when a client sends an invalid request to the server as a multipart TCP packet. Actix may be able to detect that the request will not succeed, for example due to an invalid header against a request that requires a body, the server will then respond immediately to the client while leaving the body bytes unread. When a second request is made, those body bytes are then read as the first part of the message, causing the server to block until it hits its own timeout threshold, since they can't be parsed as a valid message.

This fix forces a eof to be sent in cases where the request will not receive further processing but bytes remain unread from that request.