### PR TITLE
refactor: centralize actix-http test service

### DIFF
--- a/actix-http/src/h1/dispatcher_tests.rs
+++ b/actix-http/src/h1/dispatcher_tests.rs
@@ -25,7 +25,7 @@ use crate::{
     config::ServiceConfig,
     h1::{Codec, ExpectHandler, UpgradeHandler},
     service::HttpFlow,
-    test::{TestBuffer, TestSeqBuffer},
+    test::{test_services::ok_service, TestBuffer, TestSeqBuffer},
     Error, HttpMessage, KeepAlive, Method, OnConnectData, Request, Response, StatusCode,
 };
 
@@ -165,16 +165,6 @@ fn stabilize_date_header(payload: &mut [u8]) {
             .copy_from_slice(b"date: Thu, 01 Jan 1970 12:34:56 UTC");
         from += 35;
     }
-}
-
-fn ok_service() -> impl Service<Request, Response = Response<impl MessageBody>, Error = Error> {
-    status_service(StatusCode::OK)
-}
-
-fn status_service(
-    status: StatusCode,
-) -> impl Service<Request, Response = Response<impl MessageBody>, Error = Error> {
-    fn_service(move |_req: Request| ready(Ok::<_, Error>(Response::new(status))))
 }
 
 fn echo_path_service() -> impl Service<Request, Response = Response<impl MessageBody>, Error = Error>

--- a/actix-http/src/h1/dispatcher_tests.rs
+++ b/actix-http/src/h1/dispatcher_tests.rs
@@ -1,7 +1,6 @@
 use std::{
     cell::Cell,
     future::Future,
-    io,
     pin::Pin,
     rc::Rc,
     str,
@@ -26,6 +25,7 @@ use crate::{
     h1::{Codec, ExpectHandler, UpgradeHandler},
     service::HttpFlow,
     test::{
+        pending_once_write_buf::PendingOnceWriteBuf,
         test_services::{
             drop_payload_service, echo_path_service, echo_payload_service, ignore_payload_service,
             ok_service, ready_chunk_body_service, upgrade_response_service,
@@ -52,73 +52,6 @@ impl Service<Request> for YieldService {
             actix_rt::task::yield_now().await;
             Ok(Response::ok())
         })
-    }
-}
-
-struct PendingOnceWriteBuf {
-    io: TestBuffer,
-    block_next_write: bool,
-}
-
-impl PendingOnceWriteBuf {
-    fn new<T>(data: T) -> Self
-    where
-        T: Into<BytesMut>,
-    {
-        Self {
-            io: TestBuffer::new(data),
-            block_next_write: true,
-        }
-    }
-}
-
-impl io::Read for PendingOnceWriteBuf {
-    fn read(&mut self, dst: &mut [u8]) -> Result<usize, io::Error> {
-        self.io.read(dst)
-    }
-}
-
-impl io::Write for PendingOnceWriteBuf {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.io.write(buf)
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        self.io.flush()
-    }
-}
-
-impl actix_codec::AsyncRead for PendingOnceWriteBuf {
-    fn poll_read(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        buf: &mut actix_codec::ReadBuf<'_>,
-    ) -> Poll<io::Result<()>> {
-        Pin::new(&mut self.io).poll_read(cx, buf)
-    }
-}
-
-impl actix_codec::AsyncWrite for PendingOnceWriteBuf {
-    fn poll_write(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        buf: &[u8],
-    ) -> Poll<io::Result<usize>> {
-        if self.block_next_write {
-            self.block_next_write = false;
-            cx.waker().wake_by_ref();
-            return Poll::Pending;
-        }
-
-        Pin::new(&mut self.io).poll_write(cx, buf)
-    }
-
-    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        Pin::new(&mut self.io).poll_flush(cx)
-    }
-
-    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        Pin::new(&mut self.io).poll_shutdown(cx)
     }
 }
 

--- a/actix-http/src/h1/dispatcher_tests.rs
+++ b/actix-http/src/h1/dispatcher_tests.rs
@@ -16,17 +16,23 @@ use actix_rt::{
 };
 use actix_service::{fn_service, Service};
 use actix_utils::future::{ready, Ready};
-use bytes::{Buf, Bytes, BytesMut};
+use bytes::BytesMut;
 use futures_util::future::lazy;
 
 use super::dispatcher::{Dispatcher, DispatcherState, DispatcherStateProj, Flags};
 use crate::{
-    body::{BoxBody, MessageBody},
+    body::BoxBody,
     config::ServiceConfig,
     h1::{Codec, ExpectHandler, UpgradeHandler},
     service::HttpFlow,
-    test::{test_services::ok_service, TestBuffer, TestSeqBuffer},
-    Error, HttpMessage, KeepAlive, Method, OnConnectData, Request, Response, StatusCode,
+    test::{
+        test_services::{
+            drop_payload_service, echo_path_service, echo_payload_service, ignore_payload_service,
+            ok_service, ready_chunk_body_service, upgrade_response_service,
+        },
+        TestBuffer, TestSeqBuffer,
+    },
+    Error, HttpMessage, KeepAlive, Method, OnConnectData, Request, Response,
 };
 
 struct YieldService;
@@ -46,44 +52,6 @@ impl Service<Request> for YieldService {
             actix_rt::task::yield_now().await;
             Ok(Response::ok())
         })
-    }
-}
-
-struct ReadyChunkBody {
-    chunk_polls: Rc<Cell<usize>>,
-    remaining: usize,
-    chunk_len: usize,
-}
-
-impl ReadyChunkBody {
-    fn new(chunk_polls: Rc<Cell<usize>>, remaining: usize, chunk_len: usize) -> Self {
-        Self {
-            chunk_polls,
-            remaining,
-            chunk_len,
-        }
-    }
-}
-
-impl MessageBody for ReadyChunkBody {
-    type Error = Error;
-
-    fn size(&self) -> crate::body::BodySize {
-        crate::body::BodySize::Stream
-    }
-
-    fn poll_next(
-        mut self: Pin<&mut Self>,
-        _: &mut Context<'_>,
-    ) -> Poll<Option<Result<Bytes, Self::Error>>> {
-        if self.remaining == 0 {
-            return Poll::Ready(None);
-        }
-
-        self.remaining -= 1;
-        self.chunk_polls.set(self.chunk_polls.get() + 1);
-
-        Poll::Ready(Some(Ok(Bytes::from(vec![b'x'; self.chunk_len]))))
     }
 }
 
@@ -165,68 +133,6 @@ fn stabilize_date_header(payload: &mut [u8]) {
             .copy_from_slice(b"date: Thu, 01 Jan 1970 12:34:56 UTC");
         from += 35;
     }
-}
-
-fn echo_path_service() -> impl Service<Request, Response = Response<impl MessageBody>, Error = Error>
-{
-    fn_service(|req: Request| {
-        let path = req.path().as_bytes();
-        ready(Ok::<_, Error>(
-            Response::ok().set_body(Bytes::copy_from_slice(path)),
-        ))
-    })
-}
-
-fn drop_payload_service() -> impl Service<Request, Response = Response<&'static str>, Error = Error>
-{
-    fn_service(|mut req: Request| async move {
-        let _ = req.take_payload();
-        Ok::<_, Error>(Response::with_body(StatusCode::OK, "payload dropped"))
-    })
-}
-
-fn ignore_payload_service(
-) -> impl Service<Request, Response = Response<&'static str>, Error = Error> {
-    fn_service(|_req: Request| ready(Ok::<_, Error>(Response::with_body(StatusCode::OK, "ok"))))
-}
-
-fn echo_payload_service() -> impl Service<Request, Response = Response<Bytes>, Error = Error> {
-    fn_service(|mut req: Request| {
-        Box::pin(async move {
-            use futures_util::StreamExt as _;
-
-            let mut pl = req.take_payload();
-            let mut body = BytesMut::new();
-            while let Some(chunk) = pl.next().await {
-                body.extend_from_slice(chunk.unwrap().chunk())
-            }
-
-            Ok::<_, Error>(Response::ok().set_body(body.freeze()))
-        })
-    })
-}
-
-fn ready_chunk_body_service(
-    chunk_polls: Rc<Cell<usize>>,
-    chunk_count: usize,
-    chunk_len: usize,
-) -> impl Service<Request, Response = Response<ReadyChunkBody>, Error = Error> {
-    fn_service(move |_req: Request| {
-        ready(Ok::<_, Error>(Response::ok().set_body(
-            ReadyChunkBody::new(chunk_polls.clone(), chunk_count, chunk_len),
-        )))
-    })
-}
-
-fn upgrade_response_service(
-) -> impl Service<Request, Response = Response<impl MessageBody>, Error = Error> {
-    fn_service(|_req: Request| {
-        ready(Ok::<_, Error>(
-            Response::build(StatusCode::SWITCHING_PROTOCOLS)
-                .upgrade("websocket")
-                .finish(),
-        ))
-    })
 }
 
 #[actix_rt::test]

--- a/actix-http/src/test/mod.rs
+++ b/actix-http/src/test/mod.rs
@@ -3,6 +3,8 @@
 mod test_buffer;
 mod test_request;
 mod test_seq_buffer;
+#[cfg(test)]
+pub(crate) mod test_services;
 
 pub use self::{
     test_buffer::TestBuffer,

--- a/actix-http/src/test/mod.rs
+++ b/actix-http/src/test/mod.rs
@@ -1,5 +1,7 @@
 //! Various testing helpers for use in internal and app tests.
 
+#[cfg(test)]
+mod ready_chunk_body;
 mod test_buffer;
 mod test_request;
 mod test_seq_buffer;

--- a/actix-http/src/test/mod.rs
+++ b/actix-http/src/test/mod.rs
@@ -1,6 +1,8 @@
 //! Various testing helpers for use in internal and app tests.
 
 #[cfg(test)]
+pub(crate) mod pending_once_write_buf;
+#[cfg(test)]
 mod ready_chunk_body;
 mod test_buffer;
 mod test_request;

--- a/actix-http/src/test/pending_once_write_buf.rs
+++ b/actix-http/src/test/pending_once_write_buf.rs
@@ -9,6 +9,7 @@ use bytes::BytesMut;
 
 use super::TestBuffer;
 
+/// Test I/O buffer that returns `Poll::Pending` on its first write.
 pub(crate) struct PendingOnceWriteBuf {
     io: TestBuffer,
     block_next_write: bool,

--- a/actix-http/src/test/pending_once_write_buf.rs
+++ b/actix-http/src/test/pending_once_write_buf.rs
@@ -1,0 +1,77 @@
+use std::{
+    io,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use actix_codec::{AsyncRead, AsyncWrite, ReadBuf};
+use bytes::BytesMut;
+
+use super::TestBuffer;
+
+pub(crate) struct PendingOnceWriteBuf {
+    io: TestBuffer,
+    block_next_write: bool,
+}
+
+impl PendingOnceWriteBuf {
+    pub(crate) fn new<T>(data: T) -> Self
+    where
+        T: Into<BytesMut>,
+    {
+        Self {
+            io: TestBuffer::new(data),
+            block_next_write: true,
+        }
+    }
+}
+
+impl io::Read for PendingOnceWriteBuf {
+    fn read(&mut self, dst: &mut [u8]) -> Result<usize, io::Error> {
+        self.io.read(dst)
+    }
+}
+
+impl io::Write for PendingOnceWriteBuf {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.io.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.io.flush()
+    }
+}
+
+impl AsyncRead for PendingOnceWriteBuf {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.io).poll_read(cx, buf)
+    }
+}
+
+impl AsyncWrite for PendingOnceWriteBuf {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        if self.block_next_write {
+            self.block_next_write = false;
+            cx.waker().wake_by_ref();
+            return Poll::Pending;
+        }
+
+        Pin::new(&mut self.io).poll_write(cx, buf)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.io).poll_flush(cx)
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.io).poll_shutdown(cx)
+    }
+}

--- a/actix-http/src/test/ready_chunk_body.rs
+++ b/actix-http/src/test/ready_chunk_body.rs
@@ -1,0 +1,48 @@
+use std::{
+    cell::Cell,
+    pin::Pin,
+    rc::Rc,
+    task::{Context, Poll},
+};
+
+use bytes::Bytes;
+
+use crate::{body::MessageBody, Error};
+
+pub(crate) struct ReadyChunkBody {
+    chunk_polls: Rc<Cell<usize>>,
+    remaining: usize,
+    chunk_len: usize,
+}
+
+impl ReadyChunkBody {
+    pub(crate) fn new(chunk_polls: Rc<Cell<usize>>, remaining: usize, chunk_len: usize) -> Self {
+        Self {
+            chunk_polls,
+            remaining,
+            chunk_len,
+        }
+    }
+}
+
+impl MessageBody for ReadyChunkBody {
+    type Error = Error;
+
+    fn size(&self) -> crate::body::BodySize {
+        crate::body::BodySize::Stream
+    }
+
+    fn poll_next(
+        mut self: Pin<&mut Self>,
+        _: &mut Context<'_>,
+    ) -> Poll<Option<Result<Bytes, Self::Error>>> {
+        if self.remaining == 0 {
+            return Poll::Ready(None);
+        }
+
+        self.remaining -= 1;
+        self.chunk_polls.set(self.chunk_polls.get() + 1);
+
+        Poll::Ready(Some(Ok(Bytes::from(vec![b'x'; self.chunk_len]))))
+    }
+}

--- a/actix-http/src/test/ready_chunk_body.rs
+++ b/actix-http/src/test/ready_chunk_body.rs
@@ -9,6 +9,7 @@ use bytes::Bytes;
 
 use crate::{body::MessageBody, Error};
 
+/// Test body that yields fixed-size chunks for a configured number of polls.
 pub(crate) struct ReadyChunkBody {
     chunk_polls: Rc<Cell<usize>>,
     remaining: usize,

--- a/actix-http/src/test/test_services.rs
+++ b/actix-http/src/test/test_services.rs
@@ -1,53 +1,11 @@
-use std::{
-    cell::Cell,
-    pin::Pin,
-    rc::Rc,
-    task::{Context, Poll},
-};
+use std::{cell::Cell, rc::Rc};
 
 use actix_service::{fn_service, Service};
 use actix_utils::future::ready;
 use bytes::{Buf, Bytes, BytesMut};
 
+use super::ready_chunk_body::ReadyChunkBody;
 use crate::{body::MessageBody, Error, Request, Response, StatusCode};
-
-pub(crate) struct ReadyChunkBody {
-    chunk_polls: Rc<Cell<usize>>,
-    remaining: usize,
-    chunk_len: usize,
-}
-
-impl ReadyChunkBody {
-    fn new(chunk_polls: Rc<Cell<usize>>, remaining: usize, chunk_len: usize) -> Self {
-        Self {
-            chunk_polls,
-            remaining,
-            chunk_len,
-        }
-    }
-}
-
-impl MessageBody for ReadyChunkBody {
-    type Error = Error;
-
-    fn size(&self) -> crate::body::BodySize {
-        crate::body::BodySize::Stream
-    }
-
-    fn poll_next(
-        mut self: Pin<&mut Self>,
-        _: &mut Context<'_>,
-    ) -> Poll<Option<Result<Bytes, Self::Error>>> {
-        if self.remaining == 0 {
-            return Poll::Ready(None);
-        }
-
-        self.remaining -= 1;
-        self.chunk_polls.set(self.chunk_polls.get() + 1);
-
-        Poll::Ready(Some(Ok(Bytes::from(vec![b'x'; self.chunk_len]))))
-    }
-}
 
 /// Creates a service that responds with an empty `200 OK` response.
 pub(crate) fn ok_service(

--- a/actix-http/src/test/test_services.rs
+++ b/actix-http/src/test/test_services.rs
@@ -1,0 +1,15 @@
+use actix_service::{fn_service, Service};
+use actix_utils::future::ready;
+
+use crate::{body::MessageBody, Error, Request, Response, StatusCode};
+
+pub(crate) fn ok_service(
+) -> impl Service<Request, Response = Response<impl MessageBody>, Error = Error> {
+    status_service(StatusCode::OK)
+}
+
+fn status_service(
+    status: StatusCode,
+) -> impl Service<Request, Response = Response<impl MessageBody>, Error = Error> {
+    fn_service(move |_req: Request| ready(Ok::<_, Error>(Response::new(status))))
+}

--- a/actix-http/src/test/test_services.rs
+++ b/actix-http/src/test/test_services.rs
@@ -49,17 +49,20 @@ impl MessageBody for ReadyChunkBody {
     }
 }
 
+/// Creates a service that responds with an empty `200 OK` response.
 pub(crate) fn ok_service(
 ) -> impl Service<Request, Response = Response<impl MessageBody>, Error = Error> {
     status_service(StatusCode::OK)
 }
 
+/// Creates a service that responds with the given status and an empty body.
 fn status_service(
     status: StatusCode,
 ) -> impl Service<Request, Response = Response<impl MessageBody>, Error = Error> {
     fn_service(move |_req: Request| ready(Ok::<_, Error>(Response::new(status))))
 }
 
+/// Creates a service that echoes the request path in the response body.
 pub(crate) fn echo_path_service(
 ) -> impl Service<Request, Response = Response<impl MessageBody>, Error = Error> {
     fn_service(|req: Request| {
@@ -70,6 +73,7 @@ pub(crate) fn echo_path_service(
     })
 }
 
+/// Creates a service that drops the request payload and returns a `200 OK` response.
 pub(crate) fn drop_payload_service(
 ) -> impl Service<Request, Response = Response<&'static str>, Error = Error> {
     fn_service(|mut req: Request| async move {
@@ -78,11 +82,13 @@ pub(crate) fn drop_payload_service(
     })
 }
 
+/// Creates a service that ignores the request payload and returns a `200 OK` response.
 pub(crate) fn ignore_payload_service(
 ) -> impl Service<Request, Response = Response<&'static str>, Error = Error> {
     fn_service(|_req: Request| ready(Ok::<_, Error>(Response::with_body(StatusCode::OK, "ok"))))
 }
 
+/// Creates a service that echoes the request payload in the response body.
 pub(crate) fn echo_payload_service(
 ) -> impl Service<Request, Response = Response<Bytes>, Error = Error> {
     fn_service(|mut req: Request| {
@@ -100,6 +106,7 @@ pub(crate) fn echo_payload_service(
     })
 }
 
+/// Creates a service that returns a configurable ready chunk body.
 pub(crate) fn ready_chunk_body_service(
     chunk_polls: Rc<Cell<usize>>,
     chunk_count: usize,
@@ -112,6 +119,7 @@ pub(crate) fn ready_chunk_body_service(
     })
 }
 
+/// Creates a service that returns a `101 Switching Protocols` response.
 pub(crate) fn upgrade_response_service(
 ) -> impl Service<Request, Response = Response<impl MessageBody>, Error = Error> {
     fn_service(|_req: Request| {

--- a/actix-http/src/test/test_services.rs
+++ b/actix-http/src/test/test_services.rs
@@ -1,7 +1,53 @@
+use std::{
+    cell::Cell,
+    pin::Pin,
+    rc::Rc,
+    task::{Context, Poll},
+};
+
 use actix_service::{fn_service, Service};
 use actix_utils::future::ready;
+use bytes::{Buf, Bytes, BytesMut};
 
 use crate::{body::MessageBody, Error, Request, Response, StatusCode};
+
+pub(crate) struct ReadyChunkBody {
+    chunk_polls: Rc<Cell<usize>>,
+    remaining: usize,
+    chunk_len: usize,
+}
+
+impl ReadyChunkBody {
+    fn new(chunk_polls: Rc<Cell<usize>>, remaining: usize, chunk_len: usize) -> Self {
+        Self {
+            chunk_polls,
+            remaining,
+            chunk_len,
+        }
+    }
+}
+
+impl MessageBody for ReadyChunkBody {
+    type Error = Error;
+
+    fn size(&self) -> crate::body::BodySize {
+        crate::body::BodySize::Stream
+    }
+
+    fn poll_next(
+        mut self: Pin<&mut Self>,
+        _: &mut Context<'_>,
+    ) -> Poll<Option<Result<Bytes, Self::Error>>> {
+        if self.remaining == 0 {
+            return Poll::Ready(None);
+        }
+
+        self.remaining -= 1;
+        self.chunk_polls.set(self.chunk_polls.get() + 1);
+
+        Poll::Ready(Some(Ok(Bytes::from(vec![b'x'; self.chunk_len]))))
+    }
+}
 
 pub(crate) fn ok_service(
 ) -> impl Service<Request, Response = Response<impl MessageBody>, Error = Error> {
@@ -12,4 +58,67 @@ fn status_service(
     status: StatusCode,
 ) -> impl Service<Request, Response = Response<impl MessageBody>, Error = Error> {
     fn_service(move |_req: Request| ready(Ok::<_, Error>(Response::new(status))))
+}
+
+pub(crate) fn echo_path_service(
+) -> impl Service<Request, Response = Response<impl MessageBody>, Error = Error> {
+    fn_service(|req: Request| {
+        let path = req.path().as_bytes();
+        ready(Ok::<_, Error>(
+            Response::ok().set_body(Bytes::copy_from_slice(path)),
+        ))
+    })
+}
+
+pub(crate) fn drop_payload_service(
+) -> impl Service<Request, Response = Response<&'static str>, Error = Error> {
+    fn_service(|mut req: Request| async move {
+        let _ = req.take_payload();
+        Ok::<_, Error>(Response::with_body(StatusCode::OK, "payload dropped"))
+    })
+}
+
+pub(crate) fn ignore_payload_service(
+) -> impl Service<Request, Response = Response<&'static str>, Error = Error> {
+    fn_service(|_req: Request| ready(Ok::<_, Error>(Response::with_body(StatusCode::OK, "ok"))))
+}
+
+pub(crate) fn echo_payload_service(
+) -> impl Service<Request, Response = Response<Bytes>, Error = Error> {
+    fn_service(|mut req: Request| {
+        Box::pin(async move {
+            use futures_util::StreamExt as _;
+
+            let mut pl = req.take_payload();
+            let mut body = BytesMut::new();
+            while let Some(chunk) = pl.next().await {
+                body.extend_from_slice(chunk.unwrap().chunk())
+            }
+
+            Ok::<_, Error>(Response::ok().set_body(body.freeze()))
+        })
+    })
+}
+
+pub(crate) fn ready_chunk_body_service(
+    chunk_polls: Rc<Cell<usize>>,
+    chunk_count: usize,
+    chunk_len: usize,
+) -> impl Service<Request, Response = Response<ReadyChunkBody>, Error = Error> {
+    fn_service(move |_req: Request| {
+        ready(Ok::<_, Error>(Response::ok().set_body(
+            ReadyChunkBody::new(chunk_polls.clone(), chunk_count, chunk_len),
+        )))
+    })
+}
+
+pub(crate) fn upgrade_response_service(
+) -> impl Service<Request, Response = Response<impl MessageBody>, Error = Error> {
+    fn_service(|_req: Request| {
+        ready(Ok::<_, Error>(
+            Response::build(StatusCode::SWITCHING_PROTOCOLS)
+                .upgrade("websocket")
+                .finish(),
+        ))
+    })
 }


### PR DESCRIPTION
## Summary

- Move the HTTP/1 dispatcher test service helpers into `actix_http::test::test_services`.
- Include the OK, echo, payload, chunked-body, and upgrade-response services.
- Match the `test_services` module naming used by Actix Web.

## Validation

- `cargo +nightly fmt --all -- --check`
- `cargo clippy -p actix-http --all-targets --all-features`
- `cargo test -p actix-http --lib --all-features` (216 passed, 1 ignored)
