### PR TITLE
feat(ci): skip semver-labeling if human added it

### DIFF
--- a/.github/workflows/semver-labeler.yml
+++ b/.github/workflows/semver-labeler.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           toolchain: stable
 
-      - uses: JohnTitor/cargo-semver-checks@affdc88d7edadc20ad05cf7d901097bcd53ef29e # v0.2.0
+      - uses: JohnTitor/cargo-semver-checks@3b76737b550e48ad0bd5912e2757e80eee6294b0 # v0.2.1
         with:
           label-prefix: B-semver-
+          label-strategy: skip-if-human


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type

<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->

PR_TYPE

## PR Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [ ] Format code with the latest stable rustfmt.
- [ ] (Team) Label with affected crates and semver status.

## Overview

Now the action supports labeling strategy: https://github.com/JohnTitor/cargo-semver-checks/releases/tag/v0.2.1
semver-checks is still incomplete and sometimes a minor change is treated as a patch one, for instance. This should resolve such a situation partially.
