### PR TITLE
Add multi-directory static file serving

### DIFF
--- a/actix-files/CHANGES.md
+++ b/actix-files/CHANGES.md
@@ -4,8 +4,10 @@
 
 - Add `Files::try_compressed()` to support serving pre-compressed static files [#2615]
 - Fix handling of `bytes=0-`
+- Add `Files::new_from_array()` and `Files::new_multiple()` methods to support multiple directories from array and iterator, and implement multi-directory static file serving with priority order [#3402]
 
 [#2615]: https://github.com/actix/actix-web/pull/2615
+[#3402]: https://github.com/actix/actix-web/issues/3402
 
 ## 0.6.10
 

--- a/actix-files/src/files.rs
+++ b/actix-files/src/files.rs
@@ -151,6 +151,7 @@ impl Files {
                     Ok(canon_dir) => canon_dir,
                     Err(_) => {
                         log::error!("Specified path is not a directory: {:?}", orig_dir);
+                        // Preserve original path so requests don't fall back to CWD.
                         orig_dir
                     }
                 }

--- a/actix-files/src/service.rs
+++ b/actix-files/src/service.rs
@@ -181,8 +181,8 @@ impl Service<ServiceRequest> for FilesService {
             for directory in &this.directories {
                 let path = directory.join(&path_on_disk);
                 match path.canonicalize() {
-                    Ok(canonical_path) => {
-                        found_path = Some(canonical_path);
+                    Ok(_) => {
+                        found_path = Some(path);
                         break;
                     }
                     Err(err) => {

--- a/actix-files/tests/encoding.rs
+++ b/actix-files/tests/encoding.rs
@@ -202,9 +202,7 @@ async fn test_multiple_directories() {
 
     // Create test files
     std::fs::write("./tests/test1/test.txt", "File from test1").unwrap();
-    while !std::path::Path::new("./tests/test1/test.txt").exists() {}
     std::fs::write("./tests/test2/fallback.txt", "File from test2").unwrap();
-    while !std::path::Path::new("./tests/test2/fallback.txt").exists() {}
 
     // Test multiple directories with new_from_array
     let srv = test::init_service(App::new().service(Files::new_from_array(
@@ -245,9 +243,7 @@ async fn test_multiple_directories_iterator() {
 
     // Create test files
     std::fs::write("./tests/test3/test.txt", "File from test3").unwrap();
-    while !std::path::Path::new("./tests/test3/test.txt").exists() {}
     std::fs::write("./tests/test4/fallback.txt", "File from test4").unwrap();
-    while !std::path::Path::new("./tests/test4/fallback.txt").exists() {}
 
     // Test multiple directories with new_multiple
     let srv = test::init_service(App::new().service(Files::new_multiple(

--- a/actix-files/tests/encoding.rs
+++ b/actix-files/tests/encoding.rs
@@ -193,3 +193,72 @@ async fn partial_range_response_encoding() {
         "identity"
     );
 }
+
+#[actix_web::test]
+async fn test_multiple_directories() {
+    // Create test directories
+    std::fs::create_dir_all("./tests/test1").unwrap();
+    std::fs::create_dir_all("./tests/test2").unwrap();
+
+    // Create test files
+    std::fs::write("./tests/test1/test.txt", "File from test1").unwrap();
+    std::fs::write("./tests/test2/fallback.txt", "File from test2").unwrap();
+
+    // Test multiple directories with new_from_array
+    let srv = test::init_service(App::new().service(Files::new_from_array(
+        "/",
+        &["./tests/test1", "./tests/test2"],
+    )))
+    .await;
+
+    // Test file from first directory
+    let req = TestRequest::with_uri("/test.txt").to_request();
+    let res = test::call_service(&srv, req).await;
+    assert_eq!(res.status(), StatusCode::OK);
+    let body = test::read_body(res).await;
+    assert_eq!(&body[..], b"File from test1");
+
+    // Test file from second directory
+    let req = TestRequest::with_uri("/fallback.txt").to_request();
+    let res = test::call_service(&srv, req).await;
+    assert_eq!(res.status(), StatusCode::OK);
+    let body = test::read_body(res).await;
+    assert_eq!(&body[..], b"File from test2");
+
+    // Test non-existent file
+    let req = TestRequest::with_uri("/non-existent.txt").to_request();
+    let res = test::call_service(&srv, req).await;
+    assert_eq!(res.status(), StatusCode::NOT_FOUND);
+
+    // Clean up
+    let _ = std::fs::remove_dir_all("./tests/test1");
+    let _ = std::fs::remove_dir_all("./tests/test2");
+}
+
+#[actix_web::test]
+async fn test_multiple_directories_iterator() {
+    // Create test directories
+    std::fs::create_dir_all("./tests/test1").unwrap();
+    std::fs::create_dir_all("./tests/test2").unwrap();
+
+    // Create test files
+    std::fs::write("./tests/test1/test.txt", "File from test1").unwrap();
+
+    // Test multiple directories with new_multiple
+    let srv = test::init_service(App::new().service(Files::new_multiple(
+        "/",
+        vec!["./tests/test1", "./tests/test2"],
+    )))
+    .await;
+
+    // Test file from first directory
+    let req = TestRequest::with_uri("/test.txt").to_request();
+    let res = test::call_service(&srv, req).await;
+    assert_eq!(res.status(), StatusCode::OK);
+    let body = test::read_body(res).await;
+    assert_eq!(&body[..], b"File from test1");
+
+    // Clean up
+    let _ = std::fs::remove_dir_all("./tests/test1");
+    let _ = std::fs::remove_dir_all("./tests/test2");
+}

--- a/actix-files/tests/encoding.rs
+++ b/actix-files/tests/encoding.rs
@@ -240,19 +240,19 @@ async fn test_multiple_directories() {
 #[actix_web::test]
 async fn test_multiple_directories_iterator() {
     // Create test directories
-    std::fs::create_dir_all("./tests/test1").unwrap();
-    std::fs::create_dir_all("./tests/test2").unwrap();
+    std::fs::create_dir_all("./tests/test3").unwrap();
+    std::fs::create_dir_all("./tests/test4").unwrap();
 
     // Create test files
-    std::fs::write("./tests/test1/test.txt", "File from test1").unwrap();
-    while !std::path::Path::new("./tests/test1/test.txt").exists() {}
-    std::fs::write("./tests/test2/fallback.txt", "File from test2").unwrap();
-    while !std::path::Path::new("./tests/test2/fallback.txt").exists() {}
+    std::fs::write("./tests/test3/test.txt", "File from test3").unwrap();
+    while !std::path::Path::new("./tests/test3/test.txt").exists() {}
+    std::fs::write("./tests/test4/fallback.txt", "File from test4").unwrap();
+    while !std::path::Path::new("./tests/test4/fallback.txt").exists() {}
 
     // Test multiple directories with new_multiple
     let srv = test::init_service(App::new().service(Files::new_multiple(
         "/",
-        vec!["./tests/test1", "./tests/test2"],
+        vec!["./tests/test3", "./tests/test4"],
     )))
     .await;
 
@@ -261,14 +261,14 @@ async fn test_multiple_directories_iterator() {
     let res = test::call_service(&srv, req).await;
     assert_eq!(res.status(), StatusCode::OK);
     let body = test::read_body(res).await;
-    assert_eq!(&body[..], b"File from test1");
+    assert_eq!(&body[..], b"File from test3");
 
     // Test file from second directory
     let req = TestRequest::with_uri("/fallback.txt").to_request();
     let res = test::call_service(&srv, req).await;
     assert_eq!(res.status(), StatusCode::OK);
     let body = test::read_body(res).await;
-    assert_eq!(&body[..], b"File from test2");
+    assert_eq!(&body[..], b"File from test4");
 
     // Test non-existent file
     let req = TestRequest::with_uri("/non-existent.txt").to_request();
@@ -276,6 +276,6 @@ async fn test_multiple_directories_iterator() {
     assert_eq!(res.status(), StatusCode::NOT_FOUND);
 
     // Clean up
-    let _ = std::fs::remove_dir_all("./tests/test1");
-    let _ = std::fs::remove_dir_all("./tests/test2");
+    let _ = std::fs::remove_dir_all("./tests/test3");
+    let _ = std::fs::remove_dir_all("./tests/test4");
 }


### PR DESCRIPTION
## PR Type

Feature

## PR Checklist

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.

## Overview

Add `Files::new_from_array()` and `Files::new_multiple()` methods to support multiple directories from array and iterator, and implement multi-directory static file serving with priority order.
Close https://github.com/actix/actix-web/issues/3402
 