### PR TITLE
Remove duplicated entry for "serde::*" in cargo_check_external_types config

### DIFF
--- a/actix-web/Cargo.toml
+++ b/actix-web/Cargo.toml
@@ -52,7 +52,6 @@ allowed_external_types = [
   "serde_json::*",
   "serde_urlencoded::*",
   "serde::*",
-  "serde::*",
   "tokio::*",
   "url::*",
 ]


### PR DESCRIPTION

## PR Type

Other

## PR Checklist

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [ ] Format code with the latest stable rustfmt.
- [ ] (Team) Label with affected crates and semver status.

## Overview

No functional changes!
This PR is a simple fix of a copy/paste error in the configuration of cargo_check_external_types tool. There is a duplicate entry for `serde::*` which does not really cause any problems.
This is just a minor cleanup.