### PR TITLE
feat(http): log peer disconnects (exploratory)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,6 +102,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "tracing-test",
  "zstd",
 ]
 
@@ -2123,6 +2124,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2220,6 +2230,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3016,6 +3035,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3257,6 +3285,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -3514,6 +3551,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
+name = "tracing-test"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a4c448db514d4f24c5ddb9f73f2ee71bfb24c526cf0c570ba142d1119e0051"
+dependencies = [
+ "tracing-core",
+ "tracing-subscriber",
+ "tracing-test-macro",
+]
+
+[[package]]
+name = "tracing-test-macro"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad06847b7afb65c7866a36664b75c40b895e318cea4f71299f013fb22965329d"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3632,6 +3720,12 @@ checksum = "befb3d53c9e3ec641417685896cbc8cc5bd264d6a2e190c56aaef1af24740d99"
 dependencies = [
  "v_escape-base",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/actix-http/Cargo.toml
+++ b/actix-http/Cargo.toml
@@ -158,6 +158,7 @@ static_assertions = "1"
 tls-openssl = { package = "openssl", version = "0.10.55" }
 tls-rustls_023 = { package = "rustls", version = "0.23" }
 tokio = { version = "1.38.2", features = ["net", "rt", "macros", "sync"] }
+tracing-test = "0.2"
 
 [lints]
 workspace = true

--- a/actix-http/src/h1/dispatcher.rs
+++ b/actix-http/src/h1/dispatcher.rs
@@ -17,7 +17,7 @@ use futures_core::ready;
 use pin_project_lite::pin_project;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_util::codec::{Decoder as _, Encoder as _};
-use tracing::{error, trace};
+use tracing::{error, trace, warn};
 
 use super::{
     codec::Codec,
@@ -354,13 +354,19 @@ where
         let mut written = 0;
 
         while written < len {
-            match io.as_mut().poll_write(cx, &write_buf[written..])? {
-                Poll::Ready(0) => {
-                    error!("write zero; closing");
-                    return Poll::Ready(Err(io::Error::new(io::ErrorKind::WriteZero, "")));
+            match io.as_mut().poll_write(cx, &write_buf[written..]) {
+                Poll::Ready(Ok(0)) => {
+                    let err = io::Error::new(io::ErrorKind::WriteZero, "");
+                    warn!("HTTP/1 peer disconnected while writing: {err}");
+                    return Poll::Ready(Err(err));
                 }
 
-                Poll::Ready(n) => written += n,
+                Poll::Ready(Ok(n)) => written += n,
+
+                Poll::Ready(Err(err)) => {
+                    warn!("HTTP/1 peer disconnected while writing: {err}");
+                    return Poll::Ready(Err(err));
+                }
 
                 Poll::Pending => {
                     write_buf.advance(written);
@@ -373,7 +379,11 @@ where
         write_buf.clear();
 
         // flush the I/O and check if get blocked
-        io.poll_flush(cx)
+        let poll = io.poll_flush(cx);
+        if let Poll::Ready(Err(err)) = &poll {
+            warn!("HTTP/1 peer disconnected while flushing: {err}");
+        }
+        poll
     }
 
     fn enter_linger(flags: &mut Flags) {
@@ -1216,6 +1226,7 @@ where
                     }
 
                     if n == 0 {
+                        warn!("HTTP/1 peer disconnected while reading");
                         return Ok(true);
                     }
 
@@ -1232,9 +1243,15 @@ where
                         io::ErrorKind::WouldBlock => Ok(false),
 
                         // connection reset after partial read
-                        io::ErrorKind::ConnectionReset if read_some => Ok(true),
+                        io::ErrorKind::ConnectionReset if read_some => {
+                            warn!("HTTP/1 peer disconnected while reading: {err}");
+                            Ok(true)
+                        }
 
-                        _ => Err(DispatchError::Io(err)),
+                        _ => {
+                            warn!("HTTP/1 peer disconnected while reading: {err}");
+                            Err(DispatchError::Io(err))
+                        }
                     };
                 }
             }
@@ -1317,7 +1334,10 @@ where
                         ready!(inner.as_mut().poll_flush(cx))?;
                         Pin::new(inner.as_mut().project().io.as_mut().unwrap())
                             .poll_shutdown(cx)
-                            .map_err(DispatchError::from)
+                            .map_err(|err| {
+                                warn!("HTTP/1 peer disconnected while shutting down: {err}");
+                                DispatchError::from(err)
+                            })
                     }
                 } else {
                     // read from I/O stream and fill read buffer

--- a/actix-http/src/h1/dispatcher_tests.rs
+++ b/actix-http/src/h1/dispatcher_tests.rs
@@ -18,6 +18,7 @@ use actix_service::{fn_service, Service};
 use actix_utils::future::{ready, Ready};
 use bytes::{Buf, Bytes, BytesMut};
 use futures_util::future::lazy;
+use tracing_test::traced_test;
 
 use super::dispatcher::{Dispatcher, DispatcherState, DispatcherStateProj, Flags};
 use crate::{
@@ -25,7 +26,7 @@ use crate::{
     config::ServiceConfig,
     h1::{Codec, ExpectHandler, UpgradeHandler},
     service::HttpFlow,
-    test::{TestBuffer, TestSeqBuffer},
+    test::{ok_service, FailingWriteBuf, TestBuffer, TestSeqBuffer},
     Error, HttpMessage, KeepAlive, Method, OnConnectData, Request, Response, StatusCode,
 };
 
@@ -165,16 +166,6 @@ fn stabilize_date_header(payload: &mut [u8]) {
             .copy_from_slice(b"date: Thu, 01 Jan 1970 12:34:56 UTC");
         from += 35;
     }
-}
-
-fn ok_service() -> impl Service<Request, Response = Response<impl MessageBody>, Error = Error> {
-    status_service(StatusCode::OK)
-}
-
-fn status_service(
-    status: StatusCode,
-) -> impl Service<Request, Response = Response<impl MessageBody>, Error = Error> {
-    fn_service(move |_req: Request| ready(Ok::<_, Error>(Response::new(status))))
 }
 
 fn echo_path_service() -> impl Service<Request, Response = Response<impl MessageBody>, Error = Error>
@@ -610,6 +601,91 @@ async fn graceful_shutdown_does_not_start_buffered_request() {
         buf.write_buf_slice().is_empty(),
         "dispatcher wrote a response for the buffered request"
     );
+}
+
+#[actix_rt::test]
+#[traced_test]
+async fn peer_eof_logs_warn() {
+    let buf = TestSeqBuffer::empty();
+    buf.close_read();
+    let services = HttpFlow::new(ok_service(), ExpectHandler, None);
+    let dispatcher = Dispatcher::<_, _, _, _, UpgradeHandler>::new(
+        buf,
+        services,
+        ServiceConfig::default(),
+        None,
+        OnConnectData::default(),
+    );
+    pin!(dispatcher);
+
+    lazy(|cx| assert!(dispatcher.as_mut().poll(cx).is_ready())).await;
+
+    assert!(logs_contain("peer disconnected"));
+}
+
+#[actix_rt::test]
+#[traced_test]
+async fn peer_read_error_logs_warn() {
+    let mut buf = TestBuffer::empty();
+    buf.err = Some(Rc::new(io::Error::new(
+        io::ErrorKind::ConnectionReset,
+        "peer reset the connection",
+    )));
+    let services = HttpFlow::new(ok_service(), ExpectHandler, None);
+    let dispatcher = Dispatcher::<_, _, _, _, UpgradeHandler>::new(
+        buf,
+        services,
+        ServiceConfig::default(),
+        None,
+        OnConnectData::default(),
+    );
+    pin!(dispatcher);
+
+    lazy(|cx| assert!(dispatcher.as_mut().poll(cx).is_ready())).await;
+
+    assert!(logs_contain("peer disconnected"));
+}
+
+#[actix_rt::test]
+#[traced_test]
+async fn peer_reset_after_request_logs_warn() {
+    let mut buf = TestBuffer::new("GET / HTTP/1.1\r\n\r\n");
+    buf.err = Some(Rc::new(io::Error::new(
+        io::ErrorKind::ConnectionReset,
+        "peer reset the connection",
+    )));
+    let services = HttpFlow::new(ok_service(), ExpectHandler, None);
+    let dispatcher = Dispatcher::<_, _, _, _, UpgradeHandler>::new(
+        buf,
+        services,
+        ServiceConfig::default(),
+        None,
+        OnConnectData::default(),
+    );
+    pin!(dispatcher);
+
+    lazy(|cx| assert!(dispatcher.as_mut().poll(cx).is_ready())).await;
+
+    assert!(logs_contain("peer disconnected"));
+}
+
+#[actix_rt::test]
+#[traced_test]
+async fn peer_write_error_logs_warn() {
+    let buf = FailingWriteBuf::new("GET / HTTP/1.1\r\n\r\n");
+    let services = HttpFlow::new(ok_service(), ExpectHandler, None);
+    let dispatcher = Dispatcher::<_, _, _, _, UpgradeHandler>::new(
+        buf,
+        services,
+        ServiceConfig::default(),
+        None,
+        OnConnectData::default(),
+    );
+    pin!(dispatcher);
+
+    lazy(|cx| assert!(dispatcher.as_mut().poll(cx).is_ready())).await;
+
+    assert!(logs_contain("peer disconnected"));
 }
 
 #[actix_rt::test]

--- a/actix-http/src/h2/dispatcher.rs
+++ b/actix-http/src/h2/dispatcher.rs
@@ -111,8 +111,12 @@ where
         let this = self.get_mut();
 
         loop {
-            match Pin::new(&mut this.connection).poll_accept(cx)? {
-                Poll::Ready(Some((req, tx))) => {
+            match Pin::new(&mut this.connection).poll_accept(cx) {
+                Poll::Ready(Some(Err(err))) => {
+                    tracing::warn!("HTTP/2 peer disconnected: {err:?}");
+                    return Poll::Ready(Err(err.into()));
+                }
+                Poll::Ready(Some(Ok((req, tx)))) => {
                     let (parts, body) = req.into_parts();
                     let payload = crate::h2::Payload::new(body);
                     let pl = Payload::H2 { payload };
@@ -146,10 +150,14 @@ where
                         if let Err(err) = res {
                             match err {
                                 DispatchError::SendResponse(err) => {
-                                    tracing::trace!("Error sending response: {err:?}");
+                                    tracing::warn!(
+                                        "HTTP/2 peer disconnected while sending response: {err:?}"
+                                    );
                                 }
                                 DispatchError::SendData(err) => {
-                                    tracing::warn!("Send data error: {err:?}");
+                                    tracing::warn!(
+                                        "HTTP/2 peer disconnected while sending response data: {err:?}"
+                                    );
                                 }
                                 DispatchError::ResponseBody(err) => {
                                     tracing::error!("Response payload stream error: {err:?}");
@@ -158,7 +166,10 @@ where
                         }
                     });
                 }
-                Poll::Ready(None) => return Poll::Ready(Ok(())),
+                Poll::Ready(None) => {
+                    tracing::warn!("HTTP/2 peer disconnected");
+                    return Poll::Ready(Ok(()));
+                }
 
                 Poll::Pending => match this.ping_pong.as_mut() {
                     Some(ping_pong) => loop {
@@ -166,8 +177,12 @@ where
                             // When there is an in-flight ping-pong, poll pong and keep-alive
                             // timer. On successful pong received, update keep-alive timer to
                             // determine the next timing of ping pong.
-                            match ping_pong.ping_pong.poll_pong(cx)? {
-                                Poll::Ready(_) => {
+                            match ping_pong.ping_pong.poll_pong(cx) {
+                                Poll::Ready(Err(err)) => {
+                                    tracing::warn!("HTTP/2 peer disconnected: {err:?}");
+                                    return Poll::Ready(Err(err.into()));
+                                }
+                                Poll::Ready(Ok(_)) => {
                                     ping_pong.in_flight = false;
 
                                     let dead_line = this.config.keep_alive_deadline().unwrap();
@@ -183,7 +198,10 @@ where
                             // as an interval instead.
                             ready!(ping_pong.timer.as_mut().poll(cx));
 
-                            ping_pong.ping_pong.send_ping(Ping::opaque())?;
+                            if let Err(err) = ping_pong.ping_pong.send_ping(Ping::opaque()) {
+                                tracing::warn!("HTTP/2 peer disconnected: {err:?}");
+                                return Poll::Ready(Err(err.into()));
+                            }
 
                             let dead_line = this.config.keep_alive_deadline().unwrap();
                             ping_pong.timer.as_mut().reset(dead_line.into());
@@ -243,7 +261,10 @@ where
 
             match poll_fn(|cx| stream.poll_capacity(cx)).await {
                 // No capacity left. drop body and return.
-                None => return Ok(()),
+                None => {
+                    tracing::warn!("HTTP/2 peer disconnected while sending response");
+                    return Ok(());
+                }
 
                 Some(Err(err)) => return Err(DispatchError::SendData(err)),
 
@@ -352,4 +373,51 @@ fn prepare_response(
     }
 
     res
+}
+
+#[cfg(test)]
+mod tests {
+    use std::future::Future;
+
+    use actix_rt::net::{TcpListener, TcpStream};
+    use futures_util::future::{poll_fn, try_join};
+    use tracing_test::traced_test;
+
+    use super::Dispatcher;
+    use crate::{
+        body::BoxBody, config::ServiceConfig, service::HttpFlow, test::ok_service, OnConnectData,
+    };
+
+    #[actix_rt::test]
+    #[traced_test]
+    async fn peer_eof_logs_warn() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let client = actix_rt::spawn(async move { TcpStream::connect(addr).await.unwrap() });
+        let (server_io, _) = listener.accept().await.unwrap();
+        let client_io = client.await.unwrap();
+
+        let ((_, client_conn), server_conn) = try_join(
+            h2::client::handshake(client_io),
+            h2::server::handshake(server_io),
+        )
+        .await
+        .unwrap();
+        drop(client_conn);
+
+        let flow = HttpFlow::new(ok_service(), (), None::<()>);
+        let dispatcher = Dispatcher::<_, _, BoxBody, _, _>::new(
+            server_conn,
+            flow,
+            ServiceConfig::default(),
+            None,
+            OnConnectData::default(),
+            None,
+        );
+
+        let mut dispatcher = Box::pin(dispatcher);
+        let _ = poll_fn(|cx| dispatcher.as_mut().poll(cx)).await;
+
+        assert!(logs_contain("peer disconnected"));
+    }
 }

--- a/actix-http/src/test.rs
+++ b/actix-http/src/test.rs
@@ -10,14 +10,25 @@ use std::{
 };
 
 use actix_codec::{AsyncRead, AsyncWrite, ReadBuf};
+#[cfg(test)]
+use actix_service::{fn_service, Service};
+#[cfg(test)]
+use actix_utils::future::ready;
 use bytes::{Bytes, BytesMut};
 use http::{header, Method, Uri, Version};
 
+#[cfg(test)]
+use crate::{body::BoxBody, Error, Response};
 use crate::{
     header::{HeaderMap, TryIntoHeaderPair},
     payload::Payload,
     Request,
 };
+
+#[cfg(test)]
+pub(crate) fn ok_service() -> impl Service<Request, Response = Response<BoxBody>, Error = Error> {
+    fn_service(|_req: Request| ready(Ok::<_, Error>(Response::ok())))
+}
 
 /// Test `Request` builder.
 pub struct TestRequest(Option<Inner>);
@@ -252,6 +263,54 @@ impl AsyncWrite for TestBuffer {
         buf: &[u8],
     ) -> Poll<io::Result<usize>> {
         Poll::Ready(self.get_mut().write(buf))
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+}
+
+/// Async I/O buffer that reads supplied data and fails every write with `BrokenPipe`.
+#[cfg(test)]
+pub(crate) struct FailingWriteBuf {
+    io: TestBuffer,
+}
+
+#[cfg(test)]
+impl FailingWriteBuf {
+    /// Creates a buffer with the given readable data.
+    pub(crate) fn new<T>(data: T) -> Self
+    where
+        T: Into<BytesMut>,
+    {
+        Self {
+            io: TestBuffer::new(data),
+        }
+    }
+}
+
+#[cfg(test)]
+impl AsyncRead for FailingWriteBuf {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.io).poll_read(cx, buf)
+    }
+}
+
+#[cfg(test)]
+impl AsyncWrite for FailingWriteBuf {
+    fn poll_write(self: Pin<&mut Self>, _: &mut Context<'_>, _: &[u8]) -> Poll<io::Result<usize>> {
+        Poll::Ready(Err(io::Error::new(
+            io::ErrorKind::BrokenPipe,
+            "peer closed the connection",
+        )))
     }
 
     fn poll_flush(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {


### PR DESCRIPTION
> [!IMPORTANT]
> **Exploratory only:** this draft evaluates the usefulness and noise level of logging peer disconnects at `WARN`. It is not proposed for merge in its current form.

## Summary

- Log HTTP/1 peer disconnects during read, write, flush, and shutdown paths.
- Log HTTP/2 peer disconnects during connection, keep-alive, and response paths.
- Add behavior-level log assertions using `tracing-test`.

## Motivation

Peer disconnects can currently end dispatcher work without much visible context. This patch makes those paths observable so that we can assess how often they occur and which events are useful to operators.

## Expected impact

This should not change HTTP protocol behavior. It does add `WARN` output for disconnects, including some routine EOF cases, so the primary question is whether the proposed level and coverage produce too much noise.

## Questions to explore

- Which disconnect paths, if any, should use `WARN`?
- Should routine EOF use `DEBUG` or `TRACE` instead?
- Should errors use structured fields or more specific messages?
- Are any paths likely to emit duplicate messages for one disconnect?

## Validation

- `cargo test -p actix-http peer_` — 5 passed
- `just clippy` — passed with unrelated existing warnings
- `cargo +nightly fmt --all`
- Staged diff whitespace check passed before commit
