### PR TITLE
Add cargo-fuzz targets for OSS-Fuzz integration

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "actix-fuzz"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+actix-http = { path = "../actix-http" }
+http = "1"
+bytes = "1"
+tokio = { version = "1", features = ["rt", "macros"] }
+
+[[bin]]
+name = "fuzz_header_parse"
+path = "fuzz_targets/fuzz_header_parse.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_uri_parse"
+path = "fuzz_targets/fuzz_uri_parse.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/fuzz_header_parse.rs
+++ b/fuzz/fuzz_targets/fuzz_header_parse.rs
@@ -1,0 +1,20 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use actix_http::header::HeaderMap;
+use http::header::{HeaderName, HeaderValue};
+
+fuzz_target!(|data: &[u8]| {
+    if data.len() < 2 { return; }
+    let split = data[0] as usize % data.len().min(64);
+    let (name, value) = if split < data.len() { 
+        (&data[..split.min(data.len())], &data[split.min(data.len())..])
+    } else {
+        (data, &[] as &[u8])
+    };
+    let _ = HeaderName::from_bytes(name).map(|n| {
+        let _ = HeaderValue::from_bytes(value).map(|v| {
+            let mut map = HeaderMap::new();
+            map.insert(n, v);
+        });
+    });
+});

--- a/fuzz/fuzz_targets/fuzz_uri_parse.rs
+++ b/fuzz/fuzz_targets/fuzz_uri_parse.rs
@@ -1,0 +1,8 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use bytes::Bytes;
+use http::Uri;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = Uri::from_maybe_shared(Bytes::copy_from_slice(data));
+});


### PR DESCRIPTION
Adds cargo-fuzz targets for OSS-Fuzz integration covering pre-auth HTTP parsing: header parsing + URI parsing.