### PR TITLE
Fix integer overflow in actix_http::ws::Parser::parse

### DIFF
--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Malformed websocket frames are now gracefully rejected.
+
 ## 3.11.0
 
 - Update `brotli` dependency to `8`.


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type

Bug Fix

## PR Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.

## Overview

Previous behavior: panic if a malformed websocket frame contains an invalid length field.
New behavior: Gracefully reject such frames.

Closes #3723
