### PR TITLE
chore(files): upgrade v_htmlescape to 0.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3440,10 +3440,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "v_htmlescape"
-version = "0.15.8"
+name = "v_escape-base"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e8257fbc510f0a46eb602c10215901938b5c2a7d5e70fc11483b1d3c9b5b18c"
+checksum = "f1212fce830b75af194b578e55b3db9049f2c8c45f58d397fb25602fdb50fb3d"
+
+[[package]]
+name = "v_htmlescape"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "befb3d53c9e3ec641417685896cbc8cc5bd264d6a2e190c56aaef1af24740d99"
+dependencies = [
+ "v_escape-base",
+]
 
 [[package]]
 name = "vcpkg"

--- a/actix-files/CHANGES.md
+++ b/actix-files/CHANGES.md
@@ -7,6 +7,7 @@
 - Fix handling of `bytes=0-`
 - Fix `NamedFile` panic when serving files with pre-UNIX epoch modification times. [#2748]
 - Fix invalid `Content-Encoding: identity` header in `NamedFile` range responses. [#3191]
+- Update `v_htmlescape` dependency to `0.17`.
 
 [#3402]: https://github.com/actix/actix-web/issues/3402
 [#2615]: https://github.com/actix/actix-web/pull/2615

--- a/actix-files/Cargo.toml
+++ b/actix-files/Cargo.toml
@@ -32,7 +32,7 @@ mime = "0.3.9"
 mime_guess = "2.0.1"
 percent-encoding = "2.1"
 pin-project-lite = "0.2.7"
-v_htmlescape = "0.15.5"
+v_htmlescape = "0.17"
 
 # experimental-io-uring
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/actix-files/src/directory.rs
+++ b/actix-files/src/directory.rs
@@ -7,7 +7,7 @@ use std::{
 
 use actix_web::{dev::ServiceResponse, HttpRequest, HttpResponse};
 use percent_encoding::{utf8_percent_encode, CONTROLS};
-use v_htmlescape::escape as escape_html_entity;
+use v_htmlescape::escape_fmt;
 
 /// A directory; responds with the generated directory listing.
 #[derive(Debug)]
@@ -64,7 +64,7 @@ macro_rules! encode_file_url {
 /// ```
 macro_rules! encode_file_name {
     ($entry:ident) => {
-        escape_html_entity(&$entry.file_name().to_string_lossy())
+        escape_fmt(&$entry.file_name().to_string_lossy())
     };
 }
 


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type

<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->

PR_TYPE

## PR Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [ ] Format code with the latest stable rustfmt.
- [ ] (Team) Label with affected crates and semver status.

## Overview

Changelog: https://github.com/zzau13/v_escape/releases/tag/v_htmlescape-v0.16.0

The main motivation is to mitigate soundness bug.

<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
