### PR TITLE
test: prevent H2 connection drop test hang

### DIFF
--- a/awc/src/client/connection.rs
+++ b/awc/src/client/connection.rs
@@ -412,6 +412,7 @@ mod test {
 
         drop(conn);
 
+        /// Periodically polls a retained sender until it observes the closed H2 connection.
         struct DropCheck {
             sender: h2::client::SendRequest<Bytes>,
             interval: Interval,
@@ -430,8 +431,9 @@ mod test {
                         } else {
                             match this.interval.poll_tick(cx) {
                                 Poll::Ready(_) => {
-                                    // prevents spurious test hang
                                     this.interval.reset();
+                                    // `reset` does not register this task's waker. Poll again.
+                                    cx.waker().wake_by_ref();
 
                                     Poll::Pending
                                 }


### PR DESCRIPTION
## Summary

- wake `DropCheck` after resetting its interval so it can register the task waker
- document the purpose of `DropCheck`

## Root cause

Tokio's interval reset does not register the current task's waker. If H2 teardown did not independently wake the task, the test remained pending until the GitHub Actions job timed out.

## Validation

- `cargo test -p awc --lib client::connection::test::test_h2_connection_drop -- --exact`
- 500 consecutive focused test runs
- `cargo test -p awc --lib --all-features`
- `cargo +nightly fmt --check`
- `just clippy`
