### PR TITLE
fix(*): replace rustls-pemfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ dependencies = [
  "rcgen",
  "regex",
  "rustls 0.23.35",
- "rustls-pemfile",
+ "rustls-pki-types",
  "rustversion",
  "serde",
  "serde_json",
@@ -388,7 +388,7 @@ dependencies = [
  "regex",
  "regex-lite",
  "rustls 0.23.35",
- "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -649,7 +649,7 @@ dependencies = [
  "rustls 0.21.12",
  "rustls 0.22.4",
  "rustls 0.23.35",
- "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -2532,19 +2532,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "rustls-pki-types"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94182ad936a0c91c324cd46c6511b9510ed16af436d7b5bab34beab0afd55f7a"
+checksum = "708c0f9d5f54ba0272468c1d306a52c495b31fa155e91bc25371e6df7996908c"
 dependencies = [
  "zeroize",
 ]

--- a/actix-http/Cargo.toml
+++ b/actix-http/Cargo.toml
@@ -149,7 +149,7 @@ memchr = "2.4"
 once_cell = "1.21"
 rcgen = "0.13"
 regex = "1.3"
-rustls-pemfile = "2"
+rustls-pki-types = "1.13.1"
 rustversion = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"

--- a/actix-http/examples/tls_rustls.rs
+++ b/actix-http/examples/tls_rustls.rs
@@ -45,25 +45,14 @@ async fn main() -> io::Result<()> {
 fn rustls_config() -> rustls::ServerConfig {
     let rcgen::CertifiedKey { cert, key_pair } =
         rcgen::generate_simple_self_signed(["localhost".to_owned()]).unwrap();
-    let cert_file = cert.pem();
-    let key_file = key_pair.serialize_pem();
-
-    let cert_file = &mut io::BufReader::new(cert_file.as_bytes());
-    let key_file = &mut io::BufReader::new(key_file.as_bytes());
-
-    let cert_chain = rustls_pemfile::certs(cert_file)
-        .collect::<Result<Vec<_>, _>>()
-        .unwrap();
-    let mut keys = rustls_pemfile::pkcs8_private_keys(key_file)
-        .collect::<Result<Vec<_>, _>>()
-        .unwrap();
+    let cert_chain = vec![cert.der().clone()];
+    let key_der = rustls_pki_types::PrivateKeyDer::Pkcs8(
+        rustls_pki_types::PrivatePkcs8KeyDer::from(key_pair.serialize_der()),
+    );
 
     let mut config = rustls::ServerConfig::builder()
         .with_no_client_auth()
-        .with_single_cert(
-            cert_chain,
-            rustls::pki_types::PrivateKeyDer::Pkcs8(keys.remove(0)),
-        )
+        .with_single_cert(cert_chain, key_der)
         .unwrap();
 
     const H1_ALPN: &[u8] = b"http/1.1";

--- a/actix-http/examples/ws.rs
+++ b/actix-http/examples/ws.rs
@@ -82,29 +82,16 @@ impl Stream for Heartbeat {
 }
 
 fn tls_config() -> rustls::ServerConfig {
-    use std::io::BufReader;
-
-    use rustls_pemfile::{certs, pkcs8_private_keys};
-
     let rcgen::CertifiedKey { cert, key_pair } =
         rcgen::generate_simple_self_signed(["localhost".to_owned()]).unwrap();
-    let cert_file = cert.pem();
-    let key_file = key_pair.serialize_pem();
-
-    let cert_file = &mut BufReader::new(cert_file.as_bytes());
-    let key_file = &mut BufReader::new(key_file.as_bytes());
-
-    let cert_chain = certs(cert_file).collect::<Result<Vec<_>, _>>().unwrap();
-    let mut keys = pkcs8_private_keys(key_file)
-        .collect::<Result<Vec<_>, _>>()
-        .unwrap();
+    let cert_chain = vec![cert.der().clone()];
+    let key_der = rustls_pki_types::PrivateKeyDer::Pkcs8(
+        rustls_pki_types::PrivatePkcs8KeyDer::from(key_pair.serialize_der()),
+    );
 
     let mut config = rustls::ServerConfig::builder()
         .with_no_client_auth()
-        .with_single_cert(
-            cert_chain,
-            rustls::pki_types::PrivateKeyDer::Pkcs8(keys.remove(0)),
-        )
+        .with_single_cert(cert_chain, key_der)
         .unwrap();
 
     config.alpn_protocols.push(b"http/1.1".to_vec());

--- a/actix-http/tests/test_rustls.rs
+++ b/actix-http/tests/test_rustls.rs
@@ -4,7 +4,7 @@ extern crate tls_rustls_023 as rustls;
 
 use std::{
     convert::Infallible,
-    io::{self, BufReader, Write},
+    io::{self, Write},
     net::{SocketAddr, TcpStream as StdTcpStream},
     sync::Arc,
     task::Poll,
@@ -27,7 +27,7 @@ use derive_more::{Display, Error};
 use futures_core::{ready, Stream};
 use futures_util::stream::once;
 use rustls::{pki_types::ServerName, ServerConfig as RustlsServerConfig};
-use rustls_pemfile::{certs, pkcs8_private_keys};
+use rustls_pki_types::{PrivateKeyDer, PrivatePkcs8KeyDer};
 
 async fn load_body<S>(stream: S) -> Result<BytesMut, PayloadError>
 where
@@ -54,23 +54,12 @@ where
 fn tls_config() -> RustlsServerConfig {
     let rcgen::CertifiedKey { cert, key_pair } =
         rcgen::generate_simple_self_signed(["localhost".to_owned()]).unwrap();
-    let cert_file = cert.pem();
-    let key_file = key_pair.serialize_pem();
-
-    let cert_file = &mut BufReader::new(cert_file.as_bytes());
-    let key_file = &mut BufReader::new(key_file.as_bytes());
-
-    let cert_chain = certs(cert_file).collect::<Result<Vec<_>, _>>().unwrap();
-    let mut keys = pkcs8_private_keys(key_file)
-        .collect::<Result<Vec<_>, _>>()
-        .unwrap();
+    let cert_chain = vec![cert.der().clone()];
+    let key_der = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(key_pair.serialize_der()));
 
     let mut config = RustlsServerConfig::builder()
         .with_no_client_auth()
-        .with_single_cert(
-            cert_chain,
-            rustls::pki_types::PrivateKeyDer::Pkcs8(keys.remove(0)),
-        )
+        .with_single_cert(cert_chain, key_der)
         .unwrap();
 
     config.alpn_protocols.push(HTTP1_1_ALPN_PROTOCOL.to_vec());

--- a/actix-web/Cargo.toml
+++ b/actix-web/Cargo.toml
@@ -179,7 +179,7 @@ flate2 = "1.0.13"
 futures-util = { version = "0.3.17", default-features = false, features = ["std"] }
 rand = "0.9"
 rcgen = "0.13"
-rustls-pemfile = "2"
+rustls-pki-types = "1.13.1"
 serde = { version = "1", features = ["derive"] }
 static_assertions = "1"
 tls-openssl = { package = "openssl", version = "0.10.55" }

--- a/actix-web/tests/test_server.rs
+++ b/actix-web/tests/test_server.rs
@@ -688,30 +688,20 @@ async fn test_brotli_encoding_large_openssl() {
 
 #[cfg(feature = "rustls-0_23")]
 mod plus_rustls {
-    use std::io::BufReader;
-
     use rustls::{pki_types::PrivateKeyDer, ServerConfig as RustlsServerConfig};
-    use rustls_pemfile::{certs, pkcs8_private_keys};
+    use rustls_pki_types::PrivatePkcs8KeyDer;
 
     use super::*;
 
     fn tls_config() -> RustlsServerConfig {
         let rcgen::CertifiedKey { cert, key_pair } =
             rcgen::generate_simple_self_signed(["localhost".to_owned()]).unwrap();
-        let cert_file = cert.pem();
-        let key_file = key_pair.serialize_pem();
-
-        let cert_file = &mut BufReader::new(cert_file.as_bytes());
-        let key_file = &mut BufReader::new(key_file.as_bytes());
-
-        let cert_chain = certs(cert_file).collect::<Result<Vec<_>, _>>().unwrap();
-        let mut keys = pkcs8_private_keys(key_file)
-            .collect::<Result<Vec<_>, _>>()
-            .unwrap();
+        let cert_chain = vec![cert.der().clone()];
+        let key_der = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(key_pair.serialize_der()));
 
         RustlsServerConfig::builder()
             .with_no_client_auth()
-            .with_single_cert(cert_chain, PrivateKeyDer::Pkcs8(keys.remove(0)))
+            .with_single_cert(cert_chain, key_der)
             .unwrap()
     }
 

--- a/awc/Cargo.toml
+++ b/awc/Cargo.toml
@@ -149,7 +149,7 @@ flate2 = "1.0.13"
 futures-util = { version = "0.3.17", default-features = false }
 static_assertions = "1.1"
 rcgen = "0.13"
-rustls-pemfile = "2"
+rustls-pki-types = "1.13.1"
 tokio = { version = "1.38.2", features = ["rt-multi-thread", "macros"] }
 zstd = "0.13"
 tls-rustls-0_23 = { package = "rustls", version = "0.23" } # add rustls 0.23 with default features to make aws_lc_rs work in tests


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type

<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->

PR_TYPE

## PR Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [ ] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.

## Overview

The crate has been archived and we have to migrate to rustls-pki-types: https://github.com/rustls/pemfile/issues/61
This resolves the cargo-deny error.
We use it only on dev-deps so there's no effect on users.