### PR TITLE
Add support for the HTTP QUERY method (RFC 10008)

### DIFF
--- a/actix-http-test/CHANGES.md
+++ b/actix-http-test/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add `TestServer::{query, squery}()` for issuing HTTP `QUERY` requests (RFC 10008).
 - Minimum supported Rust version (MSRV) is now 1.88.
 
 ## 3.2.0

--- a/actix-http-test/CHANGES.md
+++ b/actix-http-test/CHANGES.md
@@ -2,8 +2,10 @@
 
 ## Unreleased
 
-- Add `TestServer::{query, squery}()` for issuing HTTP `QUERY` requests (RFC 10008).
+- Add `TestServer::{query, squery}()` for issuing HTTP `QUERY` requests (RFC 10008). [#4140]
 - Minimum supported Rust version (MSRV) is now 1.88.
+
+[#4140]: https://github.com/actix/actix-web/pull/4140
 
 ## 3.2.0
 

--- a/actix-http-test/src/lib.rs
+++ b/actix-http-test/src/lib.rs
@@ -216,6 +216,16 @@ impl TestServer {
         self.client.patch(self.surl(path.as_ref()).as_str())
     }
 
+    /// Create `QUERY` request
+    pub fn query<S: AsRef<str>>(&self, path: S) -> ClientRequest {
+        self.client.query(self.url(path.as_ref()).as_str())
+    }
+
+    /// Create HTTPS `QUERY` request
+    pub fn squery<S: AsRef<str>>(&self, path: S) -> ClientRequest {
+        self.client.query(self.surl(path.as_ref()).as_str())
+    }
+
     /// Create `DELETE` request
     pub fn delete<S: AsRef<str>>(&self, path: S) -> ClientRequest {
         self.client.delete(self.url(path.as_ref()).as_str())

--- a/actix-http/tests/test_rustls.rs
+++ b/actix-http/tests/test_rustls.rs
@@ -193,6 +193,25 @@ async fn h2_1() -> io::Result<()> {
 }
 
 #[actix_rt::test]
+async fn h2_squery() -> io::Result<()> {
+    let mut srv = test_server(move || {
+        HttpService::build()
+            .h2(|req: Request| {
+                assert_eq!(req.method().as_str(), "QUERY");
+                assert_eq!(req.version(), Version::HTTP_2);
+                ok::<_, Error>(Response::ok())
+            })
+            .rustls_0_23(tls_config_h2())
+    })
+    .await;
+
+    let response = srv.squery("/").send().await.unwrap();
+    assert!(response.status().is_success());
+    srv.stop().await;
+    Ok(())
+}
+
+#[actix_rt::test]
 async fn h2_tcp_nodelay_override_true() -> io::Result<()> {
     let mut srv = test_server(move || {
         HttpService::build()

--- a/actix-http/tests/test_server.rs
+++ b/actix-http/tests/test_server.rs
@@ -65,6 +65,24 @@ async fn h1_2() {
     srv.stop().await;
 }
 
+#[actix_rt::test]
+async fn h1_query() {
+    let mut srv = test_server(|| {
+        HttpService::build()
+            .h1(|req: Request| {
+                assert_eq!(req.method().as_str(), "QUERY");
+                ok::<_, Infallible>(Response::ok())
+            })
+            .tcp()
+    })
+    .await;
+
+    let response = srv.query("/").send().await.unwrap();
+    assert!(response.status().is_success());
+
+    srv.stop().await;
+}
+
 #[derive(Debug, Display, Error)]
 #[display("expect failed")]
 struct ExpectFailed;

--- a/actix-test/CHANGES.md
+++ b/actix-test/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add `TestServer::query()` for issuing HTTP `QUERY` requests (RFC 10008).
 - Minimum supported Rust version (MSRV) is now 1.88.
 
 ## 0.1.5

--- a/actix-test/CHANGES.md
+++ b/actix-test/CHANGES.md
@@ -2,8 +2,10 @@
 
 ## Unreleased
 
-- Add `TestServer::query()` for issuing HTTP `QUERY` requests (RFC 10008).
+- Add `TestServer::query()` for issuing HTTP `QUERY` requests (RFC 10008). [#4140]
 - Minimum supported Rust version (MSRV) is now 1.88.
+
+[#4140]: https://github.com/actix/actix-web/pull/4140
 
 ## 0.1.5
 

--- a/actix-test/src/lib.rs
+++ b/actix-test/src/lib.rs
@@ -697,6 +697,11 @@ impl TestServer {
         self.client.patch(self.url(path.as_ref()).as_str())
     }
 
+    /// Create `QUERY` request.
+    pub fn query(&self, path: impl AsRef<str>) -> ClientRequest {
+        self.client.query(self.url(path.as_ref()).as_str())
+    }
+
     /// Create `DELETE` request.
     pub fn delete(&self, path: impl AsRef<str>) -> ClientRequest {
         self.client.delete(self.url(path.as_ref()).as_str())

--- a/actix-web-codegen/CHANGES.md
+++ b/actix-web-codegen/CHANGES.md
@@ -2,8 +2,10 @@
 
 ## Unreleased
 
-- Add `#[query]` macro for routing the HTTP `QUERY` method (RFC 10008).
+- Add `#[query]` macro for routing the HTTP `QUERY` method (RFC 10008). [#4140]
 - Minimum supported Rust version (MSRV) is now 1.88.
+
+[#4140]: https://github.com/actix/actix-web/pull/4140
 
 ## 4.3.0
 

--- a/actix-web-codegen/CHANGES.md
+++ b/actix-web-codegen/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add `#[query]` macro for routing the HTTP `QUERY` method (RFC 10008).
 - Minimum supported Rust version (MSRV) is now 1.88.
 
 ## 4.3.0

--- a/actix-web-codegen/src/lib.rs
+++ b/actix-web-codegen/src/lib.rs
@@ -21,7 +21,8 @@
 //! There is a macro to set up a handler for each of the most common HTTP methods that also define
 //! additional guards and route-specific middleware.
 //!
-//! See docs for: [GET], [POST], [PATCH], [PUT], [DELETE], [HEAD], [CONNECT], [OPTIONS], [TRACE]
+//! See docs for: [GET], [POST], [PATCH], [PUT], [DELETE], [HEAD], [CONNECT], [OPTIONS], [TRACE],
+//! [QUERY]
 //!
 //! ```
 //! # use actix_web::HttpResponse;
@@ -71,6 +72,7 @@
 //! [TRACE]: macro@trace
 //! [PATCH]: macro@patch
 //! [DELETE]: macro@delete
+//! [QUERY]: macro@query
 
 #![recursion_limit = "512"]
 #![doc(html_logo_url = "https://actix.rs/img/logo.png")]
@@ -195,6 +197,7 @@ method_macro!(Connect, connect);
 method_macro!(Options, options);
 method_macro!(Trace, trace);
 method_macro!(Patch, patch);
+method_macro!(Query, query);
 
 /// Prepends a path prefix to all handlers using routing macros inside the attached module.
 ///

--- a/actix-web-codegen/src/route.rs
+++ b/actix-web-codegen/src/route.rs
@@ -101,6 +101,7 @@ standard_method_type! {
     Options,   OPTIONS, options,
     Trace,     TRACE,   trace,
     Patch,     PATCH,   patch,
+    Query,     QUERY,   query,
 }
 
 impl TryFrom<&syn::LitStr> for MethodType {

--- a/actix-web-codegen/tests/routes.rs
+++ b/actix-web-codegen/tests/routes.rs
@@ -11,7 +11,7 @@ use actix_web::{
     web, App, Error, HttpRequest, HttpResponse, Responder,
 };
 use actix_web_codegen::{
-    connect, delete, get, head, options, patch, post, put, route, routes, trace,
+    connect, delete, get, head, options, patch, post, put, query, route, routes, trace,
 };
 use futures_core::future::LocalBoxFuture;
 
@@ -33,6 +33,11 @@ async fn put_test() -> impl Responder {
 
 #[patch("/test")]
 async fn patch_test() -> impl Responder {
+    HttpResponse::Ok()
+}
+
+#[query("/test")]
+async fn query_test() -> impl Responder {
     HttpResponse::Ok()
 }
 
@@ -258,6 +263,7 @@ async fn test_body() {
             .service(options_test)
             .service(trace_test)
             .service(patch_test)
+            .service(query_test)
             .service(test_handler)
             .service(route_test)
             .service(routes_overlapping_test)
@@ -287,6 +293,13 @@ async fn test_body() {
     assert!(response.status().is_success());
 
     let request = srv.request(http::Method::PATCH, srv.url("/test"));
+    let response = request.send().await.unwrap();
+    assert!(response.status().is_success());
+
+    let request = srv.request(
+        http::Method::from_bytes(b"QUERY").unwrap(),
+        srv.url("/test"),
+    );
     let response = request.send().await.unwrap();
     assert!(response.status().is_success());
 

--- a/actix-web/CHANGES.md
+++ b/actix-web/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add support for the HTTP `QUERY` method (RFC 10008): `web::query()`, `guard::Query()`, `Resource::query()`, and `TestRequest::query()`.
+
 ## 4.14.0
 
 - Add `HttpRequest::{cookies_raw,cookie_raw}` and `ServiceRequest::{cookies_raw,cookie_raw}` for reading request cookies without percent-decoding names and values. [#3542]

--- a/actix-web/CHANGES.md
+++ b/actix-web/CHANGES.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
-- Add support for the HTTP `QUERY` method (RFC 10008): `web::query()`, `guard::Query()`, `Resource::query()`, and `TestRequest::query()`.
+- Add support for the HTTP `QUERY` method (RFC 10008): `web::query()`, `guard::Query()`, `Resource::query()`, and `TestRequest::query()`. [#4140]
+
+[#4140]: https://github.com/actix/actix-web/pull/4140
 
 ## 4.14.0
 

--- a/actix-web/src/guard/mod.rs
+++ b/actix-web/src/guard/mod.rs
@@ -425,6 +425,9 @@ impl Guard for MethodGuard {
 
 macro_rules! method_guard {
     ($method_fn:ident, $method_const:ident) => {
+        method_guard!($method_fn, $method_const, HttpMethod::$method_const);
+    };
+    ($method_fn:ident, $method_const:ident, $method:expr) => {
         #[doc = concat!("Creates a guard that matches the `", stringify!($method_const), "` request method.")]
         ///
         /// # Examples
@@ -438,7 +441,7 @@ macro_rules! method_guard {
         /// ```
         #[allow(non_snake_case)]
         pub fn $method_fn() -> impl Guard {
-            MethodGuard(HttpMethod::$method_const)
+            MethodGuard($method)
         }
     };
 }
@@ -452,6 +455,9 @@ method_guard!(Options, OPTIONS);
 method_guard!(Connect, CONNECT);
 method_guard!(Patch, PATCH);
 method_guard!(Trace, TRACE);
+// `QUERY` (RFC 10008) is a safe, idempotent method that carries a request body.
+// TODO: replace with `HttpMethod::QUERY` once the `http` dependency is bumped (see #3384).
+method_guard!(Query, QUERY, HttpMethod::from_bytes(b"QUERY").unwrap());
 
 /// Creates a guard that matches if request contains given header name and value.
 ///
@@ -542,6 +548,10 @@ mod tests {
         let req = TestRequest::patch().to_srv_request();
         assert!(Patch().check(&req.guard_ctx()));
         assert!(!Patch().check(&get_req.guard_ctx()));
+
+        let req = TestRequest::query().to_srv_request();
+        assert!(Query().check(&req.guard_ctx()));
+        assert!(!Query().check(&get_req.guard_ctx()));
 
         let r = TestRequest::delete().to_srv_request();
         assert!(Delete().check(&r.guard_ctx()));

--- a/actix-web/src/lib.rs
+++ b/actix-web/src/lib.rs
@@ -155,6 +155,7 @@ codegen_reexport!(delete);
 codegen_reexport!(trace);
 codegen_reexport!(connect);
 codegen_reexport!(options);
+codegen_reexport!(query);
 codegen_reexport!(scope);
 
 pub(crate) type BoxError = Box<dyn std::error::Error>;

--- a/actix-web/src/resource.rs
+++ b/actix-web/src/resource.rs
@@ -403,6 +403,7 @@ where
     route_shortcut!(delete, "DELETE");
     route_shortcut!(head, "HEAD");
     route_shortcut!(trace, "TRACE");
+    route_shortcut!(query, "QUERY");
 }
 
 impl<T, B> HttpServiceFactory for Resource<T>
@@ -808,6 +809,32 @@ mod tests {
             .to_request();
         let resp = call_service(&srv, req).await;
         assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+    }
+
+    #[actix_rt::test]
+    async fn test_query_method() {
+        let srv = init_service(
+            App::new().service(web::resource("/test").route(web::query().to(HttpResponse::Ok))),
+        )
+        .await;
+
+        // a QUERY request is routed to the `web::query()` handler
+        let req = TestRequest::with_uri("/test")
+            .method(Method::from_bytes(b"QUERY").unwrap())
+            .to_request();
+        let resp = call_service(&srv, req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // any other method is rejected with `405 Method Not Allowed`
+        let req = TestRequest::with_uri("/test")
+            .method(Method::GET)
+            .to_request();
+        let resp = call_service(&srv, req).await;
+        assert_eq!(resp.status(), StatusCode::METHOD_NOT_ALLOWED);
+        assert_eq!(
+            resp.headers().get(header::ALLOW).unwrap().as_bytes(),
+            b"QUERY"
+        );
     }
 
     // allow deprecated `{App, Resource}::data`

--- a/actix-web/src/test/test_request.rs
+++ b/actix-web/src/test/test_request.rs
@@ -111,6 +111,14 @@ impl TestRequest {
         TestRequest::default().method(Method::PATCH)
     }
 
+    /// Constructs test request with QUERY method.
+    ///
+    /// `QUERY` (RFC 10008) is safe and idempotent like `GET`, but carries a request body.
+    // TODO: use `Method::QUERY` once the `http` dependency is bumped (see #3384).
+    pub fn query() -> TestRequest {
+        TestRequest::default().method(Method::from_bytes(b"QUERY").unwrap())
+    }
+
     /// Constructs test request with DELETE method.
     pub fn delete() -> TestRequest {
         TestRequest::default().method(Method::DELETE)

--- a/actix-web/src/test/test_request.rs
+++ b/actix-web/src/test/test_request.rs
@@ -112,8 +112,6 @@ impl TestRequest {
     }
 
     /// Constructs test request with QUERY method.
-    ///
-    /// `QUERY` (RFC 10008) is safe and idempotent like `GET`, but carries a request body.
     // TODO: use `Method::QUERY` once the `http` dependency is bumped (see #3384).
     pub fn query() -> TestRequest {
         TestRequest::default().method(Method::from_bytes(b"QUERY").unwrap())

--- a/actix-web/src/test/test_utils.rs
+++ b/actix-web/src/test/test_utils.rs
@@ -371,6 +371,7 @@ mod tests {
                 web::resource("/index.html")
                     .route(web::put().to(|| HttpResponse::Ok().body("put!")))
                     .route(web::patch().to(|| HttpResponse::Ok().body("patch!")))
+                    .route(web::query().to(|| HttpResponse::Ok().body("query!")))
                     .route(web::delete().to(|| HttpResponse::Ok().body("delete!"))),
             ),
         )
@@ -392,9 +393,40 @@ mod tests {
         let result = call_and_read_body(&app, patch_req).await;
         assert_eq!(result, Bytes::from_static(b"patch!"));
 
+        let query_req = TestRequest::query()
+            .uri("/index.html")
+            .insert_header((header::CONTENT_TYPE, "application/json"))
+            .to_request();
+
+        let result = call_and_read_body(&app, query_req).await;
+        assert_eq!(result, Bytes::from_static(b"query!"));
+
         let delete_req = TestRequest::delete().uri("/index.html").to_request();
         let result = call_and_read_body(&app, delete_req).await;
         assert_eq!(result, Bytes::from_static(b"delete!"));
+    }
+
+    // `QUERY` is safe and idempotent like `GET`, but (like `POST`) carries a request body;
+    // this proves body extractors work for `QUERY` handlers. See RFC 10008.
+    #[actix_rt::test]
+    async fn test_query_carries_json_body() {
+        let app =
+            init_service(App::new().service(web::resource("/people").route(
+                web::query().to(|person: web::Json<Person>| HttpResponse::Ok().json(person)),
+            )))
+            .await;
+
+        let payload = r#"{"id":"12345","name":"User name"}"#.as_bytes();
+
+        let req = TestRequest::query()
+            .uri("/people")
+            .insert_header((header::CONTENT_TYPE, "application/json"))
+            .set_payload(payload)
+            .to_request();
+
+        let result: Person = call_and_read_body_json(&app, req).await;
+        assert_eq!(result.id, "12345");
+        assert_eq!(result.name, "User name");
     }
 
     #[derive(Serialize, Deserialize, Debug)]

--- a/actix-web/src/web.rs
+++ b/actix-web/src/web.rs
@@ -101,6 +101,9 @@ pub fn route() -> Route {
 
 macro_rules! method_route {
     ($method_fn:ident, $method_const:ident) => {
+        method_route!($method_fn, $method_const, Method::$method_const);
+    };
+    ($method_fn:ident, $method_const:ident, $method:expr) => {
         #[doc = concat!(" Creates a new route with `", stringify!($method_const), "` method guard.")]
         ///
         /// # Examples
@@ -115,7 +118,7 @@ macro_rules! method_route {
         /// );
         /// ```
         pub fn $method_fn() -> Route {
-            method(Method::$method_const)
+            method($method)
         }
     };
 }
@@ -127,6 +130,9 @@ method_route!(patch, PATCH);
 method_route!(delete, DELETE);
 method_route!(head, HEAD);
 method_route!(trace, TRACE);
+// `QUERY` (RFC 10008) is a safe, idempotent method that carries a request body.
+// TODO: replace with `Method::QUERY` once the `http` dependency is bumped (see #3384).
+method_route!(query, QUERY, Method::from_bytes(b"QUERY").unwrap());
 
 /// Creates a new route with specified method guard.
 ///

--- a/actix-web/tests/test_server.rs
+++ b/actix-web/tests/test_server.rs
@@ -292,6 +292,24 @@ async fn test_head_binary() {
 }
 
 #[actix_rt::test]
+async fn test_query_method() {
+    let srv = actix_test::start_with(actix_test::config().h1(), || {
+        App::new().service(
+            web::resource("/")
+                .route(web::query().to(|body: Bytes| async { HttpResponse::Ok().body(body) })),
+        )
+    });
+
+    let mut res = srv.query("/").send_body("query body").await.unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+
+    let bytes = res.body().await.unwrap();
+    assert_eq!(bytes, Bytes::from_static(b"query body"));
+
+    srv.stop().await;
+}
+
+#[actix_rt::test]
 async fn test_no_chunking() {
     let srv = actix_test::start_with(actix_test::config().h1(), || {
         App::new().service(web::resource("/").route(web::to(move || async {

--- a/awc/CHANGES.md
+++ b/awc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add `Client::query()` for constructing HTTP `QUERY` requests (RFC 10008).
 - Add camel-case header controls to `WebsocketsRequest` via `camel_case_headers()` and `set_camel_case_headers()`. [#3953]
 - Update `hickory-resolver` dependency to `0.26.1`.
 - Update `rand` dependency to `0.10`.

--- a/awc/CHANGES.md
+++ b/awc/CHANGES.md
@@ -2,12 +2,13 @@
 
 ## Unreleased
 
-- Add `Client::query()` for constructing HTTP `QUERY` requests (RFC 10008).
+- Add `Client::query()` for constructing HTTP `QUERY` requests (RFC 10008). [#4140]
 - Add camel-case header controls to `WebsocketsRequest` via `camel_case_headers()` and `set_camel_case_headers()`. [#3953]
 - Update `hickory-resolver` dependency to `0.26.1`.
 - Update `rand` dependency to `0.10`.
 
 [#3953]: https://github.com/actix/actix-web/pull/3953
+[#4140]: https://github.com/actix/actix-web/pull/4140
 
 ## 3.8.2
 

--- a/awc/src/client/mod.rs
+++ b/awc/src/client/mod.rs
@@ -181,6 +181,16 @@ impl Client {
         self.request(Method::OPTIONS, url)
     }
 
+    /// Construct HTTP *QUERY* request.
+    // TODO: use `Method::QUERY` once the `http` dependency is bumped (see #3384).
+    pub fn query<U>(&self, url: U) -> ClientRequest
+    where
+        Uri: TryFrom<U>,
+        <Uri as TryFrom<U>>::Error: Into<HttpError>,
+    {
+        self.request(Method::from_bytes(b"QUERY").unwrap(), url)
+    }
+
     /// Initialize a WebSocket connection.
     /// Returns a WebSocket connection builder.
     pub fn ws<U>(&self, url: U) -> ws::WebsocketsRequest
@@ -201,5 +211,16 @@ impl Client {
     /// (No other clone of client exists at the same time).
     pub fn headers(&mut self) -> Option<&mut HeaderMap> {
         Rc::get_mut(&mut self.0.default_headers)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn client_query_builds_query_request() {
+        let req = Client::new().query("/");
+        assert_eq!(req.get_method().as_str(), "QUERY");
     }
 }


### PR DESCRIPTION
## PR Type

Feature

## PR Checklist

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt. <!-- also verified with nightly rustfmt (what CI runs) -->
- [ ] (Team) Label with affected crates and semver status. <!-- suggested: A-web A-awc A-http C-feature, B-semver-minor -->

## Overview

Adds first-class support for the HTTP `QUERY` method, wired exactly like the existing
`PATCH` method throughout routing, guards, the `web::` helpers, the routing macros, the
`awc` client, and the test servers.

[`QUERY`](https://www.rfc-editor.org/rfc/rfc10008.html) was standardized in **RFC 10008
(June 2026)** and registered in the [IANA HTTP Method Registry]. It is **safe** and
**idempotent** like `GET`, but carries a **request body** like `POST` — the first new HTTP
method since `PATCH` (RFC 5789, 2010). Because actix-web's extractors are method-agnostic,
body extraction (`web::Json`, `web::Bytes`, …) works for `QUERY` handlers with no special
handling.

This is a purely **additive** change (new public items only) → **semver-minor**; no breaking
changes.

[IANA HTTP Method Registry]: https://www.iana.org/assignments/http-methods/http-methods.xhtml

### What's included

`actix-web`
- `guard::Query()` — method guard, mirrors `guard::Patch()`
- `web::query()` — pre-configured `Route`, mirrors `web::patch()`
- `Resource::query()` — route shortcut, mirrors `Resource::patch()`
- `TestRequest::query()` — test helper, mirrors `TestRequest::patch()`
- re-export of the `#[query]` routing macro

`actix-web-codegen`
- `#[query]` attribute macro, mirrors `#[patch]`

`awc`
- `Client::query()` — mirrors `Client::patch()`

`actix-test` / `actix-http-test`
- `TestServer::query()` (and `actix-http-test`'s HTTPS `TestServer::squery()`) — mirror `patch`/`spatch`

Every method-convenience surface that has a `patch` now has a matching `query`, so `QUERY`
is a first-class method throughout.

### Notes for reviewers

- **`http` crate version.** actix-web currently pins `http` `0.2`, which has no
  `Method::QUERY` associated constant (that constant only exists in `http` `1.x`). This PR
  therefore constructs the method with `Method::from_bytes(b"QUERY").unwrap()` and leaves a
  `TODO` to switch to `Method::QUERY` once the dependency is bumped. This mirrors the
  existing `Method::from_bytes(...).unwrap()` pattern already used in `actix-web-codegen`
  for custom methods. This PR **does not** bump `http` — that is tracked separately in
  #3384. No new dependencies are added.
- **`actix-http`.** No change needed: `actix-http` re-exports `http::Method` and has no
  local method enum/constant list, so there is nothing to mirror there.
- **Scope.** Minimal and mechanical — every change mirrors an existing `PATCH` site. No
  unrelated refactoring.

### Tests

- `guard::Query()` matches a `QUERY` request and rejects a `GET`.
- A `web::query()` route returns `200` for `QUERY` and `405` (`Allow: QUERY`) for other methods.
- A `QUERY` handler reads and echoes a JSON body (proves body-carrying works).
- `#[query]` macro integration test mirrors the existing `#[patch]` test (`test_body`).
- `awc::Client::query()` builds a request whose method is `QUERY`.
- Round-trip tests for each test-server helper against a live server: `actix_test::TestServer::query()`
  (body echo through a `web::query()` route), `actix_http_test::TestServer::query()` (plaintext HTTP/1),
  and `actix_http_test::TestServer::squery()` (rustls; asserts the request arrives as `QUERY` over HTTP/2).

### Verification

Local, matching the project's CI gates:

- `cargo +nightly fmt --all -- --check` — clean.
- `cargo clippy --workspace --all-targets ... -D clippy::todo -D clippy::dbg_macro` — 0 warnings.
- `cargo +nightly doc --no-deps ... -D warnings` — my `[QUERY]` intra-doc link resolves; no new warnings.
- `just check-min` / `just check-default` (`cargo hack --workspace check [--no-default-features]`) — pass.
- `cargo +1.88` (MSRV) check — pass.
- Tests pass across `actix-web`, `actix-web-codegen`, `awc`, `actix-test`, `actix-http-test`
  (incl. doctests and awc integration/TLS tests), 0 failed.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->


