### PR TITLE
fix(http): drain unread body if chunked and dropped payload

### DIFF
--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -8,11 +8,13 @@
 - Fix truncated body ending without error when connection closed abnormally. [#3067]
 - Add config/method for `TCP_NODELAY`. [#3918]
 - Do not compress 206 Partial Content responses. [#3191]
+- Fix lingering sockets and client stalls when responding early to dropped chunked request payloads. [#2972]
 
 [#3638]: https://github.com/actix/actix-web/issues/3638
 [#3067]: https://github.com/actix/actix-web/pull/3067
 [#3918]: https://github.com/actix/actix-web/pull/3918
 [#3191]: https://github.com/actix/actix-web/issues/3191
+[#2972]: https://github.com/actix/actix-web/issues/2972
 
 ## 3.11.2
 

--- a/actix-http/src/h1/payload.rs
+++ b/actix-http/src/h1/payload.rs
@@ -133,6 +133,11 @@ impl PayloadSender {
             PayloadStatus::Dropped
         }
     }
+
+    #[inline]
+    pub fn is_dropped(&self) -> bool {
+        self.inner.strong_count() == 0
+    }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type

<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->

PR_TYPE

## PR Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [ ] Format code with the latest stable rustfmt.
- [ ] (Team) Label with affected crates and semver status.

## Overview

<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
Fix #2972 

The problem here is that our dispatcher doesn't clean up socket when payload is dropped.
For chunked requests, we should be able to drain payloads safely if it's dropped.