### PR TITLE
fix: rename doc_auto_cfg feature

### DIFF
--- a/actix-files/src/lib.rs
+++ b/actix-files/src/lib.rs
@@ -14,7 +14,7 @@
 #![warn(missing_docs, missing_debug_implementations)]
 #![doc(html_logo_url = "https://actix.rs/img/logo.png")]
 #![doc(html_favicon_url = "https://actix.rs/favicon.ico")]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 use std::path::Path;
 

--- a/actix-http-test/src/lib.rs
+++ b/actix-http-test/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![doc(html_logo_url = "https://actix.rs/img/logo.png")]
 #![doc(html_favicon_url = "https://actix.rs/favicon.ico")]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(feature = "openssl")]
 extern crate tls_openssl as openssl;

--- a/actix-http/src/lib.rs
+++ b/actix-http/src/lib.rs
@@ -27,7 +27,7 @@
 )]
 #![doc(html_logo_url = "https://actix.rs/img/logo.png")]
 #![doc(html_favicon_url = "https://actix.rs/favicon.ico")]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub use http::{uri, uri::Uri, Method, StatusCode, Version};
 

--- a/actix-multipart-derive/src/lib.rs
+++ b/actix-multipart-derive/src/lib.rs
@@ -4,7 +4,7 @@
 
 #![doc(html_logo_url = "https://actix.rs/img/logo.png")]
 #![doc(html_favicon_url = "https://actix.rs/favicon.ico")]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![allow(clippy::disallowed_names)] // false positives in some macro expansions
 
 use std::collections::HashSet;

--- a/actix-multipart/src/lib.rs
+++ b/actix-multipart/src/lib.rs
@@ -64,7 +64,7 @@
 
 #![doc(html_logo_url = "https://actix.rs/img/logo.png")]
 #![doc(html_favicon_url = "https://actix.rs/favicon.ico")]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 // This allows us to use the actix_multipart_derive within this crate's tests
 #[cfg(test)]

--- a/actix-router/src/lib.rs
+++ b/actix-router/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![doc(html_logo_url = "https://actix.rs/img/logo.png")]
 #![doc(html_favicon_url = "https://actix.rs/favicon.ico")]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 mod de;
 mod path;

--- a/actix-test/src/lib.rs
+++ b/actix-test/src/lib.rs
@@ -29,7 +29,7 @@
 
 #![doc(html_logo_url = "https://actix.rs/img/logo.png")]
 #![doc(html_favicon_url = "https://actix.rs/favicon.ico")]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(feature = "openssl")]
 extern crate tls_openssl as openssl;

--- a/actix-web-actors/src/lib.rs
+++ b/actix-web-actors/src/lib.rs
@@ -59,7 +59,7 @@
 
 #![doc(html_logo_url = "https://actix.rs/img/logo.png")]
 #![doc(html_favicon_url = "https://actix.rs/favicon.ico")]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 mod context;
 pub mod ws;

--- a/actix-web-codegen/src/lib.rs
+++ b/actix-web-codegen/src/lib.rs
@@ -75,7 +75,7 @@
 #![recursion_limit = "512"]
 #![doc(html_logo_url = "https://actix.rs/img/logo.png")]
 #![doc(html_favicon_url = "https://actix.rs/favicon.ico")]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 use proc_macro::TokenStream;
 use quote::quote;

--- a/actix-web/src/lib.rs
+++ b/actix-web/src/lib.rs
@@ -72,7 +72,7 @@
 
 #![doc(html_logo_url = "https://actix.rs/img/logo.png")]
 #![doc(html_favicon_url = "https://actix.rs/favicon.ico")]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub use actix_http::{body, HttpMessage};
 #[cfg(feature = "cookies")]

--- a/awc/src/lib.rs
+++ b/awc/src/lib.rs
@@ -108,7 +108,7 @@
 )]
 #![doc(html_logo_url = "https://actix.rs/img/logo.png")]
 #![doc(html_favicon_url = "https://actix.rs/favicon.ico")]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub use actix_http::body;
 #[cfg(feature = "cookies")]


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type

Other 

## PR Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [ ] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.

## Overview

The feature has been merged into `doc_cfg`: https://github.com/rust-lang/rust/pull/138907
