### PR TITLE
codegen: auto-register HEAD guard for #[get] routes

### DIFF
--- a/actix-web-codegen/src/route.rs
+++ b/actix-web-codegen/src/route.rs
@@ -240,6 +240,12 @@ impl Args {
 
         let is_route_macro = method.is_none();
         if let Some(method) = method {
+            // Per RFC 7231 Section 4.3.2, a server that supports GET must also
+            // support HEAD. Automatically register a HEAD guard alongside GET
+            // so that `#[get(...)]` handlers respond to HEAD requests.
+            if method == MethodType::Get {
+                methods.insert(MethodTypeExt::Standard(MethodType::Head));
+            }
             methods.insert(MethodTypeExt::Standard(method));
         }
 


### PR DESCRIPTION
Per RFC 7231 Section 4.3.2, a server that handles GET must also handle HEAD. Right now if you use `#[get("/foo")]`, HEAD requests to `/foo` return 404 — which is technically non-compliant and surprising.

This adds an implicit HEAD guard alongside GET in the codegen, so `#[get("/path")]` behaves like `#[route("/path", method="GET", method="HEAD")]` without any extra boilerplate.

The workaround today is to write `#[route("/foo", method="GET", method="HEAD")]` but that's easy to forget and not obvious.

**Changes:**
- In `Args::new`, when the method is `Get`, also insert `Head` into the methods set
- Added integration test verifying HEAD requests succeed on `#[get]` endpoints

**Test results:**
```
running 5 tests
test test_auto_async ... ok
test test_wrap ... ok
test test_get_implies_head ... ok
test test_params ... ok
test test_body ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

Fixes #2702