### PR TITLE
upgrade cookie to 0.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,7 +82,7 @@ dependencies = [
  "actix-utils",
  "actix-web",
  "async-stream",
- "base64 0.22.1",
+ "base64",
  "bitflags 2.10.0",
  "brotli",
  "bytes",
@@ -623,7 +623,7 @@ dependencies = [
  "actix-tls",
  "actix-utils",
  "actix-web",
- "base64 0.22.1",
+ "base64",
  "brotli",
  "bytes",
  "cfg-if",
@@ -679,12 +679,6 @@ dependencies = [
  "dunce",
  "fs_extra",
 ]
-
-[[package]]
-name = "base64"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
 
 [[package]]
 name = "base64"
@@ -902,12 +896,12 @@ dependencies = [
 
 [[package]]
 name = "cookie"
-version = "0.16.2"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
  "aes-gcm",
- "base64 0.20.0",
+ "base64",
  "hkdf",
  "hmac",
  "percent-encoding",
@@ -2142,7 +2136,7 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "serde_core",
 ]
 

--- a/actix-web/CHANGES.md
+++ b/actix-web/CHANGES.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Minimum supported Rust version (MSRV) is now 1.82.
+- Upgrade cookie dependency 0.16 to 0.18
 
 ## 4.12.1
 

--- a/actix-web/Cargo.toml
+++ b/actix-web/Cargo.toml
@@ -141,7 +141,7 @@ actix-web-codegen = { version = "4.3", optional = true, default-features = false
 bytes = "1"
 bytestring = "1"
 cfg-if = "1"
-cookie = { version = "0.16", features = ["percent-encode"], optional = true }
+cookie = { version = "0.18", features = ["percent-encode"], optional = true }
 derive_more = { version = "2", features = ["as_ref", "deref", "deref_mut", "display", "error", "from"] }
 encoding_rs = "0.8"
 foldhash = "0.1"

--- a/actix-web/src/response/builder.rs
+++ b/actix-web/src/response/builder.rs
@@ -228,12 +228,12 @@ impl HttpResponseBuilder {
     ///
     /// let res = HttpResponse::Ok()
     ///     .cookie(
-    ///         Cookie::build("name", "value")
+    ///         Cookie::build(("name", "value"))
     ///             .domain("www.rust-lang.org")
     ///             .path("/")
     ///             .secure(true)
     ///             .http_only(true)
-    ///             .finish(),
+    ///             .build(),
     ///     )
     ///     .finish();
     /// ```
@@ -243,10 +243,10 @@ impl HttpResponseBuilder {
     /// use actix_web::{HttpResponse, cookie::Cookie};
     ///
     /// // the name, domain and path match the cookie created in the previous example
-    /// let mut cookie = Cookie::build("name", "value-does-not-matter")
+    /// let mut cookie = Cookie::build(("name", "value-does-not-matter"))
     ///     .domain("www.rust-lang.org")
     ///     .path("/")
-    ///     .finish();
+    ///     .build();
     /// cookie.make_removal();
     ///
     /// let res = HttpResponse::Ok()

--- a/actix-web/tests/test_server.rs
+++ b/actix-web/tests/test_server.rs
@@ -745,9 +745,9 @@ async fn test_server_cookies() {
         App::new().default_service(web::to(|| async {
             HttpResponse::Ok()
                 .cookie(
-                    Cookie::build("first", "first_value")
+                    Cookie::build(("first", "first_value"))
                         .http_only(true)
-                        .finish(),
+                        .build(),
                 )
                 .cookie(Cookie::new("second", "first_value"))
                 .cookie(Cookie::new("second", "second_value"))
@@ -760,9 +760,9 @@ async fn test_server_cookies() {
     assert!(res.status().is_success());
 
     {
-        let first_cookie = Cookie::build("first", "first_value")
+        let first_cookie = Cookie::build(("first", "first_value"))
             .http_only(true)
-            .finish();
+            .build();
         let second_cookie = Cookie::new("second", "first_value");
 
         let cookies = res.cookies().expect("To have cookies");

--- a/awc/CHANGES.md
+++ b/awc/CHANGES.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Minimum supported Rust version (MSRV) is now 1.82.
+- Upgrade cookie dependency 0.16 to 0.18
 
 ## 3.8.1
 

--- a/awc/Cargo.toml
+++ b/awc/Cargo.toml
@@ -123,7 +123,7 @@ serde_json = "1.0"
 serde_urlencoded = "0.7"
 tokio = { version = "1.38.2", features = ["sync"] }
 
-cookie = { version = "0.16", features = ["percent-encode"], optional = true }
+cookie = { version = "0.18", features = ["percent-encode"], optional = true }
 
 tls-openssl = { package = "openssl", version = "0.10.55", optional = true }
 tls-rustls-0_20 = { package = "rustls", version = "0.20", optional = true, features = ["dangerous_configuration"] }

--- a/awc/src/test.rs
+++ b/awc/src/test.rs
@@ -108,7 +108,7 @@ mod tests {
         let res = TestResponse::default()
             .version(Version::HTTP_2)
             .insert_header((header::DATE, HttpDate::from(SystemTime::now())))
-            .cookie(cookie::Cookie::build("name", "value").finish())
+            .cookie(cookie::Cookie::build(("name", "value")).build())
             .finish();
         assert!(res.headers().contains_key(header::SET_COOKIE));
         assert!(res.headers().contains_key(header::DATE));

--- a/awc/src/ws.rs
+++ b/awc/src/ws.rs
@@ -543,7 +543,7 @@ mod tests {
             .protocols(["v1", "v2"])
             .set_header_if_none(header::CONTENT_TYPE, "json")
             .set_header_if_none(header::CONTENT_TYPE, "text")
-            .cookie(Cookie::build("cookie1", "value1").finish());
+            .cookie(Cookie::build(("cookie1", "value1")).build());
         assert_eq!(
             req.origin.as_ref().unwrap().to_str().unwrap(),
             "test-origin"

--- a/awc/tests/test_client.rs
+++ b/awc/tests/test_client.rs
@@ -667,13 +667,13 @@ async fn body_streaming_implicit() {
 async fn client_cookie_handling() {
     use std::io::{Error as IoError, ErrorKind};
 
-    let cookie1 = Cookie::build("cookie1", "value1").finish();
-    let cookie2 = Cookie::build("cookie2", "value2")
+    let cookie1 = Cookie::build(("cookie1", "value1")).build();
+    let cookie2 = Cookie::build(("cookie2", "value2"))
         .domain("www.example.org")
         .path("/")
         .secure(true)
         .http_only(true)
-        .finish();
+        .build();
     // Q: are all these clones really necessary? A: Yes, possibly
     let cookie1b = cookie1.clone();
     let cookie2b = cookie2.clone();


### PR DESCRIPTION

<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type

- Other
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->

PR_TYPE

## PR Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [ ] (Team) Label with affected crates and semver status.

## Overview

<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

We use `actix-web`. and finds old `base64` dependency. come from `cookie`, from `actix-web`.
This PR upgrade cookie, and fix cookie's breaking change.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->

> Format code with the latest stable rustfmt.

I run and gets many warnings. no-diff s made.
```console
~/actix-web$ cargo fmt
Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
```