### PR TITLE
docs: Fix default value for HttpServer backlog

### DIFF
--- a/actix-web/src/server.rs
+++ b/actix-web/src/server.rs
@@ -176,7 +176,7 @@ where
     /// results in the client getting an error when attempting to connect. It should only affect
     /// servers under significant load.
     ///
-    /// Generally set in the 64–2048 range. Default value is 2048.
+    /// Generally set in the 64–2048 range. Default value is 1024.
     ///
     /// This method will have no effect if called after a `bind()`.
     pub fn backlog(mut self, backlog: u32) -> Self {


### PR DESCRIPTION
## PR Type

Other (documentation)

## PR Checklist

- [ ] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [ ] Format code with the latest stable rustfmt.
- [ ] (Team) Label with affected crates and semver status.

## Overview

`HttpServer::backlog()` is outdated:  `HttpServer::new()` initialize backlog to 1024 instead of 2048. The default value has been changed from 2048 to 1024 in eae48f9612d2391ead1963a2f49aabfd5b420aac, but the documentation hasn't been updated.

