### PR TITLE
Drain HTTP/1 connections during graceful shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,7 +229,7 @@ dependencies = [
 [[package]]
 name = "actix-server"
 version = "2.6.0"
-source = "git+https://github.com/actix/actix-net.git?rev=f0708caa1063f6d36471046848f29821f51f1724#f0708caa1063f6d36471046848f29821f51f1724"
+source = "git+https://github.com/actix/actix-net.git?branch=fix%2Fgraceful-http1-shutdown#a50fc23b85c6dd0c2cad3a8a32d1e1cb286c8210"
 dependencies = [
  "actix-rt",
  "actix-service",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,8 +228,9 @@ dependencies = [
 
 [[package]]
 name = "actix-server"
-version = "2.6.0"
-source = "git+https://github.com/actix/actix-net.git?branch=fix%2Fgraceful-http1-shutdown#a50fc23b85c6dd0c2cad3a8a32d1e1cb286c8210"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3716aae056e2f869b7b5cfd8a08fcf98890f8455bec61d69c7dff5d8576f9d2b"
 dependencies = [
  "actix-rt",
  "actix-service",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,7 +183,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -229,8 +229,7 @@ dependencies = [
 [[package]]
 name = "actix-server"
 version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a65064ea4a457eaf07f2fba30b4c695bf43b721790e9530d26cb6f9019ff7502"
+source = "git+https://github.com/actix/actix-net.git?rev=f0708caa1063f6d36471046848f29821f51f1724#f0708caa1063f6d36471046848f29821f51f1724"
 dependencies = [
  "actix-rt",
  "actix-service",
@@ -238,7 +237,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "mio",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tokio",
  "tokio-uring",
  "tracing",
@@ -394,7 +393,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion-msrv",
- "syn 3.0.3",
+ "syn 2.0.119",
  "trybuild",
 ]
 
@@ -3073,16 +3072,6 @@ checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
 dependencies = [
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,7 +183,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -394,7 +394,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion-msrv",
- "syn 2.0.119",
+ "syn 3.0.3",
  "trybuild",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ awc = { path = "awc" }
 # actix-codec = { path = "../actix-net/actix-codec" }
 # actix-utils = { path = "../actix-net/actix-utils" }
 # actix-tls = { path = "../actix-net/actix-tls" }
-actix-server = { git = "https://github.com/actix/actix-net.git", rev = "f0708caa1063f6d36471046848f29821f51f1724" }
+actix-server = { git = "https://github.com/actix/actix-net.git", branch = "fix/graceful-http1-shutdown" }
 
 [workspace.lints.rust]
 rust_2018_idioms = { level = "deny" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ awc = { path = "awc" }
 # actix-codec = { path = "../actix-net/actix-codec" }
 # actix-utils = { path = "../actix-net/actix-utils" }
 # actix-tls = { path = "../actix-net/actix-tls" }
+# actix-server = { path = "../actix-net/actix-server" }
 
 [workspace.lints.rust]
 rust_2018_idioms = { level = "deny" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,6 @@ awc = { path = "awc" }
 # actix-codec = { path = "../actix-net/actix-codec" }
 # actix-utils = { path = "../actix-net/actix-utils" }
 # actix-tls = { path = "../actix-net/actix-tls" }
-actix-server = { git = "https://github.com/actix/actix-net.git", branch = "fix/graceful-http1-shutdown" }
 
 [workspace.lints.rust]
 rust_2018_idioms = { level = "deny" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ awc = { path = "awc" }
 # actix-codec = { path = "../actix-net/actix-codec" }
 # actix-utils = { path = "../actix-net/actix-utils" }
 # actix-tls = { path = "../actix-net/actix-tls" }
-# actix-server = { path = "../actix-net/actix-server" }
+actix-server = { git = "https://github.com/actix/actix-net.git", rev = "f0708caa1063f6d36471046848f29821f51f1724" }
 
 [workspace.lints.rust]
 rust_2018_idioms = { level = "deny" }

--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Close idle HTTP/1 keep-alive connections during graceful server shutdown and close active connections after their current request finishes.
+
 ## 3.13.1
 
 - Fix HTTP/1 WebSocket upgrade responses being overwritten with `Connection: close` when the upgraded request payload remains open. [#4115]

--- a/actix-http/src/builder.rs
+++ b/actix-http/src/builder.rs
@@ -1,4 +1,4 @@
-use std::{fmt, marker::PhantomData, net, rc::Rc, time::Duration};
+use std::{fmt, future::Future, marker::PhantomData, net, rc::Rc, time::Duration};
 
 use actix_codec::Framed;
 use actix_service::{IntoServiceFactory, Service, ServiceFactory};
@@ -6,7 +6,8 @@ use actix_service::{IntoServiceFactory, Service, ServiceFactory};
 use crate::{
     body::{BoxBody, MessageBody},
     config::{
-        DEFAULT_H1_WRITE_BUFFER_SIZE, DEFAULT_H2_CONN_WINDOW_SIZE, DEFAULT_H2_STREAM_WINDOW_SIZE,
+        GracefulShutdownSignal, DEFAULT_H1_WRITE_BUFFER_SIZE, DEFAULT_H2_CONN_WINDOW_SIZE,
+        DEFAULT_H2_STREAM_WINDOW_SIZE,
     },
     h1::{self, ExpectHandler, H1Service, UpgradeHandler},
     service::HttpService,
@@ -27,6 +28,7 @@ pub struct HttpServiceBuilder<T, S, X = ExpectHandler, U = UpgradeHandler> {
     h1_write_buffer_size: usize,
     h2_conn_window_size: u32,
     h2_stream_window_size: u32,
+    graceful_shutdown_signal: Option<GracefulShutdownSignal>,
     expect: X,
     upgrade: Option<U>,
     on_connect_ext: Option<Rc<ConnectCallback<T>>>,
@@ -53,6 +55,7 @@ where
             h1_write_buffer_size: DEFAULT_H1_WRITE_BUFFER_SIZE,
             h2_conn_window_size: DEFAULT_H2_CONN_WINDOW_SIZE,
             h2_stream_window_size: DEFAULT_H2_STREAM_WINDOW_SIZE,
+            graceful_shutdown_signal: None,
 
             // dispatcher parts
             expect: ExpectHandler,
@@ -174,6 +177,17 @@ where
         self
     }
 
+    /// Sets a factory for graceful shutdown notifications.
+    #[doc(hidden)]
+    pub fn graceful_shutdown_signal<F, Fut>(mut self, signal: F) -> Self
+    where
+        F: Fn() -> Fut + 'static,
+        Fut: Future<Output = ()> + 'static,
+    {
+        self.graceful_shutdown_signal = Some(GracefulShutdownSignal::new(signal));
+        self
+    }
+
     /// Sets initial stream-level flow control window size for HTTP/2 connections.
     ///
     /// See [`ServiceConfigBuilder::h2_initial_window_size`] for more details.
@@ -213,6 +227,7 @@ where
             h1_write_buffer_size: self.h1_write_buffer_size,
             h2_conn_window_size: self.h2_conn_window_size,
             h2_stream_window_size: self.h2_stream_window_size,
+            graceful_shutdown_signal: self.graceful_shutdown_signal,
             expect: expect.into_factory(),
             upgrade: self.upgrade,
             on_connect_ext: self.on_connect_ext,
@@ -242,6 +257,7 @@ where
             h1_write_buffer_size: self.h1_write_buffer_size,
             h2_conn_window_size: self.h2_conn_window_size,
             h2_stream_window_size: self.h2_stream_window_size,
+            graceful_shutdown_signal: self.graceful_shutdown_signal,
             expect: self.expect,
             upgrade: Some(upgrade.into_factory()),
             on_connect_ext: self.on_connect_ext,
@@ -282,6 +298,7 @@ where
             .h1_write_buffer_size(self.h1_write_buffer_size)
             .h2_initial_window_size(self.h2_stream_window_size)
             .h2_initial_connection_window_size(self.h2_conn_window_size)
+            .graceful_shutdown_signal(self.graceful_shutdown_signal)
             .build();
 
         H1Service::with_config(cfg, service.into_factory())
@@ -312,6 +329,7 @@ where
             .h1_write_buffer_size(self.h1_write_buffer_size)
             .h2_initial_window_size(self.h2_stream_window_size)
             .h2_initial_connection_window_size(self.h2_conn_window_size)
+            .graceful_shutdown_signal(self.graceful_shutdown_signal)
             .build();
 
         crate::h2::H2Service::with_config(cfg, service.into_factory())
@@ -339,6 +357,7 @@ where
             .h1_write_buffer_size(self.h1_write_buffer_size)
             .h2_initial_window_size(self.h2_stream_window_size)
             .h2_initial_connection_window_size(self.h2_conn_window_size)
+            .graceful_shutdown_signal(self.graceful_shutdown_signal)
             .build();
 
         HttpService::with_config(cfg, service.into_factory())

--- a/actix-http/src/config.rs
+++ b/actix-http/src/config.rs
@@ -32,7 +32,8 @@ impl GracefulShutdownSignal {
 
 impl fmt::Debug for GracefulShutdownSignal {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("GracefulShutdownSignal")
+        f.debug_struct("GracefulShutdownSignal")
+            .finish_non_exhaustive()
     }
 }
 

--- a/actix-http/src/config.rs
+++ b/actix-http/src/config.rs
@@ -1,5 +1,8 @@
 use std::{
+    fmt,
+    future::Future,
     net::SocketAddr,
+    pin::Pin,
     rc::Rc,
     time::{Duration, Instant},
 };
@@ -7,6 +10,31 @@ use std::{
 use bytes::BytesMut;
 
 use crate::{date::DateService, KeepAlive};
+
+pub(crate) type GracefulShutdownFuture = Pin<Box<dyn Future<Output = ()>>>;
+
+#[derive(Clone)]
+pub(crate) struct GracefulShutdownSignal(Rc<dyn Fn() -> GracefulShutdownFuture>);
+
+impl GracefulShutdownSignal {
+    pub(crate) fn new<F, Fut>(signal: F) -> Self
+    where
+        F: Fn() -> Fut + 'static,
+        Fut: Future<Output = ()> + 'static,
+    {
+        Self(Rc::new(move || Box::pin(signal())))
+    }
+
+    fn notified(&self) -> GracefulShutdownFuture {
+        (self.0)()
+    }
+}
+
+impl fmt::Debug for GracefulShutdownSignal {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("GracefulShutdownSignal")
+    }
+}
 
 /// Default HTTP/2 initial connection-level flow control window size.
 ///
@@ -108,6 +136,14 @@ impl ServiceConfigBuilder {
         self
     }
 
+    pub(crate) fn graceful_shutdown_signal(
+        mut self,
+        signal: Option<GracefulShutdownSignal>,
+    ) -> Self {
+        self.inner.graceful_shutdown_signal = signal;
+        self
+    }
+
     /// Sets initial stream-level flow control window size for HTTP/2 connections.
     ///
     /// Higher values can improve upload performance on high-latency links at the cost of higher
@@ -153,6 +189,7 @@ struct Inner {
     h1_write_buffer_size: usize,
     h2_conn_window_size: u32,
     h2_stream_window_size: u32,
+    graceful_shutdown_signal: Option<GracefulShutdownSignal>,
 }
 
 impl Default for Inner {
@@ -169,6 +206,7 @@ impl Default for Inner {
             h1_write_buffer_size: DEFAULT_H1_WRITE_BUFFER_SIZE,
             h2_conn_window_size: DEFAULT_H2_CONN_WINDOW_SIZE,
             h2_stream_window_size: DEFAULT_H2_STREAM_WINDOW_SIZE,
+            graceful_shutdown_signal: None,
         }
     }
 }
@@ -194,6 +232,7 @@ impl ServiceConfig {
             h1_write_buffer_size: DEFAULT_H1_WRITE_BUFFER_SIZE,
             h2_conn_window_size: DEFAULT_H2_CONN_WINDOW_SIZE,
             h2_stream_window_size: DEFAULT_H2_STREAM_WINDOW_SIZE,
+            graceful_shutdown_signal: None,
         }))
     }
 
@@ -256,6 +295,13 @@ impl ServiceConfig {
     /// HTTP/1 response write buffer size (in bytes).
     pub fn h1_write_buffer_size(&self) -> usize {
         self.0.h1_write_buffer_size
+    }
+
+    pub(crate) fn graceful_shutdown(&self) -> Option<GracefulShutdownFuture> {
+        self.0
+            .graceful_shutdown_signal
+            .as_ref()
+            .map(GracefulShutdownSignal::notified)
     }
 
     /// Returns configured `TCP_NODELAY` setting for accepted TCP connections.

--- a/actix-http/src/h1/dispatcher.rs
+++ b/actix-http/src/h1/dispatcher.rs
@@ -569,7 +569,6 @@ where
         'res: loop {
             let mut this = self.as_mut().project();
             match this.state.as_mut().project() {
-                // no future is in InnerDispatcher state; pop next message
                 StateProj::None if this.flags.contains(Flags::DRAINING) => {
                     this.messages.clear();
                     this.flags.remove(Flags::KEEP_ALIVE);
@@ -581,6 +580,7 @@ where
                     return Ok(PollResponse::DoNothing);
                 }
 
+                // no future is in InnerDispatcher state; pop next message
                 StateProj::None => match this.messages.pop_front() {
                     // handle request message
                     Some(DispatcherMessage::Item(req)) => {

--- a/actix-http/src/h1/dispatcher.rs
+++ b/actix-http/src/h1/dispatcher.rs
@@ -63,6 +63,11 @@ bitflags! {
         const LINGER           = 0b0100_0000;
 
         /// Set when the server is draining this connection during graceful shutdown.
+        ///
+        /// Unlike [`SHUTDOWN`](Self::SHUTDOWN), this state continues polling the current request
+        /// and response. It prevents queued requests from starting and transitions to `SHUTDOWN`
+        /// after the current response finishes. [`LINGER`](Self::LINGER) remains separate and is
+        /// used only to close cleanly after a response to an unread request payload.
         const DRAINING         = 0b1000_0000;
     }
 }
@@ -462,7 +467,10 @@ where
             (
                 this.flags.contains(Flags::DRAINING),
                 !is_upgrade
-                    && should_close_after_response(this.payload.as_ref(), *this.payload_drainable),
+                    && should_close_for_unread_payload(
+                        this.payload.as_ref(),
+                        *this.payload_drainable,
+                    ),
             )
         };
         let close_after_response = (!is_upgrade && draining) || close_for_unread_payload;
@@ -509,7 +517,10 @@ where
             (
                 this.flags.contains(Flags::DRAINING),
                 !is_upgrade
-                    && should_close_after_response(this.payload.as_ref(), *this.payload_drainable),
+                    && should_close_for_unread_payload(
+                        this.payload.as_ref(),
+                        *this.payload_drainable,
+                    ),
             )
         };
         let close_after_response = (!is_upgrade && draining) || close_for_unread_payload;
@@ -653,7 +664,7 @@ where
                                 // this.payload was the payload for the request we just finished
                                 // responding to. We can check to see if we finished reading it
                                 // yet, and if not, shutdown the connection.
-                                let close_after_response = should_close_after_response(
+                                let close_for_unread_payload = should_close_for_unread_payload(
                                     this.payload.as_ref(),
                                     *this.payload_drainable,
                                 );
@@ -663,7 +674,7 @@ where
                                 // set state to None and handle next message
                                 this.state.set(State::None);
 
-                                if not_pipelined && close_after_response {
+                                if not_pipelined && close_for_unread_payload {
                                     if this.config.client_disconnect_deadline().is_some() {
                                         Self::enter_linger(this.flags);
                                     } else {
@@ -711,7 +722,7 @@ where
                                 // this.payload was the payload for the request we just finished
                                 // responding to. We can check to see if we finished reading it
                                 // yet, and if not, shutdown the connection.
-                                let close_after_response = should_close_after_response(
+                                let close_for_unread_payload = should_close_for_unread_payload(
                                     this.payload.as_ref(),
                                     *this.payload_drainable,
                                 );
@@ -721,7 +732,7 @@ where
                                 // set state to None and handle next message
                                 this.state.set(State::None);
 
-                                if not_pipelined && close_after_response {
+                                if not_pipelined && close_for_unread_payload {
                                     if this.config.client_disconnect_deadline().is_some() {
                                         Self::enter_linger(this.flags);
                                     } else {
@@ -1456,7 +1467,10 @@ where
     }
 }
 
-fn should_close_after_response(payload: Option<&PayloadSender>, payload_drainable: bool) -> bool {
+fn should_close_for_unread_payload(
+    payload: Option<&PayloadSender>,
+    payload_drainable: bool,
+) -> bool {
     let payload_unfinished = payload.is_some();
     let drain_payload = payload.is_some_and(|pl| pl.is_dropped()) && payload_drainable;
 

--- a/actix-http/src/h1/dispatcher.rs
+++ b/actix-http/src/h1/dispatcher.rs
@@ -61,6 +61,9 @@ bitflags! {
 
         /// Set while gracefully closing a connection after an early response.
         const LINGER           = 0b0100_0000;
+
+        /// Set when the server is draining this connection during graceful shutdown.
+        const DRAINING         = 0b1000_0000;
     }
 }
 
@@ -167,6 +170,7 @@ pin_project! {
         head_timer: TimerState,
         ka_timer: TimerState,
         shutdown_timer: TimerState,
+        graceful_shutdown: Option<crate::config::GracefulShutdownFuture>,
 
         pub(super) io: Option<T>,
         read_buf: BytesMut,
@@ -281,6 +285,7 @@ where
                     head_timer: TimerState::new(config.client_request_deadline().is_some()),
                     ka_timer: TimerState::new(config.keep_alive().enabled()),
                     shutdown_timer: TimerState::new(config.client_disconnect_deadline().is_some()),
+                    graceful_shutdown: config.graceful_shutdown(),
 
                     io: Some(io),
                     read_buf: BytesMut::with_capacity(HW_BUFFER_SIZE),
@@ -451,10 +456,16 @@ where
         mut res: Response<()>,
         body: B,
     ) -> Result<(), DispatchError> {
-        let close_after_response = !res.upgrade() && {
+        let is_upgrade = res.upgrade();
+        let (draining, close_for_unread_payload) = {
             let this = self.as_mut().project();
-            should_close_after_response(this.payload.as_ref(), *this.payload_drainable)
+            (
+                this.flags.contains(Flags::DRAINING),
+                !is_upgrade
+                    && should_close_after_response(this.payload.as_ref(), *this.payload_drainable),
+            )
         };
+        let close_after_response = (!is_upgrade && draining) || close_for_unread_payload;
 
         if close_after_response {
             res.head_mut().set_connection_type(ConnectionType::Close);
@@ -465,7 +476,7 @@ where
             BodySize::None | BodySize::Sized(0) => {
                 let mut this = self.as_mut().project();
 
-                if close_after_response {
+                if close_for_unread_payload {
                     if this.config.client_disconnect_deadline().is_some() {
                         Self::enter_linger(this.flags);
                     } else {
@@ -492,10 +503,16 @@ where
         mut res: Response<()>,
         body: BoxBody,
     ) -> Result<(), DispatchError> {
-        let close_after_response = !res.upgrade() && {
+        let is_upgrade = res.upgrade();
+        let (draining, close_for_unread_payload) = {
             let this = self.as_mut().project();
-            should_close_after_response(this.payload.as_ref(), *this.payload_drainable)
+            (
+                this.flags.contains(Flags::DRAINING),
+                !is_upgrade
+                    && should_close_after_response(this.payload.as_ref(), *this.payload_drainable),
+            )
         };
+        let close_after_response = (!is_upgrade && draining) || close_for_unread_payload;
 
         if close_after_response {
             res.head_mut().set_connection_type(ConnectionType::Close);
@@ -506,7 +523,7 @@ where
             BodySize::None | BodySize::Sized(0) => {
                 let mut this = self.as_mut().project();
 
-                if close_after_response {
+                if close_for_unread_payload {
                     if this.config.client_disconnect_deadline().is_some() {
                         Self::enter_linger(this.flags);
                     } else {
@@ -542,6 +559,17 @@ where
             let mut this = self.as_mut().project();
             match this.state.as_mut().project() {
                 // no future is in InnerDispatcher state; pop next message
+                StateProj::None if this.flags.contains(Flags::DRAINING) => {
+                    this.messages.clear();
+                    this.flags.remove(Flags::KEEP_ALIVE);
+
+                    if !this.flags.contains(Flags::LINGER) {
+                        this.flags.insert(Flags::SHUTDOWN);
+                    }
+
+                    return Ok(PollResponse::DoNothing);
+                }
+
                 StateProj::None => match this.messages.pop_front() {
                     // handle request message
                     Some(DispatcherMessage::Item(req)) => {
@@ -1079,6 +1107,25 @@ where
         Ok(())
     }
 
+    fn poll_graceful_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) {
+        let this = self.as_mut().project();
+
+        let notified = this
+            .graceful_shutdown
+            .as_mut()
+            .is_some_and(|signal| signal.as_mut().poll(cx).is_ready());
+
+        if notified {
+            *this.graceful_shutdown = None;
+            this.flags.remove(Flags::KEEP_ALIVE);
+            this.flags.insert(Flags::DRAINING);
+
+            if this.ka_timer.is_enabled() {
+                this.ka_timer.clear(line!());
+            }
+        }
+    }
+
     /// Poll head, keep-alive, and disconnect timer.
     fn poll_timers(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Result<(), DispatchError> {
         self.as_mut().poll_head_timer(cx)?;
@@ -1236,6 +1283,7 @@ where
                     &inner.shutdown_timer,
                 );
 
+                inner.as_mut().poll_graceful_shutdown(cx);
                 inner.as_mut().poll_timers(cx)?;
 
                 let poll = if inner.flags.contains(Flags::LINGER) {

--- a/actix-http/src/h1/dispatcher.rs
+++ b/actix-http/src/h1/dispatcher.rs
@@ -876,6 +876,10 @@ where
     ///
     /// Returns true if any meaningful work was done.
     fn poll_request(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Result<bool, DispatchError> {
+        if self.flags.contains(Flags::DRAINING) && self.state.is_none() {
+            return Ok(false);
+        }
+
         let pipeline_queue_full = self.messages.len() >= MAX_PIPELINED_MESSAGES;
         let can_not_read = !self.can_read(cx);
 

--- a/actix-http/src/h1/dispatcher_tests.rs
+++ b/actix-http/src/h1/dispatcher_tests.rs
@@ -572,6 +572,47 @@ async fn keep_alive_follow_up_req() {
 }
 
 #[actix_rt::test]
+async fn graceful_shutdown_does_not_start_buffered_request() {
+    use crate::config::{GracefulShutdownSignal, ServiceConfigBuilder};
+
+    let request_started = Rc::new(Cell::new(false));
+    let service_request_started = Rc::clone(&request_started);
+    let services = HttpFlow::new(
+        fn_service(move |_req: Request| {
+            service_request_started.set(true);
+            ready(Ok::<_, Error>(Response::ok()))
+        }),
+        ExpectHandler,
+        None::<UpgradeHandler>,
+    );
+    let config = ServiceConfigBuilder::new()
+        .graceful_shutdown_signal(Some(GracefulShutdownSignal::new(|| ready(()))))
+        .build();
+    let buf = TestBuffer::new("GET /buffered HTTP/1.1\r\n\r\n");
+    let dispatcher = Dispatcher::new(
+        buf.clone(),
+        services,
+        config,
+        None,
+        OnConnectData::default(),
+    );
+    pin!(dispatcher);
+
+    // The shutdown notification and request data are ready in the same dispatcher poll.
+    let mut cx = Context::from_waker(futures_util::task::noop_waker_ref());
+    assert!(dispatcher.as_mut().poll(&mut cx).is_ready());
+
+    assert!(
+        !request_started.get(),
+        "buffered request started during graceful shutdown"
+    );
+    assert!(
+        buf.write_buf_slice().is_empty(),
+        "dispatcher wrote a response for the buffered request"
+    );
+}
+
+#[actix_rt::test]
 async fn req_parse_err() {
     lazy(|cx| {
         let buf = TestBuffer::new("GET /test HTTP/1\r\n\r\n");

--- a/actix-web/CHANGES.md
+++ b/actix-web/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Close idle HTTP/1 keep-alive connections during graceful shutdown and let active connections
+  finish only their current request before closing.
+
 ## 4.14.0
 
 - Add `HttpRequest::{cookies_raw,cookie_raw}` and `ServiceRequest::{cookies_raw,cookie_raw}` for reading request cookies without percent-decoding names and values. [#3542]

--- a/actix-web/CHANGES.md
+++ b/actix-web/CHANGES.md
@@ -2,8 +2,7 @@
 
 ## Unreleased
 
-- Close idle HTTP/1 keep-alive connections during graceful shutdown and let active connections
-  finish only their current request before closing.
+- Close idle HTTP/1 keep-alive connections during graceful shutdown and let active connections finish only their current request before closing.
 
 ## 4.14.0
 

--- a/actix-web/Cargo.toml
+++ b/actix-web/Cargo.toml
@@ -137,7 +137,7 @@ actix-service = "2"
 actix-tls = { version = "3.4", default-features = false, optional = true }
 actix-utils = "3"
 
-actix-http = { version = "3.13.1", path = "../actix-http" }
+actix-http = "3.13.1"
 actix-router = { version = "0.5.4", default-features = false, features = ["http"] }
 actix-web-codegen = { version = "4.3", optional = true, default-features = false }
 

--- a/actix-web/Cargo.toml
+++ b/actix-web/Cargo.toml
@@ -132,12 +132,12 @@ experimental-introspection = ["serde/derive"]
 actix-codec = "0.5"
 actix-macros = { version = "0.2.3", optional = true }
 actix-rt = { version = "2.6", default-features = false }
-actix-server = "2.6"
+actix-server = "2.7"
 actix-service = "2"
 actix-tls = { version = "3.4", default-features = false, optional = true }
 actix-utils = "3"
 
-actix-http = "3.13.1"
+actix-http = { version = "3.13.1", path = "../actix-http" }
 actix-router = { version = "0.5.4", default-features = false, features = ["http"] }
 actix-web-codegen = { version = "4.3", optional = true, default-features = false }
 

--- a/actix-web/src/server.rs
+++ b/actix-web/src/server.rs
@@ -12,7 +12,7 @@ use std::{
 #[cfg(feature = "__tls")]
 use actix_http::TlsAcceptorConfig;
 use actix_http::{body::MessageBody, Extensions, HttpService, KeepAlive, Request, Response};
-use actix_server::{Server, ServerBuilder};
+use actix_server::{GracefulShutdownSignal, Server, ServerBuilder};
 use actix_service::{
     map_config, IntoServiceFactory, Service, ServiceFactory, ServiceFactoryExt as _,
 };
@@ -87,6 +87,7 @@ where
     backlog: u32,
     sockets: Vec<Socket>,
     builder: ServerBuilder,
+    graceful_shutdown_signal: GracefulShutdownSignal,
     #[allow(clippy::type_complexity)]
     on_connect_fn: Option<Arc<dyn Fn(&dyn Any, &mut Extensions) + Send + Sync>>,
     _phantom: PhantomData<(S, B)>,
@@ -114,6 +115,9 @@ where
     /// [`bind()`](Self::bind()) docs for more on how worker count and bind address resolution
     /// causes multiple server factory instantiations.
     pub fn new(factory: F) -> Self {
+        let builder = ServerBuilder::default();
+        let graceful_shutdown_signal = builder.graceful_shutdown_signal();
+
         HttpServer {
             factory,
             config: Arc::new(Mutex::new(Config {
@@ -130,7 +134,8 @@ where
             })),
             backlog: 1024,
             sockets: Vec::new(),
-            builder: ServerBuilder::default(),
+            builder,
+            graceful_shutdown_signal,
             on_connect_fn: None,
             _phantom: PhantomData,
         }
@@ -632,14 +637,20 @@ where
         });
 
         let on_connect_fn = self.on_connect_fn.clone();
+        let graceful_shutdown_signal = self.graceful_shutdown_signal.clone();
 
         self.builder =
             self.builder
                 .listen(format!("actix-web-service-{}", addr), lst, move || {
                     let cfg = cfg.lock().unwrap();
                     let host = cfg.host.clone().unwrap_or_else(|| format!("{}", addr));
+                    let shutdown_signal = graceful_shutdown_signal.clone();
 
                     let mut svc = HttpService::build()
+                        .graceful_shutdown_signal(move || {
+                            let signal = shutdown_signal.clone();
+                            async move { signal.notified().await }
+                        })
                         .keep_alive(cfg.keep_alive)
                         .client_request_timeout(cfg.client_request_timeout)
                         .client_disconnect_timeout(cfg.client_disconnect_timeout)
@@ -693,14 +704,20 @@ where
         });
 
         let on_connect_fn = self.on_connect_fn.clone();
+        let graceful_shutdown_signal = self.graceful_shutdown_signal.clone();
 
         self.builder =
             self.builder
                 .listen(format!("actix-web-service-{}", addr), lst, move || {
                     let cfg = cfg.lock().unwrap();
                     let host = cfg.host.clone().unwrap_or_else(|| format!("{}", addr));
+                    let shutdown_signal = graceful_shutdown_signal.clone();
 
                     let mut svc = HttpService::build()
+                        .graceful_shutdown_signal(move || {
+                            let signal = shutdown_signal.clone();
+                            async move { signal.notified().await }
+                        })
                         .keep_alive(cfg.keep_alive)
                         .client_request_timeout(cfg.client_request_timeout)
                         .client_disconnect_timeout(cfg.client_disconnect_timeout)
@@ -786,14 +803,20 @@ where
         });
 
         let on_connect_fn = self.on_connect_fn.clone();
+        let graceful_shutdown_signal = self.graceful_shutdown_signal.clone();
 
         self.builder =
             self.builder
                 .listen(format!("actix-web-service-{}", addr), lst, move || {
                     let c = cfg.lock().unwrap();
                     let host = c.host.clone().unwrap_or_else(|| format!("{}", addr));
+                    let shutdown_signal = graceful_shutdown_signal.clone();
 
                     let mut svc = HttpService::build()
+                        .graceful_shutdown_signal(move || {
+                            let signal = shutdown_signal.clone();
+                            async move { signal.notified().await }
+                        })
                         .keep_alive(c.keep_alive)
                         .client_request_timeout(c.client_request_timeout)
                         .h1_allow_half_closed(c.h1_allow_half_closed)
@@ -853,14 +876,20 @@ where
         });
 
         let on_connect_fn = self.on_connect_fn.clone();
+        let graceful_shutdown_signal = self.graceful_shutdown_signal.clone();
 
         self.builder =
             self.builder
                 .listen(format!("actix-web-service-{}", addr), lst, move || {
                     let c = cfg.lock().unwrap();
                     let host = c.host.clone().unwrap_or_else(|| format!("{}", addr));
+                    let shutdown_signal = graceful_shutdown_signal.clone();
 
                     let mut svc = HttpService::build()
+                        .graceful_shutdown_signal(move || {
+                            let signal = shutdown_signal.clone();
+                            async move { signal.notified().await }
+                        })
                         .keep_alive(c.keep_alive)
                         .client_request_timeout(c.client_request_timeout)
                         .h1_allow_half_closed(c.h1_allow_half_closed)
@@ -935,14 +964,20 @@ where
         });
 
         let on_connect_fn = self.on_connect_fn.clone();
+        let graceful_shutdown_signal = self.graceful_shutdown_signal.clone();
 
         self.builder =
             self.builder
                 .listen(format!("actix-web-service-{}", addr), lst, move || {
                     let c = cfg.lock().unwrap();
                     let host = c.host.clone().unwrap_or_else(|| format!("{}", addr));
+                    let shutdown_signal = graceful_shutdown_signal.clone();
 
                     let mut svc = HttpService::build()
+                        .graceful_shutdown_signal(move || {
+                            let signal = shutdown_signal.clone();
+                            async move { signal.notified().await }
+                        })
                         .keep_alive(c.keep_alive)
                         .client_request_timeout(c.client_request_timeout)
                         .h1_allow_half_closed(c.h1_allow_half_closed)
@@ -1017,14 +1052,20 @@ where
         });
 
         let on_connect_fn = self.on_connect_fn.clone();
+        let graceful_shutdown_signal = self.graceful_shutdown_signal.clone();
 
         self.builder =
             self.builder
                 .listen(format!("actix-web-service-{}", addr), lst, move || {
                     let c = cfg.lock().unwrap();
                     let host = c.host.clone().unwrap_or_else(|| format!("{}", addr));
+                    let shutdown_signal = graceful_shutdown_signal.clone();
 
                     let mut svc = HttpService::build()
+                        .graceful_shutdown_signal(move || {
+                            let signal = shutdown_signal.clone();
+                            async move { signal.notified().await }
+                        })
                         .keep_alive(c.keep_alive)
                         .client_request_timeout(c.client_request_timeout)
                         .h1_allow_half_closed(c.h1_allow_half_closed)
@@ -1099,14 +1140,20 @@ where
         });
 
         let on_connect_fn = self.on_connect_fn.clone();
+        let graceful_shutdown_signal = self.graceful_shutdown_signal.clone();
 
         self.builder =
             self.builder
                 .listen(format!("actix-web-service-{}", addr), lst, move || {
                     let c = cfg.lock().unwrap();
                     let host = c.host.clone().unwrap_or_else(|| format!("{}", addr));
+                    let shutdown_signal = graceful_shutdown_signal.clone();
 
                     let mut svc = HttpService::build()
+                        .graceful_shutdown_signal(move || {
+                            let signal = shutdown_signal.clone();
+                            async move { signal.notified().await }
+                        })
                         .keep_alive(c.keep_alive)
                         .client_request_timeout(c.client_request_timeout)
                         .client_disconnect_timeout(c.client_disconnect_timeout)
@@ -1166,6 +1213,7 @@ where
 
         let cfg = Arc::clone(&self.config);
         let factory = self.factory.clone();
+        let graceful_shutdown_signal = self.graceful_shutdown_signal.clone();
         let socket_addr =
             net::SocketAddr::new(net::IpAddr::V4(net::Ipv4Addr::new(127, 0, 0, 1)), 8080);
 
@@ -1190,7 +1238,12 @@ where
                     .map_err(|err| err.into().error_response());
 
                 fn_service(|io: UnixStream| async { Ok((io, Protocol::Http1, None)) }).and_then({
+                    let shutdown_signal = graceful_shutdown_signal.clone();
                     let mut svc = HttpService::build()
+                        .graceful_shutdown_signal(move || {
+                            let signal = shutdown_signal.clone();
+                            async move { signal.notified().await }
+                        })
                         .keep_alive(c.keep_alive)
                         .client_request_timeout(c.client_request_timeout)
                         .client_disconnect_timeout(c.client_disconnect_timeout)
@@ -1228,6 +1281,7 @@ where
         let addr = lst.local_addr()?;
         let name = format!("actix-web-service-{:?}", addr);
         let on_connect_fn = self.on_connect_fn.clone();
+        let graceful_shutdown_signal = self.graceful_shutdown_signal.clone();
 
         self.builder = self.builder.listen_uds(name, lst, move || {
             let c = cfg.lock().unwrap();
@@ -1238,7 +1292,12 @@ where
             );
 
             fn_service(|io: UnixStream| async { Ok((io, Protocol::Http1, None)) }).and_then({
+                let shutdown_signal = graceful_shutdown_signal.clone();
                 let mut svc = HttpService::build()
+                    .graceful_shutdown_signal(move || {
+                        let signal = shutdown_signal.clone();
+                        async move { signal.notified().await }
+                    })
                     .keep_alive(c.keep_alive)
                     .client_request_timeout(c.client_request_timeout)
                     .h1_allow_half_closed(c.h1_allow_half_closed)

--- a/actix-web/tests/test_httpserver.rs
+++ b/actix-web/tests/test_httpserver.rs
@@ -26,6 +26,7 @@ use tokio::{
     sync::{oneshot, Notify},
 };
 
+// Read the response head while retaining direct ownership of the connection.
 async fn read_http1_response_head(stream: &mut TcpStream) -> io::Result<Vec<u8>> {
     let mut response = Vec::new();
 
@@ -217,6 +218,7 @@ async fn graceful_shutdown_closes_idle_http1_connection_after_in_flight_request(
             )
     })
     .workers(1)
+    // Keep these timeouts above the test assertions so they cannot cause EOF.
     .keep_alive(Duration::from_secs(30))
     .shutdown_timeout(5)
     .disable_signals()
@@ -228,6 +230,7 @@ async fn graceful_shutdown_closes_idle_http1_connection_after_in_flight_request(
     let server_handle = server.handle();
     let server_task = actix_web::rt::spawn(server);
 
+    // Complete one request, leaving this connection idle and eligible for HTTP/1 keep-alive.
     let mut idle_connection = TcpStream::connect(addr).await.unwrap();
     idle_connection
         .write_all(b"GET /idle HTTP/1.1\r\nhost: localhost\r\n\r\n")
@@ -238,6 +241,7 @@ async fn graceful_shutdown_closes_idle_http1_connection_after_in_flight_request(
         .unwrap();
     assert!(response.starts_with(b"HTTP/1.1 200 OK\r\n"));
 
+    // Establish keep-alive on a second connection before giving it active and queued work.
     let mut in_flight_connection = TcpStream::connect(addr).await.unwrap();
     in_flight_connection
         .write_all(b"GET /idle HTTP/1.1\r\nhost: localhost\r\n\r\n")
@@ -248,6 +252,7 @@ async fn graceful_shutdown_closes_idle_http1_connection_after_in_flight_request(
         .unwrap();
     assert!(response.starts_with(b"HTTP/1.1 200 OK\r\n"));
 
+    // Pipeline one request that blocks in its handler and one request that must remain queued.
     in_flight_connection
         .write_all(
             b"GET /in-flight HTTP/1.1\r\nhost: localhost\r\n\r\n\
@@ -255,16 +260,20 @@ async fn graceful_shutdown_closes_idle_http1_connection_after_in_flight_request(
         )
         .await
         .unwrap();
+
+    // Do not start shutdown until the first pipelined request is in flight.
     request_started.notified().await;
 
     let shutdown_task = actix_web::rt::spawn(async move {
         server_handle.stop(true).await;
     });
 
+    // The idle connection must close while the active request remains blocked.
     let mut buf = [0];
     let idle_connection_closed =
         timeout(Duration::from_millis(500), idle_connection.read(&mut buf)).await;
 
+    // Allow the current request, but not its queued successor, to finish during shutdown.
     finish_request.notify_one();
 
     let response = timeout(
@@ -276,12 +285,14 @@ async fn graceful_shutdown_closes_idle_http1_connection_after_in_flight_request(
     .unwrap();
     assert!(response.starts_with(b"HTTP/1.1 200 OK\r\n"));
 
+    // The active connection must close instead of returning to keep-alive after its response.
     let in_flight_connection_closed = timeout(
         Duration::from_millis(500),
         in_flight_connection.read(&mut buf),
     )
     .await;
 
+    // Do not leave the server waiting on client sockets when an EOF assertion fails.
     drop((idle_connection, in_flight_connection));
 
     timeout(Duration::from_secs(2), shutdown_task)
@@ -306,6 +317,7 @@ async fn graceful_shutdown_closes_idle_http1_connection_after_in_flight_request(
 
 #[actix_rt::test]
 async fn shutdown_signal_closes_idle_http1_connection() {
+    // Control the exact point at which the builder-configured shutdown signal resolves.
     let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
 
     let server = HttpServer::new(|| {
@@ -323,6 +335,7 @@ async fn shutdown_signal_closes_idle_http1_connection() {
     let addr = server.addrs()[0];
     let server_task = actix_web::rt::spawn(server.run());
 
+    // Complete a request and leave the connection idle in HTTP/1 keep-alive.
     let mut connection = TcpStream::connect(addr).await.unwrap();
     connection
         .write_all(b"GET / HTTP/1.1\r\nhost: localhost\r\n\r\n")
@@ -331,6 +344,7 @@ async fn shutdown_signal_closes_idle_http1_connection() {
     let response = read_http1_response_head(&mut connection).await.unwrap();
     assert!(response.starts_with(b"HTTP/1.1 200 OK\r\n"));
 
+    // Resolve HttpServer::shutdown_signal and expect it to reach the HTTP/1 dispatcher.
     shutdown_tx.send(()).unwrap();
 
     let mut buf = [0];

--- a/actix-web/tests/test_httpserver.rs
+++ b/actix-web/tests/test_httpserver.rs
@@ -3,14 +3,40 @@ extern crate tls_openssl as openssl;
 
 use std::{
     convert::Infallible,
-    sync::{mpsc, Arc},
+    io,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        mpsc, Arc,
+    },
     thread,
     time::Duration,
 };
 
-use actix_web::{rt::time::sleep, web, App, HttpRequest, HttpResponse, HttpServer};
+use actix_web::{
+    rt::{
+        net::TcpStream,
+        time::{sleep, timeout},
+    },
+    web, App, HttpRequest, HttpResponse, HttpServer,
+};
 use bytes::Bytes;
 use futures_util::stream;
+use tokio::{
+    io::{AsyncReadExt as _, AsyncWriteExt as _},
+    sync::{oneshot, Notify},
+};
+
+async fn read_http1_response_head(stream: &mut TcpStream) -> io::Result<Vec<u8>> {
+    let mut response = Vec::new();
+
+    loop {
+        response.push(stream.read_u8().await?);
+
+        if response.ends_with(b"\r\n\r\n") {
+            return Ok(response);
+        }
+    }
+}
 
 #[actix_rt::test]
 async fn test_start() {
@@ -147,6 +173,179 @@ async fn test_app_data_dropped_after_graceful_shutdown_with_slow_request() {
     }
 
     panic!("app data still referenced after graceful shutdown");
+}
+
+#[actix_rt::test]
+async fn graceful_shutdown_closes_idle_http1_connection_after_in_flight_request() {
+    let request_started = Arc::new(Notify::new());
+    let finish_request = Arc::new(Notify::new());
+    let queued_request_started = Arc::new(AtomicBool::new(false));
+
+    let server_request_started = Arc::clone(&request_started);
+    let server_finish_request = Arc::clone(&finish_request);
+    let server_queued_request_started = Arc::clone(&queued_request_started);
+
+    let server = HttpServer::new(move || {
+        let request_started = Arc::clone(&server_request_started);
+        let finish_request = Arc::clone(&server_finish_request);
+        let queued_request_started = Arc::clone(&server_queued_request_started);
+
+        App::new()
+            .route(
+                "/idle",
+                web::get().to(|| async { HttpResponse::Ok().finish() }),
+            )
+            .route(
+                "/in-flight",
+                web::get().to(move || {
+                    let request_started = Arc::clone(&request_started);
+                    let finish_request = Arc::clone(&finish_request);
+
+                    async move {
+                        request_started.notify_one();
+                        finish_request.notified().await;
+                        HttpResponse::Ok().finish()
+                    }
+                }),
+            )
+            .route(
+                "/queued",
+                web::get().to(move || {
+                    queued_request_started.store(true, Ordering::SeqCst);
+                    async { HttpResponse::Ok().finish() }
+                }),
+            )
+    })
+    .workers(1)
+    .keep_alive(Duration::from_secs(30))
+    .shutdown_timeout(5)
+    .disable_signals()
+    .bind(("127.0.0.1", 0))
+    .unwrap();
+
+    let addr = server.addrs()[0];
+    let server = server.run();
+    let server_handle = server.handle();
+    let server_task = actix_web::rt::spawn(server);
+
+    let mut idle_connection = TcpStream::connect(addr).await.unwrap();
+    idle_connection
+        .write_all(b"GET /idle HTTP/1.1\r\nhost: localhost\r\n\r\n")
+        .await
+        .unwrap();
+    let response = read_http1_response_head(&mut idle_connection)
+        .await
+        .unwrap();
+    assert!(response.starts_with(b"HTTP/1.1 200 OK\r\n"));
+
+    let mut in_flight_connection = TcpStream::connect(addr).await.unwrap();
+    in_flight_connection
+        .write_all(b"GET /idle HTTP/1.1\r\nhost: localhost\r\n\r\n")
+        .await
+        .unwrap();
+    let response = read_http1_response_head(&mut in_flight_connection)
+        .await
+        .unwrap();
+    assert!(response.starts_with(b"HTTP/1.1 200 OK\r\n"));
+
+    in_flight_connection
+        .write_all(
+            b"GET /in-flight HTTP/1.1\r\nhost: localhost\r\n\r\n\
+              GET /queued HTTP/1.1\r\nhost: localhost\r\n\r\n",
+        )
+        .await
+        .unwrap();
+    request_started.notified().await;
+
+    let shutdown_task = actix_web::rt::spawn(async move {
+        server_handle.stop(true).await;
+    });
+
+    let mut buf = [0];
+    let idle_connection_closed =
+        timeout(Duration::from_millis(500), idle_connection.read(&mut buf)).await;
+
+    finish_request.notify_one();
+
+    let response = timeout(
+        Duration::from_millis(500),
+        read_http1_response_head(&mut in_flight_connection),
+    )
+    .await
+    .expect("in-flight request did not finish during graceful shutdown")
+    .unwrap();
+    assert!(response.starts_with(b"HTTP/1.1 200 OK\r\n"));
+
+    let in_flight_connection_closed = timeout(
+        Duration::from_millis(500),
+        in_flight_connection.read(&mut buf),
+    )
+    .await;
+
+    drop((idle_connection, in_flight_connection));
+
+    timeout(Duration::from_secs(2), shutdown_task)
+        .await
+        .expect("server did not stop after its connections closed")
+        .unwrap();
+    server_task.await.unwrap().unwrap();
+
+    assert!(
+        matches!(idle_connection_closed, Ok(Ok(0))),
+        "idle keep-alive connection did not close immediately"
+    );
+    assert!(
+        matches!(in_flight_connection_closed, Ok(Ok(0))),
+        "keep-alive connection did not close after its in-flight request"
+    );
+    assert!(
+        !queued_request_started.load(Ordering::SeqCst),
+        "queued request started during graceful shutdown"
+    );
+}
+
+#[actix_rt::test]
+async fn shutdown_signal_closes_idle_http1_connection() {
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+
+    let server = HttpServer::new(|| {
+        App::new().route("/", web::get().to(|| async { HttpResponse::Ok().finish() }))
+    })
+    .workers(1)
+    .keep_alive(Duration::from_secs(30))
+    .shutdown_timeout(5)
+    .shutdown_signal(async move {
+        let _ = shutdown_rx.await;
+    })
+    .bind(("127.0.0.1", 0))
+    .unwrap();
+
+    let addr = server.addrs()[0];
+    let server_task = actix_web::rt::spawn(server.run());
+
+    let mut connection = TcpStream::connect(addr).await.unwrap();
+    connection
+        .write_all(b"GET / HTTP/1.1\r\nhost: localhost\r\n\r\n")
+        .await
+        .unwrap();
+    let response = read_http1_response_head(&mut connection).await.unwrap();
+    assert!(response.starts_with(b"HTTP/1.1 200 OK\r\n"));
+
+    shutdown_tx.send(()).unwrap();
+
+    let mut buf = [0];
+    let connection_closed = timeout(Duration::from_millis(500), connection.read(&mut buf)).await;
+
+    timeout(Duration::from_secs(2), server_task)
+        .await
+        .expect("server did not stop after the shutdown signal")
+        .unwrap()
+        .unwrap();
+
+    assert!(
+        matches!(connection_closed, Ok(Ok(0))),
+        "idle keep-alive connection did not close after the shutdown signal"
+    );
 }
 
 #[cfg(feature = "openssl")]


### PR DESCRIPTION
## Summary

- propagate the server's graceful shutdown notification into every HTTP service factory
- close idle HTTP/1 keep-alive connections as soon as graceful shutdown starts
- let the current HTTP/1 request finish, then close the connection
- discard queued pipelined requests without starting them
- cover both `ServerHandle::stop(true)` and `HttpServer::shutdown_signal()`

Requires actix-server 2.7, which contains the signal API from actix/actix-net#930.

## Root cause

Actix-server detaches each connection future and waits for its active-connection counter during graceful shutdown. The HTTP/1 dispatcher had no notification that shutdown had started, so an idle connection stayed open and a connection that completed its active request returned to keep-alive.

## Behavior

When graceful shutdown starts, an idle connection closes immediately. An active connection finishes only its current request, flushes the final response, and closes. Requests already queued behind the active request do not start.

## Validation

- `cargo test -p actix-web --test test_httpserver shutdown -- --nocapture`
- `cargo test -p actix-http --lib h1::dispatcher -- --nocapture`
- `just clippy`
- `cargo package --locked -p actix-web --allow-dirty --no-verify`
