### PR TITLE
Add option to allow/disallow half closures in HTTP/1

### DIFF
--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
-- Properly wake Payload receivers when feeding errors or EOF
+- Properly wake Payload receivers when feeding errors or EOF.
+- Add `ServiceConfigBuilder` type to facilitate future configuration extensions.
+- Add a configuration option to allow/disallow half closed connections in HTTP/1. This defaults to allow, reverting the change made in 3.11.1.
 
 ## 3.11.1
 

--- a/actix-http/src/builder.rs
+++ b/actix-http/src/builder.rs
@@ -7,7 +7,7 @@ use crate::{
     body::{BoxBody, MessageBody},
     h1::{self, ExpectHandler, H1Service, UpgradeHandler},
     service::HttpService,
-    ConnectCallback, Extensions, KeepAlive, Request, Response, ServiceConfig,
+    ConnectCallback, Extensions, KeepAlive, Request, Response, ServiceConfigBuilder,
 };
 
 /// An HTTP service builder.
@@ -195,13 +195,13 @@ where
         S::InitError: fmt::Debug,
         S::Response: Into<Response<B>>,
     {
-        let cfg = ServiceConfig::new(
-            self.keep_alive,
-            self.client_request_timeout,
-            self.client_disconnect_timeout,
-            self.secure,
-            self.local_addr,
-        );
+        let cfg = ServiceConfigBuilder::new()
+            .keep_alive(self.keep_alive)
+            .client_request_timeout(self.client_request_timeout)
+            .client_disconnect_timeout(self.client_disconnect_timeout)
+            .secure(self.secure)
+            .local_addr(self.local_addr)
+            .build();
 
         H1Service::with_config(cfg, service.into_factory())
             .expect(self.expect)
@@ -220,13 +220,13 @@ where
 
         B: MessageBody + 'static,
     {
-        let cfg = ServiceConfig::new(
-            self.keep_alive,
-            self.client_request_timeout,
-            self.client_disconnect_timeout,
-            self.secure,
-            self.local_addr,
-        );
+        let cfg = ServiceConfigBuilder::new()
+            .keep_alive(self.keep_alive)
+            .client_request_timeout(self.client_request_timeout)
+            .client_disconnect_timeout(self.client_disconnect_timeout)
+            .secure(self.secure)
+            .local_addr(self.local_addr)
+            .build();
 
         crate::h2::H2Service::with_config(cfg, service.into_factory())
             .on_connect_ext(self.on_connect_ext)
@@ -242,13 +242,13 @@ where
 
         B: MessageBody + 'static,
     {
-        let cfg = ServiceConfig::new(
-            self.keep_alive,
-            self.client_request_timeout,
-            self.client_disconnect_timeout,
-            self.secure,
-            self.local_addr,
-        );
+        let cfg = ServiceConfigBuilder::new()
+            .keep_alive(self.keep_alive)
+            .client_request_timeout(self.client_request_timeout)
+            .client_disconnect_timeout(self.client_disconnect_timeout)
+            .secure(self.secure)
+            .local_addr(self.local_addr)
+            .build();
 
         HttpService::with_config(cfg, service.into_factory())
             .expect(self.expect)

--- a/actix-http/src/config.rs
+++ b/actix-http/src/config.rs
@@ -9,6 +9,7 @@ use bytes::BytesMut;
 use crate::{date::DateService, KeepAlive};
 
 /// A builder for creating a [`ServiceConfig`]
+#[derive(Default, Debug)]
 pub struct ServiceConfigBuilder {
     inner: Inner,
 }
@@ -75,16 +76,8 @@ impl ServiceConfigBuilder {
     }
 }
 
-impl Default for ServiceConfigBuilder {
-    fn default() -> Self {
-        Self {
-            inner: Inner::default(),
-        }
-    }
-}
-
 /// HTTP service configuration.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct ServiceConfig(Rc<Inner>);
 
 #[derive(Debug)]
@@ -109,12 +102,6 @@ impl Default for Inner {
             date_service: DateService::new(),
             h1_allow_half_closed: true,
         }
-    }
-}
-
-impl Default for ServiceConfig {
-    fn default() -> Self {
-        Self(Rc::default())
     }
 }
 

--- a/actix-http/src/h1/dispatcher_tests.rs
+++ b/actix-http/src/h1/dispatcher_tests.rs
@@ -1000,8 +1000,7 @@ async fn allow_half_closed() {
 
 #[actix_rt::test]
 async fn disallow_half_closed() {
-    use crate::config::ServiceConfigBuilder;
-    use crate::h1::dispatcher::State;
+    use crate::{config::ServiceConfigBuilder, h1::dispatcher::State};
 
     let buf = TestSeqBuffer::new(http_msg("GET / HTTP/1.1"));
     buf.close_read();

--- a/actix-http/src/h1/dispatcher_tests.rs
+++ b/actix-http/src/h1/dispatcher_tests.rs
@@ -1,4 +1,10 @@
-use std::{future::Future, str, task::Poll, time::Duration};
+use std::{
+    future::Future,
+    pin::Pin,
+    str,
+    task::{Context, Poll},
+    time::Duration,
+};
 
 use actix_codec::Framed;
 use actix_rt::{pin, time::sleep};
@@ -9,13 +15,33 @@ use futures_util::future::lazy;
 
 use super::dispatcher::{Dispatcher, DispatcherState, DispatcherStateProj, Flags};
 use crate::{
-    body::MessageBody,
+    body::{BoxBody, MessageBody},
     config::ServiceConfig,
     h1::{Codec, ExpectHandler, UpgradeHandler},
     service::HttpFlow,
     test::{TestBuffer, TestSeqBuffer},
     Error, HttpMessage, KeepAlive, Method, OnConnectData, Request, Response, StatusCode,
 };
+
+struct YieldService;
+
+impl Service<Request> for YieldService {
+    type Response = Response<BoxBody>;
+    type Error = Response<BoxBody>;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>>>>;
+
+    actix_service::always_ready!();
+
+    fn call(&self, _: Request) -> Self::Future {
+        Box::pin(async {
+            // Yield twice because the dispatcher can poll the service twice per dispatcher's poll:
+            // once in `handle_request` and another in `poll_response`
+            actix_rt::task::yield_now().await;
+            actix_rt::task::yield_now().await;
+            Ok(Response::ok())
+        })
+    }
+}
 
 fn find_slice(haystack: &[u8], needle: &[u8], from: usize) -> Option<usize> {
     memchr::memmem::find(&haystack[from..], needle)
@@ -922,6 +948,92 @@ async fn handler_drop_payload() {
         );
     })
     .await;
+}
+
+#[actix_rt::test]
+async fn allow_half_closed() {
+    let buf = TestSeqBuffer::new(http_msg("GET / HTTP/1.1"));
+    buf.close_read();
+    let services = HttpFlow::new(YieldService, ExpectHandler, None::<UpgradeHandler>);
+
+    let mut cx = Context::from_waker(futures_util::task::noop_waker_ref());
+    let disptacher = Dispatcher::new(
+        buf.clone(),
+        services,
+        ServiceConfig::default(),
+        None,
+        OnConnectData::default(),
+    );
+    pin!(disptacher);
+
+    assert!(disptacher.as_mut().poll(&mut cx).is_pending());
+    assert_eq!(disptacher.poll_count, 1);
+
+    assert!(disptacher.as_mut().poll(&mut cx).is_ready());
+    assert_eq!(disptacher.poll_count, 3);
+
+    let mut res = BytesMut::from(buf.take_write_buf().as_ref());
+    stabilize_date_header(&mut res);
+    let exp = http_msg(
+        r"
+        HTTP/1.1 200 OK
+        content-length: 0
+        date: Thu, 01 Jan 1970 12:34:56 UTC
+        ",
+    );
+    assert_eq!(
+        res,
+        exp,
+        "\nexpected response not in write buffer:\n\
+               response: {:?}\n\
+               expected: {:?}",
+        String::from_utf8_lossy(&res),
+        String::from_utf8_lossy(&exp)
+    );
+
+    let DispatcherStateProj::Normal { inner } = disptacher.as_mut().project().inner.project()
+    else {
+        panic!("End dispatcher state should be Normal");
+    };
+    assert!(inner.state.is_none());
+}
+
+#[actix_rt::test]
+async fn disallow_half_closed() {
+    use crate::config::ServiceConfigBuilder;
+    use crate::h1::dispatcher::State;
+
+    let buf = TestSeqBuffer::new(http_msg("GET / HTTP/1.1"));
+    buf.close_read();
+    let services = HttpFlow::new(YieldService, ExpectHandler, None::<UpgradeHandler>);
+    let config = ServiceConfigBuilder::new()
+        .h1_allow_half_closed(false)
+        .build();
+
+    let mut cx = Context::from_waker(futures_util::task::noop_waker_ref());
+    let disptacher = Dispatcher::new(
+        buf.clone(),
+        services,
+        config,
+        None,
+        OnConnectData::default(),
+    );
+    pin!(disptacher);
+
+    assert!(disptacher.as_mut().poll(&mut cx).is_pending());
+    assert_eq!(disptacher.poll_count, 1);
+
+    assert!(disptacher.as_mut().poll(&mut cx).is_ready());
+    assert_eq!(disptacher.poll_count, 2);
+
+    let res = BytesMut::from(buf.take_write_buf().as_ref());
+    assert!(res.is_empty());
+
+    let DispatcherStateProj::Normal { inner } = disptacher.as_mut().project().inner.project()
+    else {
+        panic!("End dispatcher state should be Normal");
+    };
+    assert!(matches!(inner.state, State::ServiceCall { .. }))
 }
 
 fn http_msg(msg: impl AsRef<str>) -> BytesMut {

--- a/actix-http/src/lib.rs
+++ b/actix-http/src/lib.rs
@@ -63,7 +63,7 @@ pub use self::payload::PayloadStream;
 pub use self::service::TlsAcceptorConfig;
 pub use self::{
     builder::HttpServiceBuilder,
-    config::ServiceConfig,
+    config::{ServiceConfig, ServiceConfigBuilder},
     error::Error,
     extensions::Extensions,
     header::ContentEncoding,

--- a/actix-http/src/test.rs
+++ b/actix-http/src/test.rs
@@ -337,8 +337,8 @@ impl io::Read for TestSeqBuffer {
         let mut inner = self.0.borrow_mut();
 
         if inner.read_buf.is_empty() {
-            if let Some(e) = inner.err.take() {
-                Err(e)
+            if let Some(err) = inner.err.take() {
+                Err(err)
             } else if inner.read_closed {
                 Ok(0)
             } else {

--- a/actix-http/src/test.rs
+++ b/actix-http/src/test.rs
@@ -275,6 +275,7 @@ impl TestSeqBuffer {
     {
         Self(Rc::new(RefCell::new(TestSeqInner {
             read_buf: data.into(),
+            read_closed: false,
             write_buf: BytesMut::new(),
             err: None,
         })))
@@ -293,36 +294,59 @@ impl TestSeqBuffer {
         Ref::map(self.0.borrow(), |inner| &inner.write_buf)
     }
 
+    pub fn take_write_buf(&self) -> Bytes {
+        self.0.borrow_mut().write_buf.split().freeze()
+    }
+
     pub fn err(&self) -> Ref<'_, Option<io::Error>> {
         Ref::map(self.0.borrow(), |inner| &inner.err)
     }
 
     /// Add data to read buffer.
+    ///
+    /// # Panics
+    ///
+    /// Panics if called after [`TestSeqBuffer::close_read`] has been called
     pub fn extend_read_buf<T: AsRef<[u8]>>(&mut self, data: T) {
-        self.0
-            .borrow_mut()
-            .read_buf
-            .extend_from_slice(data.as_ref())
+        let mut inner = self.0.borrow_mut();
+        if inner.read_closed {
+            panic!("Tried to extend the read buffer after calling close_read");
+        }
+
+        inner.read_buf.extend_from_slice(data.as_ref())
+    }
+
+    /// Closes the [`AsyncRead`]/[`Read`] part of this test buffer.
+    ///
+    /// The current data in the buffer will still be returned by a call to read/poll_read, however,
+    /// after the buffer is empty, it will return `Ok(0)` to signify the EOF condition
+    pub fn close_read(&self) {
+        self.0.borrow_mut().read_closed = true;
     }
 }
 
 pub struct TestSeqInner {
     read_buf: BytesMut,
+    read_closed: bool,
     write_buf: BytesMut,
     err: Option<io::Error>,
 }
 
 impl io::Read for TestSeqBuffer {
     fn read(&mut self, dst: &mut [u8]) -> Result<usize, io::Error> {
-        if self.0.borrow().read_buf.is_empty() {
-            if self.0.borrow().err.is_some() {
-                Err(self.0.borrow_mut().err.take().unwrap())
+        let mut inner = self.0.borrow_mut();
+
+        if inner.read_buf.is_empty() {
+            if let Some(e) = inner.err.take() {
+                Err(e)
+            } else if inner.read_closed {
+                Ok(0)
             } else {
                 Err(io::Error::new(io::ErrorKind::WouldBlock, ""))
             }
         } else {
-            let size = std::cmp::min(self.0.borrow().read_buf.len(), dst.len());
-            let b = self.0.borrow_mut().read_buf.split_to(size);
+            let size = std::cmp::min(inner.read_buf.len(), dst.len());
+            let b = inner.read_buf.split_to(size);
             dst[..size].copy_from_slice(&b);
             Ok(size)
         }

--- a/actix-web/src/server.rs
+++ b/actix-web/src/server.rs
@@ -31,6 +31,7 @@ struct Config {
     keep_alive: KeepAlive,
     client_request_timeout: Duration,
     client_disconnect_timeout: Duration,
+    h1_allow_half_closed: bool,
     #[allow(dead_code)] // only dead when no TLS features are enabled
     tls_handshake_timeout: Option<Duration>,
 }
@@ -116,6 +117,7 @@ where
                 keep_alive: KeepAlive::default(),
                 client_request_timeout: Duration::from_secs(5),
                 client_disconnect_timeout: Duration::from_secs(1),
+                h1_allow_half_closed: true,
                 tls_handshake_timeout: None,
             })),
             backlog: 1024,
@@ -255,6 +257,18 @@ where
     #[deprecated(since = "4.0.0", note = "Renamed to `client_disconnect_timeout`.")]
     pub fn client_shutdown(self, dur: u64) -> Self {
         self.client_disconnect_timeout(Duration::from_millis(dur))
+    }
+
+    /// Sets whether HTTP/1 connections should support half-closures.
+    ///
+    /// Clients can choose to shutdown their writer-side of the connection after completing their
+    /// request and while waiting for the server response. Setting this to `false` will cause the
+    /// server to abort the connection handling as soon as it detects an EOF from the client.
+    ///
+    /// The default behavior is to allow, i.e. `true`
+    pub fn h1_allow_half_closed(self, allow: bool) -> Self {
+        self.config.lock().unwrap().h1_allow_half_closed = allow;
+        self
     }
 
     /// Sets function that will be called once before each connection is handled.
@@ -558,6 +572,7 @@ where
                         .keep_alive(cfg.keep_alive)
                         .client_request_timeout(cfg.client_request_timeout)
                         .client_disconnect_timeout(cfg.client_disconnect_timeout)
+                        .h1_allow_half_closed(cfg.h1_allow_half_closed)
                         .local_addr(addr);
 
                     if let Some(handler) = on_connect_fn.clone() {
@@ -602,6 +617,7 @@ where
                         .keep_alive(cfg.keep_alive)
                         .client_request_timeout(cfg.client_request_timeout)
                         .client_disconnect_timeout(cfg.client_disconnect_timeout)
+                        .h1_allow_half_closed(cfg.h1_allow_half_closed)
                         .local_addr(addr);
 
                     if let Some(handler) = on_connect_fn.clone() {
@@ -677,6 +693,7 @@ where
                     let svc = HttpService::build()
                         .keep_alive(c.keep_alive)
                         .client_request_timeout(c.client_request_timeout)
+                        .h1_allow_half_closed(c.h1_allow_half_closed)
                         .client_disconnect_timeout(c.client_disconnect_timeout);
 
                     let svc = if let Some(handler) = on_connect_fn.clone() {
@@ -728,6 +745,7 @@ where
                     let svc = HttpService::build()
                         .keep_alive(c.keep_alive)
                         .client_request_timeout(c.client_request_timeout)
+                        .h1_allow_half_closed(c.h1_allow_half_closed)
                         .client_disconnect_timeout(c.client_disconnect_timeout);
 
                     let svc = if let Some(handler) = on_connect_fn.clone() {
@@ -794,6 +812,7 @@ where
                     let svc = HttpService::build()
                         .keep_alive(c.keep_alive)
                         .client_request_timeout(c.client_request_timeout)
+                        .h1_allow_half_closed(c.h1_allow_half_closed)
                         .client_disconnect_timeout(c.client_disconnect_timeout);
 
                     let svc = if let Some(handler) = on_connect_fn.clone() {
@@ -860,6 +879,7 @@ where
                     let svc = HttpService::build()
                         .keep_alive(c.keep_alive)
                         .client_request_timeout(c.client_request_timeout)
+                        .h1_allow_half_closed(c.h1_allow_half_closed)
                         .client_disconnect_timeout(c.client_disconnect_timeout);
 
                     let svc = if let Some(handler) = on_connect_fn.clone() {
@@ -927,6 +947,7 @@ where
                         .keep_alive(c.keep_alive)
                         .client_request_timeout(c.client_request_timeout)
                         .client_disconnect_timeout(c.client_disconnect_timeout)
+                        .h1_allow_half_closed(c.h1_allow_half_closed)
                         .local_addr(addr);
 
                     let svc = if let Some(handler) = on_connect_fn.clone() {
@@ -995,6 +1016,7 @@ where
                         .keep_alive(c.keep_alive)
                         .client_request_timeout(c.client_request_timeout)
                         .client_disconnect_timeout(c.client_disconnect_timeout)
+                        .h1_allow_half_closed(c.h1_allow_half_closed)
                         .finish(map_config(fac, move |_| config.clone())),
                 )
             },
@@ -1036,6 +1058,7 @@ where
                 let mut svc = HttpService::build()
                     .keep_alive(c.keep_alive)
                     .client_request_timeout(c.client_request_timeout)
+                    .h1_allow_half_closed(c.h1_allow_half_closed)
                     .client_disconnect_timeout(c.client_disconnect_timeout);
 
                 if let Some(handler) = on_connect_fn.clone() {


### PR DESCRIPTION
## PR Type

Bug fix / Feature

## PR Checklist

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [ ] (Team) Label with affected crates and semver status.

## Overview

Closes #3748

First, this PR adds the `ServiceConfigBuilder` type, because currently it's difficult to extend the config type itself.

With that in place, this PR adds an option to allow/disallow half closures in HTTP/1 (i.e. client closes its writer side of the connection but still expects a response). This option defaults to allow, reverting back to the behavior before #3665, cc @bitcapybara .