### PR TITLE
docs: fix API documentation label in README

### DIFF
--- a/actix-web/README.md
+++ b/actix-web/README.md
@@ -54,7 +54,7 @@ Please use them in a production environment at your own risk.
 - [Website & User Guide](https://actix.rs)
 - [Examples Repository](https://github.com/actix/examples)
 - [API Documentation](https://docs.rs/actix-web)
-- [API Documentation (mainranch)](https://actix.rs/actix-web/actix_web)
+- [API Documentation (main branch)](https://actix.rs/actix-web/actix_web)
 
 ## Example
 


### PR DESCRIPTION
## Summary

Fix a typo in the README API Documentation label.

Changed:

- `API Documentation (mainranch)`
- to `API Documentation (main branch)`

## Changes

- Updated one documentation label in `actix-web/README.md`.
- No URL or behavior changes.

## Testing

- `git diff --check` passed.
- Full test suite not run because this is a docs-only typo fix.
