### PR TITLE
test: cover HTTP test helper types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,6 +100,7 @@ dependencies = [
  "smallvec",
  "static_assertions",
  "tokio",
+ "tokio-test",
  "tokio-util",
  "tracing",
  "zstd",
@@ -3414,6 +3415,17 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio-test"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6d24790a10a7af737693a3e8f1d03faef7e6ca0cc99aae5066f533766de545"
+dependencies = [
+ "futures-core",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]

--- a/actix-http/Cargo.toml
+++ b/actix-http/Cargo.toml
@@ -158,6 +158,7 @@ static_assertions = "1"
 tls-openssl = { package = "openssl", version = "0.10.55" }
 tls-rustls_023 = { package = "rustls", version = "0.23" }
 tokio = { version = "1.38.2", features = ["net", "rt", "macros", "sync"] }
+tokio-test = "0.4"
 
 [lints]
 workspace = true

--- a/actix-http/src/test/pending_once_write_buf.rs
+++ b/actix-http/src/test/pending_once_write_buf.rs
@@ -83,6 +83,7 @@ mod tests {
 
     use bytes::Bytes;
     use futures_util::task::noop_waker_ref;
+    use tokio_test::{assert_pending, assert_ready_eq, assert_ready_ok};
 
     use super::*;
 
@@ -105,21 +106,17 @@ mod tests {
 
         let mut read = [0; 4];
         let mut read_buf = ReadBuf::new(&mut read);
-        assert!(Pin::new(&mut buffer)
-            .poll_read(&mut cx, &mut read_buf)
-            .is_ready());
+        assert_ready_ok!(Pin::new(&mut buffer).poll_read(&mut cx, &mut read_buf));
         assert_eq!(read_buf.filled(), b"read");
 
-        assert!(Pin::new(&mut buffer)
-            .poll_write(&mut cx, b"write")
-            .is_pending());
-        assert_eq!(
+        assert_pending!(Pin::new(&mut buffer).poll_write(&mut cx, b"write"));
+        assert_ready_eq!(
             Pin::new(&mut buffer)
                 .poll_write(&mut cx, b"write")
                 .map(|result| result.unwrap()),
-            Poll::Ready(5)
+            5
         );
-        assert!(Pin::new(&mut buffer).poll_flush(&mut cx).is_ready());
-        assert!(Pin::new(&mut buffer).poll_shutdown(&mut cx).is_ready());
+        assert_ready_ok!(Pin::new(&mut buffer).poll_flush(&mut cx));
+        assert_ready_ok!(Pin::new(&mut buffer).poll_shutdown(&mut cx));
     }
 }

--- a/actix-http/src/test/pending_once_write_buf.rs
+++ b/actix-http/src/test/pending_once_write_buf.rs
@@ -83,7 +83,7 @@ mod tests {
 
     use bytes::Bytes;
     use futures_util::task::noop_waker_ref;
-    use tokio_test::{assert_pending, assert_ready_eq, assert_ready_ok};
+    use tokio_test::{assert_pending, assert_ready_ok};
 
     use super::*;
 
@@ -110,10 +110,8 @@ mod tests {
         assert_eq!(read_buf.filled(), b"read");
 
         assert_pending!(Pin::new(&mut buffer).poll_write(&mut cx, b"write"));
-        assert_ready_eq!(
-            Pin::new(&mut buffer)
-                .poll_write(&mut cx, b"write")
-                .map(|result| result.unwrap()),
+        assert_eq!(
+            assert_ready_ok!(Pin::new(&mut buffer).poll_write(&mut cx, b"write")),
             5
         );
         assert_ready_ok!(Pin::new(&mut buffer).poll_flush(&mut cx));

--- a/actix-http/src/test/pending_once_write_buf.rs
+++ b/actix-http/src/test/pending_once_write_buf.rs
@@ -110,10 +110,11 @@ mod tests {
         assert_eq!(read_buf.filled(), b"read");
 
         assert_pending!(Pin::new(&mut buffer).poll_write(&mut cx, b"write"));
-        assert_eq!(
-            assert_ready_ok!(Pin::new(&mut buffer).poll_write(&mut cx, b"write")),
-            5
+        let written = assert_ready_ok!(
+            Pin::new(&mut buffer).poll_write(&mut cx, b"write"),
+            "expected a successful write"
         );
+        assert_eq!(written, 5);
         assert_ready_ok!(Pin::new(&mut buffer).poll_flush(&mut cx));
         assert_ready_ok!(Pin::new(&mut buffer).poll_shutdown(&mut cx));
     }

--- a/actix-http/src/test/pending_once_write_buf.rs
+++ b/actix-http/src/test/pending_once_write_buf.rs
@@ -76,3 +76,50 @@ impl AsyncWrite for PendingOnceWriteBuf {
         Pin::new(&mut self.io).poll_shutdown(cx)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::{io, task::Context};
+
+    use bytes::Bytes;
+    use futures_util::task::noop_waker_ref;
+
+    use super::*;
+
+    #[test]
+    fn io_operations() {
+        let mut buffer = PendingOnceWriteBuf::new("read");
+        let mut read = [0; 4];
+        assert_eq!(io::Read::read(&mut buffer, &mut read).unwrap(), 4);
+        assert_eq!(&read, b"read");
+
+        assert_eq!(io::Write::write(&mut buffer, b"write").unwrap(), 5);
+        io::Write::flush(&mut buffer).unwrap();
+        assert_eq!(buffer.io.take_write_buf(), Bytes::from_static(b"write"));
+    }
+
+    #[test]
+    fn async_operations() {
+        let mut cx = Context::from_waker(noop_waker_ref());
+        let mut buffer = PendingOnceWriteBuf::new("read");
+
+        let mut read = [0; 4];
+        let mut read_buf = ReadBuf::new(&mut read);
+        assert!(Pin::new(&mut buffer)
+            .poll_read(&mut cx, &mut read_buf)
+            .is_ready());
+        assert_eq!(read_buf.filled(), b"read");
+
+        assert!(Pin::new(&mut buffer)
+            .poll_write(&mut cx, b"write")
+            .is_pending());
+        assert_eq!(
+            Pin::new(&mut buffer)
+                .poll_write(&mut cx, b"write")
+                .map(|result| result.unwrap()),
+            Poll::Ready(5)
+        );
+        assert!(Pin::new(&mut buffer).poll_flush(&mut cx).is_ready());
+        assert!(Pin::new(&mut buffer).poll_shutdown(&mut cx).is_ready());
+    }
+}

--- a/actix-http/src/test/ready_chunk_body.rs
+++ b/actix-http/src/test/ready_chunk_body.rs
@@ -53,7 +53,7 @@ mod tests {
     use std::task::Context;
 
     use futures_util::task::noop_waker_ref;
-    use tokio_test::assert_ready_eq;
+    use tokio_test::{assert_ok, assert_ready};
 
     use super::*;
 
@@ -64,24 +64,15 @@ mod tests {
         let mut cx = Context::from_waker(noop_waker_ref());
 
         assert_eq!(body.size(), crate::body::BodySize::Stream);
-        assert_ready_eq!(
-            Pin::new(&mut body)
-                .poll_next(&mut cx)
-                .map(|chunk| chunk.unwrap().unwrap()),
-            Bytes::from_static(b"xxx")
-        );
-        assert_ready_eq!(
-            Pin::new(&mut body)
-                .poll_next(&mut cx)
-                .map(|chunk| chunk.unwrap().unwrap()),
-            Bytes::from_static(b"xxx")
-        );
-        assert_ready_eq!(
-            Pin::new(&mut body)
-                .poll_next(&mut cx)
-                .map(|chunk| chunk.is_none()),
-            true
-        );
+        let chunk = assert_ready!(Pin::new(&mut body).poll_next(&mut cx))
+            .expect("ready chunk body should yield a chunk");
+        assert_eq!(assert_ok!(chunk), Bytes::from_static(b"xxx"));
+
+        let chunk = assert_ready!(Pin::new(&mut body).poll_next(&mut cx))
+            .expect("ready chunk body should yield a chunk");
+        assert_eq!(assert_ok!(chunk), Bytes::from_static(b"xxx"));
+
+        assert!(assert_ready!(Pin::new(&mut body).poll_next(&mut cx)).is_none());
         assert_eq!(chunk_polls.get(), 2);
     }
 }

--- a/actix-http/src/test/ready_chunk_body.rs
+++ b/actix-http/src/test/ready_chunk_body.rs
@@ -47,3 +47,40 @@ impl MessageBody for ReadyChunkBody {
         Poll::Ready(Some(Ok(Bytes::from(vec![b'x'; self.chunk_len]))))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::task::Context;
+
+    use futures_util::task::noop_waker_ref;
+
+    use super::*;
+
+    #[test]
+    fn yields_configured_chunks() {
+        let chunk_polls = Rc::new(Cell::new(0));
+        let mut body = ReadyChunkBody::new(chunk_polls.clone(), 2, 3);
+        let mut cx = Context::from_waker(noop_waker_ref());
+
+        assert_eq!(body.size(), crate::body::BodySize::Stream);
+        assert_eq!(
+            Pin::new(&mut body)
+                .poll_next(&mut cx)
+                .map(|chunk| chunk.unwrap().unwrap()),
+            Poll::Ready(Bytes::from_static(b"xxx"))
+        );
+        assert_eq!(
+            Pin::new(&mut body)
+                .poll_next(&mut cx)
+                .map(|chunk| chunk.unwrap().unwrap()),
+            Poll::Ready(Bytes::from_static(b"xxx"))
+        );
+        assert_eq!(
+            Pin::new(&mut body)
+                .poll_next(&mut cx)
+                .map(|chunk| chunk.is_none()),
+            Poll::Ready(true)
+        );
+        assert_eq!(chunk_polls.get(), 2);
+    }
+}

--- a/actix-http/src/test/ready_chunk_body.rs
+++ b/actix-http/src/test/ready_chunk_body.rs
@@ -53,6 +53,7 @@ mod tests {
     use std::task::Context;
 
     use futures_util::task::noop_waker_ref;
+    use tokio_test::assert_ready_eq;
 
     use super::*;
 
@@ -63,23 +64,23 @@ mod tests {
         let mut cx = Context::from_waker(noop_waker_ref());
 
         assert_eq!(body.size(), crate::body::BodySize::Stream);
-        assert_eq!(
+        assert_ready_eq!(
             Pin::new(&mut body)
                 .poll_next(&mut cx)
                 .map(|chunk| chunk.unwrap().unwrap()),
-            Poll::Ready(Bytes::from_static(b"xxx"))
+            Bytes::from_static(b"xxx")
         );
-        assert_eq!(
+        assert_ready_eq!(
             Pin::new(&mut body)
                 .poll_next(&mut cx)
                 .map(|chunk| chunk.unwrap().unwrap()),
-            Poll::Ready(Bytes::from_static(b"xxx"))
+            Bytes::from_static(b"xxx")
         );
-        assert_eq!(
+        assert_ready_eq!(
             Pin::new(&mut body)
                 .poll_next(&mut cx)
                 .map(|chunk| chunk.is_none()),
-            Poll::Ready(true)
+            true
         );
         assert_eq!(chunk_polls.get(), 2);
     }

--- a/actix-http/src/test/ready_chunk_body.rs
+++ b/actix-http/src/test/ready_chunk_body.rs
@@ -66,11 +66,13 @@ mod tests {
         assert_eq!(body.size(), crate::body::BodySize::Stream);
         let chunk = assert_ready!(Pin::new(&mut body).poll_next(&mut cx))
             .expect("ready chunk body should yield a chunk");
-        assert_eq!(assert_ok!(chunk), Bytes::from_static(b"xxx"));
+        let chunk = assert_ok!(chunk, "expected a successful chunk");
+        assert_eq!(chunk, Bytes::from_static(b"xxx"));
 
         let chunk = assert_ready!(Pin::new(&mut body).poll_next(&mut cx))
             .expect("ready chunk body should yield a chunk");
-        assert_eq!(assert_ok!(chunk), Bytes::from_static(b"xxx"));
+        let chunk = assert_ok!(chunk, "expected a successful chunk");
+        assert_eq!(chunk, Bytes::from_static(b"xxx"));
 
         assert!(assert_ready!(Pin::new(&mut body).poll_next(&mut cx)).is_none());
         assert_eq!(chunk_polls.get(), 2);

--- a/actix-http/src/test/test_buffer.rs
+++ b/actix-http/src/test/test_buffer.rs
@@ -145,7 +145,7 @@ mod tests {
     use std::{io, task::Context};
 
     use futures_util::task::noop_waker_ref;
-    use tokio_test::{assert_pending, assert_ready_eq, assert_ready_ok};
+    use tokio_test::{assert_pending, assert_ready_err, assert_ready_ok};
 
     use super::*;
 
@@ -202,18 +202,14 @@ mod tests {
         error.err = Some(Rc::new(io::Error::other("error")));
         let mut read = [];
         let mut read_buf = ReadBuf::new(&mut read);
-        assert_ready_eq!(
-            Pin::new(&mut error)
-                .poll_read(&mut cx, &mut read_buf)
-                .map(|result| result.unwrap_err().to_string()),
-            "error".to_owned()
+        assert_eq!(
+            assert_ready_err!(Pin::new(&mut error).poll_read(&mut cx, &mut read_buf)).to_string(),
+            "error"
         );
 
         let mut buffer = TestBuffer::empty();
-        assert_ready_eq!(
-            Pin::new(&mut buffer)
-                .poll_write(&mut cx, b"write")
-                .map(|result| result.unwrap()),
+        assert_eq!(
+            assert_ready_ok!(Pin::new(&mut buffer).poll_write(&mut cx, b"write")),
             5
         );
         assert_ready_ok!(Pin::new(&mut buffer).poll_flush(&mut cx));

--- a/actix-http/src/test/test_buffer.rs
+++ b/actix-http/src/test/test_buffer.rs
@@ -111,8 +111,14 @@ impl AsyncRead for TestBuffer {
         buf: &mut ReadBuf<'_>,
     ) -> Poll<io::Result<()>> {
         let dst = buf.initialize_unfilled();
-        let res = self.get_mut().read(dst).map(|n| buf.advance(n));
-        Poll::Ready(res)
+        match self.get_mut().read(dst) {
+            Ok(n) => {
+                buf.advance(n);
+                Poll::Ready(Ok(()))
+            }
+            Err(err) if err.kind() == io::ErrorKind::WouldBlock => Poll::Pending,
+            Err(err) => Poll::Ready(Err(err)),
+        }
     }
 }
 
@@ -191,11 +197,19 @@ mod tests {
         let mut empty = TestBuffer::empty();
         let mut read = [];
         let mut read_buf = ReadBuf::new(&mut read);
+        assert!(Pin::new(&mut empty)
+            .poll_read(&mut cx, &mut read_buf)
+            .is_pending());
+
+        let mut error = TestBuffer::empty();
+        error.err = Some(Rc::new(io::Error::other("error")));
+        let mut read = [];
+        let mut read_buf = ReadBuf::new(&mut read);
         assert_eq!(
-            Pin::new(&mut empty)
+            Pin::new(&mut error)
                 .poll_read(&mut cx, &mut read_buf)
-                .map(|result| result.unwrap_err().kind()),
-            Poll::Ready(io::ErrorKind::WouldBlock)
+                .map(|result| result.unwrap_err().to_string()),
+            Poll::Ready("error".to_owned())
         );
 
         let mut buffer = TestBuffer::empty();

--- a/actix-http/src/test/test_buffer.rs
+++ b/actix-http/src/test/test_buffer.rs
@@ -202,16 +202,18 @@ mod tests {
         error.err = Some(Rc::new(io::Error::other("error")));
         let mut read = [];
         let mut read_buf = ReadBuf::new(&mut read);
-        assert_eq!(
-            assert_ready_err!(Pin::new(&mut error).poll_read(&mut cx, &mut read_buf)).to_string(),
-            "error"
+        let error = assert_ready_err!(
+            Pin::new(&mut error).poll_read(&mut cx, &mut read_buf),
+            "expected a ready error"
         );
+        assert_eq!(error.to_string(), "error");
 
         let mut buffer = TestBuffer::empty();
-        assert_eq!(
-            assert_ready_ok!(Pin::new(&mut buffer).poll_write(&mut cx, b"write")),
-            5
+        let written = assert_ready_ok!(
+            Pin::new(&mut buffer).poll_write(&mut cx, b"write"),
+            "expected a successful write"
         );
+        assert_eq!(written, 5);
         assert_ready_ok!(Pin::new(&mut buffer).poll_flush(&mut cx));
         assert_ready_ok!(Pin::new(&mut buffer).poll_shutdown(&mut cx));
     }

--- a/actix-http/src/test/test_buffer.rs
+++ b/actix-http/src/test/test_buffer.rs
@@ -133,3 +133,79 @@ impl AsyncWrite for TestBuffer {
         Poll::Ready(Ok(()))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::{io, task::Context};
+
+    use futures_util::task::noop_waker_ref;
+
+    use super::*;
+
+    #[test]
+    fn buffer_read_write() {
+        let mut buffer = TestBuffer::new("read");
+        let clone = buffer.clone();
+
+        assert_eq!(&*buffer.read_buf_slice(), b"read");
+        buffer.read_buf_slice_mut()[0] = b'R';
+        assert_eq!(&*buffer.read_buf_slice(), b"Read");
+
+        io::Write::write_all(&mut buffer, b"write").unwrap();
+        assert_eq!(&*buffer.write_buf_slice(), b"write");
+        buffer.write_buf_slice_mut()[0] = b'W';
+        assert_eq!(&*buffer.write_buf_slice(), b"Write");
+        io::Write::flush(&mut buffer).unwrap();
+        assert_eq!(clone.take_write_buf(), Bytes::from_static(b"Write"));
+        assert!(buffer.write_buf_slice().is_empty());
+
+        buffer.extend_read_buf("!");
+        let mut read = [0; 5];
+        assert_eq!(io::Read::read(&mut buffer, &mut read).unwrap(), 5);
+        assert_eq!(&read, b"Read!");
+        assert_eq!(
+            io::Read::read(&mut buffer, &mut read).unwrap_err().kind(),
+            io::ErrorKind::WouldBlock
+        );
+
+        let mut empty = TestBuffer::empty();
+        empty.err = Some(Rc::new(io::Error::other("error")));
+        assert_eq!(
+            io::Read::read(&mut empty, &mut []).unwrap_err().to_string(),
+            "error"
+        );
+    }
+
+    #[test]
+    fn buffer_async_io() {
+        let mut cx = Context::from_waker(noop_waker_ref());
+        let mut buffer = TestBuffer::new("read");
+        let mut read = [0; 4];
+        let mut read_buf = ReadBuf::new(&mut read);
+
+        assert!(Pin::new(&mut buffer)
+            .poll_read(&mut cx, &mut read_buf)
+            .is_ready());
+        assert_eq!(read_buf.filled(), b"read");
+
+        let mut empty = TestBuffer::empty();
+        let mut read = [];
+        let mut read_buf = ReadBuf::new(&mut read);
+        assert_eq!(
+            Pin::new(&mut empty)
+                .poll_read(&mut cx, &mut read_buf)
+                .map(|result| result.unwrap_err().kind()),
+            Poll::Ready(io::ErrorKind::WouldBlock)
+        );
+
+        let mut buffer = TestBuffer::empty();
+        assert_eq!(
+            Pin::new(&mut buffer)
+                .poll_write(&mut cx, b"write")
+                .map(|result| result.unwrap()),
+            Poll::Ready(5)
+        );
+        assert!(Pin::new(&mut buffer).poll_flush(&mut cx).is_ready());
+        assert!(Pin::new(&mut buffer).poll_shutdown(&mut cx).is_ready());
+    }
+}

--- a/actix-http/src/test/test_buffer.rs
+++ b/actix-http/src/test/test_buffer.rs
@@ -145,6 +145,7 @@ mod tests {
     use std::{io, task::Context};
 
     use futures_util::task::noop_waker_ref;
+    use tokio_test::{assert_pending, assert_ready_eq, assert_ready_ok};
 
     use super::*;
 
@@ -189,37 +190,33 @@ mod tests {
         let mut read = [0; 4];
         let mut read_buf = ReadBuf::new(&mut read);
 
-        assert!(Pin::new(&mut buffer)
-            .poll_read(&mut cx, &mut read_buf)
-            .is_ready());
+        assert_ready_ok!(Pin::new(&mut buffer).poll_read(&mut cx, &mut read_buf));
         assert_eq!(read_buf.filled(), b"read");
 
         let mut empty = TestBuffer::empty();
         let mut read = [];
         let mut read_buf = ReadBuf::new(&mut read);
-        assert!(Pin::new(&mut empty)
-            .poll_read(&mut cx, &mut read_buf)
-            .is_pending());
+        assert_pending!(Pin::new(&mut empty).poll_read(&mut cx, &mut read_buf));
 
         let mut error = TestBuffer::empty();
         error.err = Some(Rc::new(io::Error::other("error")));
         let mut read = [];
         let mut read_buf = ReadBuf::new(&mut read);
-        assert_eq!(
+        assert_ready_eq!(
             Pin::new(&mut error)
                 .poll_read(&mut cx, &mut read_buf)
                 .map(|result| result.unwrap_err().to_string()),
-            Poll::Ready("error".to_owned())
+            "error".to_owned()
         );
 
         let mut buffer = TestBuffer::empty();
-        assert_eq!(
+        assert_ready_eq!(
             Pin::new(&mut buffer)
                 .poll_write(&mut cx, b"write")
                 .map(|result| result.unwrap()),
-            Poll::Ready(5)
+            5
         );
-        assert!(Pin::new(&mut buffer).poll_flush(&mut cx).is_ready());
-        assert!(Pin::new(&mut buffer).poll_shutdown(&mut cx).is_ready());
+        assert_ready_ok!(Pin::new(&mut buffer).poll_flush(&mut cx));
+        assert_ready_ok!(Pin::new(&mut buffer).poll_shutdown(&mut cx));
     }
 }

--- a/actix-http/src/test/test_request.rs
+++ b/actix-http/src/test/test_request.rs
@@ -127,3 +127,50 @@ impl TestRequest {
 fn parts(parts: &mut Option<Inner>) -> &mut Inner {
     parts.as_mut().expect("cannot reuse test request builder")
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_builder() {
+        let mut request = TestRequest::with_uri("/initial");
+        request
+            .version(Version::HTTP_10)
+            .method(Method::POST)
+            .uri("/final")
+            .insert_header(("x-test", "one"))
+            .append_header(("x-test", "two"));
+
+        let request = request.finish();
+        assert_eq!(request.head().uri, Uri::from_static("/final"));
+        assert_eq!(request.head().method, Method::POST);
+        assert_eq!(request.head().version, Version::HTTP_10);
+        assert_eq!(request.head().headers.get_all("x-test").count(), 2);
+
+        let mut request = TestRequest::default();
+        request.set_payload("body");
+        let request = request.finish();
+        assert_eq!(
+            request.head().headers.get(header::CONTENT_LENGTH).unwrap(),
+            "4"
+        );
+
+        let mut request = TestRequest::default();
+        let request = request.take();
+        let mut request = request;
+        assert_eq!(request.finish().head().uri, Uri::from_static("/"));
+    }
+
+    #[test]
+    #[should_panic(expected = "Error inserting test header")]
+    fn insert_header_rejects_invalid_header() {
+        TestRequest::default().insert_header(("invalid name", "value"));
+    }
+
+    #[test]
+    #[should_panic(expected = "Error inserting test header")]
+    fn append_header_rejects_invalid_header() {
+        TestRequest::default().append_header(("invalid name", "value"));
+    }
+}

--- a/actix-http/src/test/test_seq_buffer.rs
+++ b/actix-http/src/test/test_seq_buffer.rs
@@ -209,16 +209,18 @@ mod tests {
         error.0.borrow_mut().err = Some(io::Error::other("error"));
         let mut read = [];
         let mut read_buf = ReadBuf::new(&mut read);
-        assert_eq!(
-            assert_ready_err!(Pin::new(&mut error).poll_read(&mut cx, &mut read_buf)).to_string(),
-            "error"
+        let error = assert_ready_err!(
+            Pin::new(&mut error).poll_read(&mut cx, &mut read_buf),
+            "expected a ready error"
         );
+        assert_eq!(error.to_string(), "error");
 
         let mut buffer = TestSeqBuffer::empty();
-        assert_eq!(
-            assert_ready_ok!(Pin::new(&mut buffer).poll_write(&mut cx, b"write")),
-            5
+        let written = assert_ready_ok!(
+            Pin::new(&mut buffer).poll_write(&mut cx, b"write"),
+            "expected a successful write"
         );
+        assert_eq!(written, 5);
         assert_ready_ok!(Pin::new(&mut buffer).poll_flush(&mut cx));
         assert_ready_ok!(Pin::new(&mut buffer).poll_shutdown(&mut cx));
     }

--- a/actix-http/src/test/test_seq_buffer.rs
+++ b/actix-http/src/test/test_seq_buffer.rs
@@ -146,3 +146,95 @@ impl AsyncWrite for TestSeqBuffer {
         Poll::Ready(Ok(()))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::{io, task::Context};
+
+    use futures_util::task::noop_waker_ref;
+
+    use super::*;
+
+    #[test]
+    fn buffer_read_write() {
+        let mut buffer = TestSeqBuffer::new("read");
+        let clone = buffer.clone();
+
+        assert_eq!(buffer.read_buf().as_ref(), b"read");
+        assert!(buffer.err().is_none());
+        buffer.extend_read_buf("!");
+
+        let mut read = [0; 5];
+        assert_eq!(io::Read::read(&mut buffer, &mut read).unwrap(), 5);
+        assert_eq!(&read, b"read!");
+
+        io::Write::write_all(&mut buffer, b"write").unwrap();
+        io::Write::flush(&mut buffer).unwrap();
+        assert_eq!(buffer.write_buf().as_ref(), b"write");
+        assert_eq!(clone.take_write_buf(), Bytes::from_static(b"write"));
+        assert!(buffer.write_buf().is_empty());
+
+        assert_eq!(
+            io::Read::read(&mut buffer, &mut []).unwrap_err().kind(),
+            io::ErrorKind::WouldBlock
+        );
+        buffer.close_read();
+        assert_eq!(io::Read::read(&mut buffer, &mut []).unwrap(), 0);
+
+        let mut error = TestSeqBuffer::empty();
+        error.0.borrow_mut().err = Some(io::Error::other("error"));
+        assert_eq!(
+            io::Read::read(&mut error, &mut []).unwrap_err().to_string(),
+            "error"
+        );
+    }
+
+    #[test]
+    fn buffer_async_io() {
+        let mut cx = Context::from_waker(noop_waker_ref());
+
+        let mut pending = TestSeqBuffer::empty();
+        let mut read = [];
+        let mut read_buf = ReadBuf::new(&mut read);
+        assert!(Pin::new(&mut pending)
+            .poll_read(&mut cx, &mut read_buf)
+            .is_pending());
+
+        let mut buffer = TestSeqBuffer::new("read");
+        let mut read = [0; 4];
+        let mut read_buf = ReadBuf::new(&mut read);
+        assert!(Pin::new(&mut buffer)
+            .poll_read(&mut cx, &mut read_buf)
+            .is_ready());
+        assert_eq!(read_buf.filled(), b"read");
+
+        let mut error = TestSeqBuffer::empty();
+        error.0.borrow_mut().err = Some(io::Error::other("error"));
+        let mut read = [];
+        let mut read_buf = ReadBuf::new(&mut read);
+        assert_eq!(
+            Pin::new(&mut error)
+                .poll_read(&mut cx, &mut read_buf)
+                .map(|result| result.unwrap_err().to_string()),
+            Poll::Ready("error".to_owned())
+        );
+
+        let mut buffer = TestSeqBuffer::empty();
+        assert_eq!(
+            Pin::new(&mut buffer)
+                .poll_write(&mut cx, b"write")
+                .map(|result| result.unwrap()),
+            Poll::Ready(5)
+        );
+        assert!(Pin::new(&mut buffer).poll_flush(&mut cx).is_ready());
+        assert!(Pin::new(&mut buffer).poll_shutdown(&mut cx).is_ready());
+    }
+
+    #[test]
+    #[should_panic(expected = "Tried to extend the read buffer")]
+    fn extend_read_buf_after_close_panics() {
+        let mut buffer = TestSeqBuffer::empty();
+        buffer.close_read();
+        buffer.extend_read_buf("data");
+    }
+}

--- a/actix-http/src/test/test_seq_buffer.rs
+++ b/actix-http/src/test/test_seq_buffer.rs
@@ -152,6 +152,7 @@ mod tests {
     use std::{io, task::Context};
 
     use futures_util::task::noop_waker_ref;
+    use tokio_test::{assert_pending, assert_ready_eq, assert_ready_ok};
 
     use super::*;
 
@@ -196,38 +197,34 @@ mod tests {
         let mut pending = TestSeqBuffer::empty();
         let mut read = [];
         let mut read_buf = ReadBuf::new(&mut read);
-        assert!(Pin::new(&mut pending)
-            .poll_read(&mut cx, &mut read_buf)
-            .is_pending());
+        assert_pending!(Pin::new(&mut pending).poll_read(&mut cx, &mut read_buf));
 
         let mut buffer = TestSeqBuffer::new("read");
         let mut read = [0; 4];
         let mut read_buf = ReadBuf::new(&mut read);
-        assert!(Pin::new(&mut buffer)
-            .poll_read(&mut cx, &mut read_buf)
-            .is_ready());
+        assert_ready_ok!(Pin::new(&mut buffer).poll_read(&mut cx, &mut read_buf));
         assert_eq!(read_buf.filled(), b"read");
 
         let mut error = TestSeqBuffer::empty();
         error.0.borrow_mut().err = Some(io::Error::other("error"));
         let mut read = [];
         let mut read_buf = ReadBuf::new(&mut read);
-        assert_eq!(
+        assert_ready_eq!(
             Pin::new(&mut error)
                 .poll_read(&mut cx, &mut read_buf)
                 .map(|result| result.unwrap_err().to_string()),
-            Poll::Ready("error".to_owned())
+            "error".to_owned()
         );
 
         let mut buffer = TestSeqBuffer::empty();
-        assert_eq!(
+        assert_ready_eq!(
             Pin::new(&mut buffer)
                 .poll_write(&mut cx, b"write")
                 .map(|result| result.unwrap()),
-            Poll::Ready(5)
+            5
         );
-        assert!(Pin::new(&mut buffer).poll_flush(&mut cx).is_ready());
-        assert!(Pin::new(&mut buffer).poll_shutdown(&mut cx).is_ready());
+        assert_ready_ok!(Pin::new(&mut buffer).poll_flush(&mut cx));
+        assert_ready_ok!(Pin::new(&mut buffer).poll_shutdown(&mut cx));
     }
 
     #[test]

--- a/actix-http/src/test/test_seq_buffer.rs
+++ b/actix-http/src/test/test_seq_buffer.rs
@@ -152,7 +152,7 @@ mod tests {
     use std::{io, task::Context};
 
     use futures_util::task::noop_waker_ref;
-    use tokio_test::{assert_pending, assert_ready_eq, assert_ready_ok};
+    use tokio_test::{assert_pending, assert_ready_err, assert_ready_ok};
 
     use super::*;
 
@@ -209,18 +209,14 @@ mod tests {
         error.0.borrow_mut().err = Some(io::Error::other("error"));
         let mut read = [];
         let mut read_buf = ReadBuf::new(&mut read);
-        assert_ready_eq!(
-            Pin::new(&mut error)
-                .poll_read(&mut cx, &mut read_buf)
-                .map(|result| result.unwrap_err().to_string()),
-            "error".to_owned()
+        assert_eq!(
+            assert_ready_err!(Pin::new(&mut error).poll_read(&mut cx, &mut read_buf)).to_string(),
+            "error"
         );
 
         let mut buffer = TestSeqBuffer::empty();
-        assert_ready_eq!(
-            Pin::new(&mut buffer)
-                .poll_write(&mut cx, b"write")
-                .map(|result| result.unwrap()),
+        assert_eq!(
+            assert_ready_ok!(Pin::new(&mut buffer).poll_write(&mut cx, b"write")),
             5
         );
         assert_ready_ok!(Pin::new(&mut buffer).poll_flush(&mut cx));


### PR DESCRIPTION
## Summary

- add focused tests for the actix-http test helper types
- cover read, write, polling, buffering, and error paths

## Validation

- `cargo test -p actix-http --lib --all-features`
- `cargo clippy -p actix-http --all-targets --all-features`
- `cargo llvm-cov -p actix-http --lib --all-features` (100% for the five helper-type modules)