### PR TITLE
fix: correct "Implementors" to "Implementers" in docs

### DIFF
--- a/actix-router/src/resource_path.rs
+++ b/actix-router/src/resource_path.rs
@@ -3,7 +3,7 @@ use crate::Path;
 /// Abstraction over types that can provide a mutable [`Path`] for routing.
 ///
 /// This trait is used by the router to extract the request path in a uniform way across different
-/// request types (e.g., Actix Web's `ServiceRequest`). Implementors return a mutable [`Path`]
+/// request types (e.g., Actix Web's `ServiceRequest`). Implementers return a mutable [`Path`]
 /// wrapper so routing can read and potentially normalize/parse the path without requiring the
 /// original request type.
 pub trait Resource {

--- a/actix-web/MIGRATION-4.0.md
+++ b/actix-web/MIGRATION-4.0.md
@@ -422,7 +422,7 @@ async fn main() {
 
 ## Guards API
 
-Implementors of routing guards will need to use the modified interface of the `Guard` trait. The API is more flexible than before. See [guard module docs](https://docs.rs/actix-web/4/actix_web/guard/struct.GuardContext.html) for more details.
+Implementers of routing guards will need to use the modified interface of the `Guard` trait. The API is more flexible than before. See [guard module docs](https://docs.rs/actix-web/4/actix_web/guard/struct.GuardContext.html) for more details.
 
 ```diff
   struct MethodGuard(HttpMethod);


### PR DESCRIPTION
## Summary

Fixes two occurrences of the misspelling "Implementors" → "Implementers" in doc comments and migration guide.

- `actix-router/src/resource_path.rs` — doc comment for the `Resource` trait
- `actix-web/MIGRATION-4.0.md` — Guards API section

Found with `codespell`.