### PR TITLE
fix(http): terminate ByteString message bodies

### DIFF
--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Fix `MessageBody` implementation for `ByteString` to signal completion after yielding its contents. [#4177]
+
+[#4177]: https://github.com/actix/actix-web/issues/4177
+
 ## 3.13.1
 
 - Fix HTTP/1 WebSocket upgrade responses being overwritten with `Connection: close` when the upgraded request payload remains open. [#4115]

--- a/actix-http/src/body/message_body.rs
+++ b/actix-http/src/body/message_body.rs
@@ -458,8 +458,12 @@ mod foreign_impls {
             self: Pin<&mut Self>,
             _cx: &mut Context<'_>,
         ) -> Poll<Option<Result<Bytes, Self::Error>>> {
-            let string = mem::take(self.get_mut());
-            Poll::Ready(Some(Ok(string.into_bytes())))
+            if self.is_empty() {
+                Poll::Ready(None)
+            } else {
+                let string = mem::take(self.get_mut());
+                Poll::Ready(Some(Ok(string.into_bytes())))
+            }
         }
 
         #[inline]
@@ -664,6 +668,15 @@ mod tests {
         let pl = "test".to_owned();
         pin!(pl);
         assert_poll_next!(pl, Bytes::from("test"));
+    }
+
+    #[actix_rt::test]
+    async fn test_byte_string() {
+        let pl = bytestring::ByteString::from_static("test");
+        assert_eq!(pl.size(), BodySize::Sized(4));
+        pin!(pl);
+        assert_poll_next!(pl, Bytes::from_static(b"test"));
+        assert_poll_next_none!(pl);
     }
 
     #[actix_rt::test]


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type

<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->

Bug Fix

## PR Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.

## Overview

<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
The `MessageBody` implementation for `ByteString` kept producing empty chunks after yielding its contents, preventing polling consumers from observing completion.
<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
Closes #4177