### PR TITLE
chore: Add public export for `EitherExtractError`

### DIFF
--- a/actix-web/CHANGES.md
+++ b/actix-web/CHANGES.md
@@ -5,7 +5,7 @@
 - `actix_web::response::builder::HttpResponseBuilder::streaming()` now sets `Content-Type` to `application/octet-stream` if `Content-Type` does not exist.
 - `actix_web::response::builder::HttpResponseBuilder::streaming()` now calls `actix_web::response::builder::HttpResponseBuilder::no_chunking()` if `Content-Length` is set by user.
 - Add `ws` crate feature (on-by-default) which forwards to `actix-http` and guards some of its `ResponseError` impls.
-- Add public export for `EitherExtractError`.
+- Add public export for `EitherExtractError` in `error` module.
 
 ## 4.11.0
 

--- a/actix-web/CHANGES.md
+++ b/actix-web/CHANGES.md
@@ -5,6 +5,7 @@
 - `actix_web::response::builder::HttpResponseBuilder::streaming()` now sets `Content-Type` to `application/octet-stream` if `Content-Type` does not exist.
 - `actix_web::response::builder::HttpResponseBuilder::streaming()` now calls `actix_web::response::builder::HttpResponseBuilder::no_chunking()` if `Content-Length` is set by user.
 - Add `ws` crate feature (on-by-default) which forwards to `actix-http` and guards some of its `ResponseError` impls.
+- Add public export for `EitherExtractError`.
 
 ## 4.11.0
 

--- a/actix-web/src/error/mod.rs
+++ b/actix-web/src/error/mod.rs
@@ -21,6 +21,7 @@ mod response_error;
 
 pub(crate) use self::macros::{downcast_dyn, downcast_get_type_id};
 pub use self::{error::Error, internal::*, response_error::ResponseError};
+pub use crate::types::EitherExtractError;
 
 /// A convenience [`Result`](std::result::Result) for Actix Web operations.
 ///

--- a/actix-web/src/lib.rs
+++ b/actix-web/src/lib.rs
@@ -121,7 +121,7 @@ pub use crate::{
     route::Route,
     scope::Scope,
     server::HttpServer,
-    types::{Either, EitherExtractError},
+    types::Either,
 };
 
 macro_rules! codegen_reexport {

--- a/actix-web/src/lib.rs
+++ b/actix-web/src/lib.rs
@@ -121,7 +121,7 @@ pub use crate::{
     route::Route,
     scope::Scope,
     server::HttpServer,
-    types::Either,
+    types::{Either, EitherExtractError},
 };
 
 macro_rules! codegen_reexport {

--- a/actix-web/src/types/mod.rs
+++ b/actix-web/src/types/mod.rs
@@ -11,7 +11,7 @@ mod query;
 mod readlines;
 
 pub use self::{
-    either::Either,
+    either::{Either, EitherExtractError},
     form::{Form, FormConfig, UrlEncoded},
     header::Header,
     html::Html,


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type

<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->

Refactor

## PR Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->



- ~~Tests for the changes have been added / updated.~~
- ~~Documentation comments have been added / updated.~~
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.
## Overview

Exports `EitherExtractError` in the `error` module, making it accessible 
for users who need to handle errors when working with `Either<A, B>` extractors


<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
Closes #3541 
