### PR TITLE
fix(web): fix `match_*` incorrectness

### DIFF
--- a/actix-web/CHANGES.md
+++ b/actix-web/CHANGES.md
@@ -3,8 +3,10 @@
 ## Unreleased
 
 - Panic when calling `Route::to()` or `Route::service()` after `Route::wrap()` to prevent silently dropping route middleware. [#3944]
+- Fix `HttpRequest::{match_pattern,match_name}` reporting path-only matches when route guards disambiguate overlapping resources. [#3346]
 
 [#3944]: https://github.com/actix/actix-web/pull/3944
+[#3346]: https://github.com/actix/actix-web/issues/3346
 
 ## 4.13.0
 

--- a/actix-web/src/rmap.rs
+++ b/actix-web/src/rmap.rs
@@ -240,8 +240,38 @@ impl ResourceMap {
         )
     }
 
+    pub(crate) fn is_resource_path_match(&self, resource_path: &[u16]) -> bool {
+        self.find_node_by_resource_path(resource_path)
+            .is_some_and(|node| node.nodes.is_none())
+    }
+
+    pub(crate) fn match_name_by_resource_path(&self, resource_path: &[u16]) -> Option<&str> {
+        self.find_node_by_resource_path(resource_path)?
+            .pattern
+            .name()
+    }
+
+    pub(crate) fn match_pattern_by_resource_path(&self, resource_path: &[u16]) -> Option<String> {
+        self.find_node_by_resource_path(resource_path)?
+            .root_rmap_fn(String::with_capacity(AVG_PATH_LEN), |mut acc, node| {
+                let pattern = node.pattern.pattern()?;
+                acc.push_str(pattern);
+                Some(acc)
+            })
+    }
+
     fn find_matching_node(&self, path: &str) -> Option<&ResourceMap> {
         self._find_matching_node(path).flatten()
+    }
+
+    fn find_node_by_resource_path(&self, resource_path: &[u16]) -> Option<&ResourceMap> {
+        let mut node = self;
+
+        for id in resource_path {
+            node = node.nodes.as_ref()?.get(*id as usize)?;
+        }
+
+        Some(node)
     }
 
     /// Returns `None` if root pattern doesn't match;

--- a/actix-web/src/scope.rs
+++ b/actix-web/src/scope.rs
@@ -533,7 +533,15 @@ impl Service<ServiceRequest> for ScopeService {
             guards.iter().all(|guard| guard.check(&guard_ctx))
         });
 
-        if let Some((srv, _info)) = res {
+        if let Some((srv, info)) = res {
+            req.push_resource_id(info.0);
+
+            let matched = req
+                .resource_map()
+                .is_resource_path_match(req.resource_id_path());
+
+            req.mark_resource_path(matched);
+
             srv.call(req)
         } else {
             self.default.call(req)

--- a/actix-web/src/service.rs
+++ b/actix-web/src/service.rs
@@ -321,6 +321,21 @@ impl ServiceRequest {
             .push(extensions);
     }
 
+    #[inline]
+    pub(crate) fn push_resource_id(&mut self, id: u16) {
+        self.req.push_resource_id(id);
+    }
+
+    #[inline]
+    pub(crate) fn mark_resource_path(&mut self, is_matched: bool) {
+        self.req.mark_resource_path(is_matched);
+    }
+
+    #[inline]
+    pub(crate) fn resource_id_path(&self) -> &[u16] {
+        self.req.resource_path()
+    }
+
     /// Creates a context object for use with a routing [guard](crate::guard).
     #[inline]
     pub fn guard_ctx(&self) -> GuardContext<'_> {


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type

<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->

PR_TYPE

## PR Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [ ] Format code with the latest stable rustfmt.
- [ ] (Team) Label with affected crates and semver status.

## Overview

<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
Fix #3346
This adds an inner state to recognize ambiguous paths correctly.