### PR TITLE
awc: add camel_case headers api

### DIFF
--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Encode the HTTP/1 `Connection: Upgrade` header in Camel-Case when camel-case header formatting is enabled.[#3953]
+
+[#3953]: https://github.com/actix/actix-web/pull/3953
+
 ## 3.12.0
 
 - Minimum supported Rust version (MSRV) is now 1.88.

--- a/actix-http/src/h1/encoder.rs
+++ b/actix-http/src/h1/encoder.rs
@@ -117,7 +117,7 @@ pub(crate) trait MessageType: Sized {
                 } else {
                     dst.put_slice(b"connection: upgrade\r\n")
                 }
-            },
+            }
             ConnectionType::KeepAlive if version < Version::HTTP_11 => {
                 if camel_case {
                     dst.put_slice(b"Connection: keep-alive\r\n")
@@ -585,6 +585,16 @@ mod tests {
         assert!(data.contains("Content-Type: plain/text\r\n"));
         assert!(data.contains("Date: date\r\n"));
         assert!(data.contains("Upgrade-Insecure-Requests: 1\r\n"));
+
+        let _ = head.encode_headers(
+            &mut bytes,
+            Version::HTTP_11,
+            BodySize::None,
+            ConnectionType::Upgrade,
+            &ServiceConfig::default(),
+        );
+        let data = String::from_utf8(Vec::from(bytes.split().freeze().as_ref())).unwrap();
+        assert!(data.contains("Connection: Upgrade\r\n"));
 
         let _ = head.encode_headers(
             &mut bytes,

--- a/actix-http/src/h1/encoder.rs
+++ b/actix-http/src/h1/encoder.rs
@@ -113,7 +113,7 @@ pub(crate) trait MessageType: Sized {
         match conn_type {
             ConnectionType::Upgrade => {
                 if camel_case {
-                    dst.put_slice(b"Connection: upgrade\r\n")
+                    dst.put_slice(b"Connection: Upgrade\r\n")
                 } else {
                     dst.put_slice(b"connection: upgrade\r\n")
                 }

--- a/actix-http/src/h1/encoder.rs
+++ b/actix-http/src/h1/encoder.rs
@@ -111,7 +111,13 @@ pub(crate) trait MessageType: Sized {
 
         // Connection
         match conn_type {
-            ConnectionType::Upgrade => dst.put_slice(b"connection: upgrade\r\n"),
+            ConnectionType::Upgrade => {
+                if camel_case {
+                    dst.put_slice(b"Connection: upgrade\r\n")
+                } else {
+                    dst.put_slice(b"connection: upgrade\r\n")
+                }
+            },
             ConnectionType::KeepAlive if version < Version::HTTP_11 => {
                 if camel_case {
                     dst.put_slice(b"Connection: keep-alive\r\n")

--- a/actix-http/src/requests/head.rs
+++ b/actix-http/src/requests/head.rs
@@ -61,14 +61,15 @@ impl RequestHead {
         &mut self.headers
     }
 
-    /// Is to uppercase headers with Camel-Case.
-    /// Default is `false`
+    /// Returns whether headers should be sent in Camel-Case.
+    ///
+    /// Default is `false`.
     #[inline]
     pub fn camel_case_headers(&self) -> bool {
         self.flags.contains(Flags::CAMEL_CASE)
     }
 
-    /// Set `true` to send headers which are formatted as Camel-Case.
+    /// Sets whether to send headers formatted as Camel-Case.
     #[inline]
     pub fn set_camel_case_headers(&mut self, val: bool) {
         if val {

--- a/awc/CHANGES.md
+++ b/awc/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add camel-case header controls to `WebsocketsRequest` via `camel_case_headers()` and `set_camel_case_headers()`. [#3953]
+
+[#3953]: https://github.com/actix/actix-web/pull/3953
+
 ## 3.8.2
 
 - Minimum supported Rust version (MSRV) is now 1.88.

--- a/awc/src/ws.rs
+++ b/awc/src/ws.rs
@@ -245,6 +245,19 @@ impl WebsocketsRequest {
         self.header(AUTHORIZATION, format!("Bearer {}", token))
     }
 
+    /// Is to uppercase headers with Camel-Case.
+    /// Default is `false`
+    #[inline]
+    pub fn camel_case_headers(&self) -> bool {
+        self.head.camel_case_headers()
+    }
+
+    /// Set `true` to send headers which are formatted as Camel-Case.
+    #[inline]
+    pub fn set_camel_case_headers(&mut self, val: bool) {
+        self.head.set_camel_case_headers(val)
+    }
+
     /// Complete request construction and connect to a WebSocket server.
     pub async fn connect(
         mut self,

--- a/awc/src/ws.rs
+++ b/awc/src/ws.rs
@@ -245,17 +245,19 @@ impl WebsocketsRequest {
         self.header(AUTHORIZATION, format!("Bearer {}", token))
     }
 
-    /// Is to uppercase headers with Camel-Case.
-    /// Default is `false`
+    /// Returns whether headers should be sent in Camel-Case.
+    ///
+    /// Default is `false`.
     #[inline]
     pub fn camel_case_headers(&self) -> bool {
         self.head.camel_case_headers()
     }
 
-    /// Set `true` to send headers which are formatted as Camel-Case.
+    /// Sets whether to send headers formatted as Camel-Case.
     #[inline]
-    pub fn set_camel_case_headers(&mut self, val: bool) {
-        self.head.set_camel_case_headers(val)
+    pub fn set_camel_case_headers(mut self, val: bool) -> Self {
+        self.head.set_camel_case_headers(val);
+        self
     }
 
     /// Complete request construction and connect to a WebSocket server.
@@ -540,6 +542,12 @@ mod tests {
 
         #[allow(clippy::let_underscore_future)]
         let _ = req.connect();
+    }
+
+    #[actix_rt::test]
+    async fn camel_case_headers() {
+        let req = Client::new().ws("/").set_camel_case_headers(true);
+        assert!(req.camel_case_headers());
     }
 
     #[actix_rt::test]


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type

<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->

Feature

## PR Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [X] Tests for the changes have been added / updated.
- [X] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [X] Format code with the latest stable rustfmt.
- [ ] (Team) Label with affected crates and semver status.

## Overview

<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

I add `camel_case_headers` and `set_camel_case_headers` to `awc` websocket to provice support header camel case
also fix `Connection: Upgrade` camel case in `actix-http`

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->

Close #3954

