### PR TITLE
fix(codegen): deterministic guard order for multi-method routes

### DIFF
--- a/actix-web-codegen/CHANGES.md
+++ b/actix-web-codegen/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Generate deterministic output for routes registered with multiple methods. Previously the method guard chain was emitted in `HashSet` iteration order, which is not stable across compilations and made the generated code non-reproducible.
 - Minimum supported Rust version (MSRV) is now 1.88.
 
 ## 4.3.0

--- a/actix-web-codegen/src/route.rs
+++ b/actix-web-codegen/src/route.rs
@@ -439,7 +439,13 @@ impl ToTokens for Route {
                 let method_guards = {
                     debug_assert!(!methods.is_empty(), "Args::methods should not be empty");
 
-                    let mut others = methods.iter();
+                    // Sort the methods for deterministic codegen. `methods` is a `HashSet`,
+                    // whose iteration order is not stable across compilations; emitting the
+                    // guard chain in that order makes the generated code (and therefore the
+                    // build output) non-reproducible for routes with more than one method.
+                    let mut sorted = methods.iter().collect::<Vec<_>>();
+                    sorted.sort_by_cached_key(|m| m.to_tokens_multi_guard_or_chain().to_string());
+                    let mut others = sorted.into_iter();
                     let first = others.next().unwrap();
 
                     if methods.len() > 1 {


### PR DESCRIPTION
## Problem

`#[route]`, `#[get]`, and the other routing macros store the route's methods in a `HashSet<MethodTypeExt>`. For a route registered with more than one method, the generated guard chain is emitted by iterating that `HashSet`:

```rust
let mut others = methods.iter();
let first = others.next().unwrap();
// ... first.to_tokens_multi_guard(others.map(...))
```

`HashSet` iteration order is not stable across compilations (the hasher is randomly seeded per process), so the generated `guard::Any(..).or(..)` chain comes out in a different order on different builds. That makes the generated code — and therefore any binary that links it — **non-reproducible build to build**.

### Minimal reproduction

```rust
use actix_web::{route, HttpResponse};

#[route("/", method = "GET", method = "HEAD", method = "POST")]
async fn h() -> HttpResponse { HttpResponse::Ok().finish() }
```

Expanding this crate three times (`cargo expand`) yields different output each run — the method guards permute, e.g.:

```
-  ::actix_web::guard::Any(::actix_web::guard::Post()).or(::actix_web::guard::Get())
+  ::actix_web::guard::Any(::actix_web::guard::Get()).or(::actix_web::guard::Post())
```

## Fix

Sort the methods by their rendered guard tokens before emitting the chain, so codegen is stable regardless of `HashSet` iteration order. With the patch the same expansion is byte-identical across repeated builds (0 diff).

The change is limited to the order in which the existing guards are emitted; the set of guards and runtime behavior are unchanged.
