### PR TITLE
Add support for permanent redirects in `Files` service

### DIFF
--- a/actix-files/src/files.rs
+++ b/actix-files/src/files.rs
@@ -150,7 +150,7 @@ impl Files {
     /// Redirect with permanent redirect status code
     ///
     /// By default redirect with temporary redirect status code
-    pub fn with_permanent_redirect_directory(mut self) -> Self {
+    pub fn with_permanent_redirect(mut self) -> Self {
         self.with_permanent_redirect = true;
         self
     }

--- a/actix-files/src/files.rs
+++ b/actix-files/src/files.rs
@@ -41,6 +41,7 @@ pub struct Files {
     index: Option<String>,
     show_index: bool,
     redirect_to_slash: bool,
+    with_permanent_redirect: bool,
     default: Rc<RefCell<Option<Rc<HttpNewService>>>>,
     renderer: Rc<DirectoryRenderer>,
     mime_override: Option<Rc<MimeOverride>>,
@@ -65,6 +66,7 @@ impl Clone for Files {
             index: self.index.clone(),
             show_index: self.show_index,
             redirect_to_slash: self.redirect_to_slash,
+            with_permanent_redirect: self.with_permanent_redirect,
             default: self.default.clone(),
             renderer: self.renderer.clone(),
             file_flags: self.file_flags,
@@ -113,6 +115,7 @@ impl Files {
             index: None,
             show_index: false,
             redirect_to_slash: false,
+            with_permanent_redirect: false,
             default: Rc::new(RefCell::new(None)),
             renderer: Rc::new(directory_listing),
             mime_override: None,
@@ -141,6 +144,14 @@ impl Files {
     /// By default never redirect.
     pub fn redirect_to_slash_directory(mut self) -> Self {
         self.redirect_to_slash = true;
+        self
+    }
+
+    /// Redirect with permanent redirect status code
+    ///
+    /// By default redirect with temporary redirect status code
+    pub fn with_permanent_redirect_directory(mut self) -> Self {
+        self.with_permanent_redirect = true;
         self
     }
 
@@ -388,6 +399,7 @@ impl ServiceFactory<ServiceRequest> for Files {
             guards: self.use_guards.clone(),
             hidden_files: self.hidden_files,
             size_threshold: self.read_mode_threshold,
+            with_permanent_redirect: self.with_permanent_redirect,
         };
 
         if let Some(ref default) = *self.default.borrow() {

--- a/actix-files/src/files.rs
+++ b/actix-files/src/files.rs
@@ -147,9 +147,9 @@ impl Files {
         self
     }
 
-    /// Redirect with permanent redirect status code
+    /// Redirect with permanent redirect status code (308).
     ///
-    /// By default redirect with temporary redirect status code
+    /// By default redirect with temporary redirect status code (307).
     pub fn with_permanent_redirect(mut self) -> Self {
         self.with_permanent_redirect = true;
         self

--- a/actix-files/src/lib.rs
+++ b/actix-files/src/lib.rs
@@ -736,7 +736,21 @@ mod tests {
         .await;
         let req = TestRequest::with_uri("/tests").to_request();
         let resp = test::call_service(&srv, req).await;
-        assert_eq!(resp.status(), StatusCode::FOUND);
+        assert_eq!(resp.status(), StatusCode::TEMPORARY_REDIRECT);
+
+        // should redirect if index present with permanent redirect
+        let srv = test::init_service(
+            App::new().service(
+                Files::new("/", ".")
+                    .index_file("test.png")
+                    .redirect_to_slash_directory()
+                    .with_permanent_redirect_directory(),
+            ),
+        )
+        .await;
+        let req = TestRequest::with_uri("/tests").to_request();
+        let resp = test::call_service(&srv, req).await;
+        assert_eq!(resp.status(), StatusCode::PERMANENT_REDIRECT);
 
         // should redirect if files listing is enabled
         let srv = test::init_service(
@@ -749,7 +763,7 @@ mod tests {
         .await;
         let req = TestRequest::with_uri("/tests").to_request();
         let resp = test::call_service(&srv, req).await;
-        assert_eq!(resp.status(), StatusCode::FOUND);
+        assert_eq!(resp.status(), StatusCode::TEMPORARY_REDIRECT);
 
         // should not redirect if the path is wrong
         let req = TestRequest::with_uri("/not_existing").to_request();

--- a/actix-files/src/lib.rs
+++ b/actix-files/src/lib.rs
@@ -744,7 +744,7 @@ mod tests {
                 Files::new("/", ".")
                     .index_file("test.png")
                     .redirect_to_slash_directory()
-                    .with_permanent_redirect_directory(),
+                    .with_permanent_redirect(),
             ),
         )
         .await;


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type

<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->

Feature

## PR Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.

## Overview

<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Current behavior redirect only with `FOUND`.
This pull request:
- Change default redirect to temporary redirect
- Add support for permanent redirects in `Files` service

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
Close #3543 
