### PR TITLE
fix(awc): close connections after GO_AWAY local or remote GO_AWAY errors

### DIFF
--- a/awc/CHANGES.md
+++ b/awc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix a bug where `GO_AWAY` errors did not stop connections from returning to the pool.
+
 ## 3.8.0
 
 - Add `hickory-dns` crate feature (off-by-default).

--- a/awc/src/client/h2proto.rs
+++ b/awc/src/client/h2proto.rs
@@ -107,7 +107,7 @@ where
 
     let res = poll_fn(|cx| io.poll_ready(cx)).await;
     if let Err(err) = res {
-        io.on_release(err.is_io());
+        io.on_release(err.is_io() || err.is_go_away());
         return Err(SendRequestError::from(err));
     }
 
@@ -121,7 +121,7 @@ where
             fut.await.map_err(SendRequestError::from)?
         }
         Err(err) => {
-            io.on_release(err.is_io());
+            io.on_release(err.is_io() || err.is_go_away());
             return Err(err.into());
         }
     };


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type

<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->

Bug Fix

## PR Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [ ] (Team) Label with affected crates and semver status.

## Overview

This fix attempts to resolve the issue described here: https://github.com/actix/actix-web/issues/3788

Essentially local GO_AWAY errors are generated by `h2` when a connection has seen too many local-resets (such as from locally-enforced timeouts).

This is a more general fix than seen here: https://github.com/actix/actix-web/pull/3678 which resolves a very similar issue with remote-resets also being ignored.

This fix would have a go away - whether generated locally by `h2` or remotely - cause the connection to be closed instead of returned to the pool for reuse.

<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->

Closes #3788 
Closes #3678
