### PR TITLE
fix(multipart): include inner error in Payload and Parse display strings

### DIFF
--- a/actix-multipart/CHANGES.md
+++ b/actix-multipart/CHANGES.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
-- Include inner error in `MultipartError::Payload` and `MultipartError::Parse` display strings. [#4168]
+- Include inner error in `MultipartError::Payload`, `MultipartError::Parse`, and `MultipartError::Field` display strings. [#4168]
+- Fix `MultipartError::ContentDispositionNameMissing` display string to indicate missing name parameter.
+- Improve `JsonFieldError::ContentType` and `TextError::ContentType` error messages.
 
 [#4168]: https://github.com/actix/actix-web/issues/4168
 

--- a/actix-multipart/CHANGES.md
+++ b/actix-multipart/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Include inner error in `MultipartError::Payload` and `MultipartError::Parse` display strings. [#4168]
+
+[#4168]: https://github.com/actix/actix-web/issues/4168
+
 ## 0.8.0
 
 - Add multi-field multipart payload builders to `actix_multipart::test`. [#3575]

--- a/actix-multipart/src/error.rs
+++ b/actix-multipart/src/error.rs
@@ -60,11 +60,11 @@ pub enum Error {
     Incomplete,
 
     /// Field parsing failed.
-    #[display("Error during field parsing")]
+    #[display("Error during field parsing: {_0}")]
     Parse(ParseError),
 
     /// HTTP payload error.
-    #[display("Payload error")]
+    #[display("Payload error: {_0}")]
     Payload(PayloadError),
 
     /// Stream is not consumed.
@@ -113,5 +113,14 @@ mod tests {
     fn test_multipart_error() {
         let resp = Error::BoundaryMissing.error_response();
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+
+        let err = Error::Payload(PayloadError::Overflow);
+        assert_eq!(err.to_string(), "Payload error: payload reached size limit");
+
+        let err = Error::Parse(ParseError::Incomplete);
+        assert_eq!(
+            err.to_string(),
+            "Error during field parsing: message is incomplete"
+        );
     }
 }

--- a/actix-multipart/src/error.rs
+++ b/actix-multipart/src/error.rs
@@ -48,7 +48,9 @@ pub enum Error {
     /// always include a "name" parameter.
     ///
     /// [RFC 7578 §4.2]: https://datatracker.ietf.org/doc/html/rfc7578#section-4.2
-    #[display("Content-Disposition header was not found when parsing a \"form-data\" field")]
+    #[display(
+        "Content-Disposition 'name' parameter was not found when parsing a \"form-data\" field"
+    )]
     ContentDispositionNameMissing,
 
     /// Nested multipart is not supported.
@@ -72,7 +74,7 @@ pub enum Error {
     NotConsumed,
 
     /// Form field handler raised error.
-    #[display("An error occurred processing field: {name}")]
+    #[display("An error occurred processing field '{name}': {source}")]
     Field {
         name: String,
         source: actix_web::Error,
@@ -121,6 +123,21 @@ mod tests {
         assert_eq!(
             err.to_string(),
             "Error during field parsing: message is incomplete"
+        );
+
+        let err = Error::ContentDispositionNameMissing;
+        assert_eq!(
+            err.to_string(),
+            "Content-Disposition 'name' parameter was not found when parsing a \"form-data\" field"
+        );
+
+        let err = Error::Field {
+            name: "avatar".to_owned(),
+            source: actix_web::error::ErrorBadRequest("invalid file format"),
+        };
+        assert_eq!(
+            err.to_string(),
+            "An error occurred processing field 'avatar': invalid file format"
         );
     }
 }

--- a/actix-multipart/src/form/json.rs
+++ b/actix-multipart/src/form/json.rs
@@ -70,7 +70,7 @@ pub enum JsonFieldError {
     Deserialize(serde_json::Error),
 
     /// Content type error.
-    #[display("Content type error")]
+    #[display("Field Content-Type is not application/json")]
     ContentType,
 }
 
@@ -137,7 +137,7 @@ mod tests {
     use actix_web::{http::StatusCode, web, web::Bytes, App, HttpResponse, Responder};
 
     use crate::form::{
-        json::{Json, JsonConfig},
+        json::{Json, JsonConfig, JsonFieldError},
         MultipartForm,
     };
 
@@ -207,5 +207,13 @@ mod tests {
         *req.headers_mut() = headers;
         let res = req.send_body(body).await.unwrap();
         assert_eq!(res.status(), StatusCode::OK);
+    }
+
+    #[test]
+    fn test_json_field_error_display() {
+        assert_eq!(
+            JsonFieldError::ContentType.to_string(),
+            "Field Content-Type is not application/json"
+        );
     }
 }

--- a/actix-multipart/src/form/text.rs
+++ b/actix-multipart/src/form/text.rs
@@ -85,7 +85,7 @@ pub enum TextError {
     Deserialize(serde_plain::Error),
 
     /// Content type error.
-    #[display("Content type error")]
+    #[display("Field Content-Type is not text/plain")]
     ContentType,
 }
 
@@ -158,7 +158,7 @@ mod tests {
 
     use crate::form::{
         tests::send_form,
-        text::{Text, TextConfig},
+        text::{Text, TextConfig, TextError},
         MultipartForm,
     };
 
@@ -193,5 +193,13 @@ mod tests {
         form.add_reader_file_with_mime("number", bytes, "", mime::TEXT_PLAIN);
         let response = send_form(&srv, form, "/").await;
         assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[test]
+    fn test_text_error_display() {
+        assert_eq!(
+            TextError::ContentType.to_string(),
+            "Field Content-Type is not text/plain"
+        );
     }
 }


### PR DESCRIPTION
## PR Type

Bug Fix

## PR Checklist

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [x] (Team) Label with affected crates and semver status.

## Overview

Improves error messages and `Display` implementations across `actix-multipart`:

1. **`MultipartError::Payload` and `MultipartError::Parse`**: Include inner error details (`{_0}`).
2. **`MultipartError::Field`**: Include underlying source error (`'{name}': {source}`).
3. **`MultipartError::ContentDispositionNameMissing`**: Fix display message to indicate that the `name` parameter is missing (rather than the entire header).
4. **`JsonFieldError::ContentType` and `TextError::ContentType`**: Provide clear messages describing expected media types (`Field Content-Type is not application/json` / `text/plain`).

Closes #4168