### PR TITLE
docs: clarify cross-level middleware ordering between App and Scope

### DIFF
--- a/actix-web/src/app.rs
+++ b/actix-web/src/app.rs
@@ -326,6 +326,20 @@ where
     /// Middleware can be applied similarly to individual `Scope`s and `Resource`s.
     /// See [`Scope::wrap`](crate::Scope::wrap) and [`Resource::wrap`].
     ///
+    /// # Middleware Ordering
+    ///
+    /// App-level middleware wraps the entire request router and **always executes before** any
+    /// [`Scope`](crate::Scope)-level or [`Resource`]-level middleware, regardless of the order in
+    /// which services are registered on the builder. Scope middleware cannot bypass or run before
+    /// App middleware.
+    ///
+    /// If you need certain routes to skip a middleware, apply that middleware at the
+    /// [`Scope`](crate::Scope) level instead of the `App` level.
+    ///
+    /// For more info on middleware ordering, see the
+    /// [Cross-Level Middleware Ordering](crate::middleware#cross-level-middleware-ordering)
+    /// section.
+    ///
     /// For more info on middleware take a look at the [`middleware` module][crate::middleware].
     ///
     /// # Examples


### PR DESCRIPTION
## Summary

Fixes the documentation gap described in #2993.

The existing docs state:
> Middleware is registered for each App, Scope, or Resource and executed in opposite order as registration.

This is accurate _within_ a single level, but misleading when middleware is registered at both the `App` level and a `Scope` level. Users reasonably expect a scope-level middleware to run before an app-level one (since it appears "later in registration"), but that is not how it works.

## Root Cause

App-level middleware structurally wraps the entire request router. A `Scope` is a service registered _inside_ that router. This means:
- App MW is always the outermost layer
- Routing to a scope happens _inside_ App MW
- Scope MW cannot bypass or run before App MW

This is by design and correct — but it was undocumented.

## Changes

**`actix-web/src/middleware/mod.rs`**
- Qualify the opening "opposite order" statement to note it applies within a single level only
- Add a new **"Cross-Level Middleware Ordering"** section with:
  - Prose explanation of why App MW always runs first
  - ASCII diagram showing the full nesting: App MW → Router → Scope MW → Resource MW → Handler
  - Explicit note that scope MW cannot bypass App MW
  - Code example demonstrating the recommended per-scope pattern

**`actix-web/src/app.rs`**
- Add a **"# Middleware Ordering"** note to `App::wrap`'s doc comment pointing to the new section

## What this does NOT change

- No behavior change — documentation only
- Does not touch `Scope::wrap`, `Resource::wrap`, or `authors-guide.md` (keeping PR scope focused)