### PR TITLE
Changed HttpMessage content_type from &str to Option<&str>

### DIFF
--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 3.11.3
+
+- Update `HttpMessage`s `content_type` method to return `Option<&str>` instead of `&str`.
+
 ## 3.11.2
 
 - Properly wake Payload receivers when feeding errors or EOF.

--- a/actix-web/src/test/test_utils.rs
+++ b/actix-web/src/test/test_utils.rs
@@ -505,7 +505,10 @@ mod tests {
             .set_form(&payload)
             .to_request();
 
-        assert_eq!(req.content_type(), "application/x-www-form-urlencoded");
+        assert_eq!(
+            req.content_type().unwrap(),
+            "application/x-www-form-urlencoded"
+        );
 
         let result: Person = call_and_read_body_json(&app, req).await;
         assert_eq!(&result.id, "12345");
@@ -549,7 +552,7 @@ mod tests {
             .set_json(&payload)
             .to_request();
 
-        assert_eq!(req.content_type(), "application/json");
+        assert_eq!(req.content_type(), Some("application/json"));
 
         let result: Person = call_and_read_body_json(&app, req).await;
         assert_eq!(&result.id, "12345");

--- a/actix-web/src/types/form.rs
+++ b/actix-web/src/types/form.rs
@@ -289,7 +289,7 @@ impl<T> UrlEncoded<T> {
     /// Create a new future to decode a URL encoded request payload.
     pub fn new(req: &HttpRequest, payload: &mut Payload) -> Self {
         // check content type
-        if req.content_type().to_lowercase() != "application/x-www-form-urlencoded" {
+        if req.content_type() != Some("application/x-www-form-urlencoded") {
             return Self::err(UrlencodedError::ContentType);
         }
         let encoding = match req.encoding() {


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type

<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->

Refactor

## PR Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.

## Overview

Changed the return type of the method content_type of the trait HttpMessage. The tests and other parts of the code that used this method were also updated. I was able to compile the project successfully.

<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
Closes #3797 
