### PR TITLE
fix: exclude dependencies from doc tests

### DIFF
--- a/justfile
+++ b/justfile
@@ -82,10 +82,9 @@ test-coverage-lcov: test-coverage
     cargo {{ toolchain }} llvm-cov report --doctests --lcov --output-path=lcov.info
 
 # Document crates in workspace.
-# FIXME: Re-add `RUSTDOCFLAGS="--cfg=docsrs -Dwarnings"` once crypto-related crates are updated.
 doc *args: && doc-set-workspace-crates
     rm -f "$(cargo metadata --format-version=1 | jq -r '.target_directory')/doc/crates.js"
-    cargo +nightly doc --workspace {{ all_crate_features }} {{ args }}
+    RUSTDOCFLAGS="--cfg=docsrs -Dwarnings" cargo +nightly doc --no-deps --workspace {{ all_crate_features }} {{ args }}
 
 [private]
 doc-set-workspace-crates:


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type

<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->

PR_TYPE

## PR Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [ ] Format code with the latest stable rustfmt.
- [ ] (Team) Label with affected crates and semver status.

## Overview

This excludes external deps from doc tests as there're less practical benefits from running doc tests on external deps.
