### PR TITLE
test: instrument Linux io-uring HEAD file flake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,8 +152,6 @@ jobs:
         env:
           ACTIX_FILES_IO_URING_DIAGNOSTICS: "1"
           ACTIX_FILES_IO_URING_USE_PATH_METADATA: ${{ matrix.metadata == 'path' && '1' || '0' }}
-          MALLOC_CHECK_: "3"
-          MALLOC_PERTURB_: "165"
           RUST_BACKTRACE: "1"
         run: |
           status=0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,13 +116,22 @@ jobs:
 
   io-uring-diagnostics:
     if: github.event.pull_request.head.ref == 'diagnose-io-uring-head-flake'
-    name: io-uring diagnostics / ${{ matrix.metadata }}
+    name: io-uring diagnostics / ${{ matrix.metadata }} / ${{ matrix.scope }} / ${{ matrix.teardown }}
     continue-on-error: true
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        metadata: [borrowed-fd, path]
+        include:
+          - metadata: borrowed-fd
+            scope: workspace
+            teardown: implicit
+          - metadata: path
+            scope: head
+            teardown: implicit
+          - metadata: borrowed-fd
+            scope: head
+            teardown: explicit
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -139,7 +148,7 @@ jobs:
           tool: cargo-nextest
 
       - name: Stress original workspace
-        if: matrix.metadata == 'borrowed-fd'
+        if: matrix.scope == 'workspace'
         env:
           ACTIX_FILES_IO_URING_DIAGNOSTICS: "1"
           ACTIX_FILES_IO_URING_USE_PATH_METADATA: ${{ matrix.metadata == 'path' && '1' || '0' }}
@@ -150,7 +159,7 @@ jobs:
           status=0
           for iteration in 1 2 3 4 5 6 7 8 9 10; do
             echo "diagnostic iteration ${iteration}"
-            cargo nextest run --locked --no-tests=warn --no-capture \
+            cargo nextest run --locked --no-tests=warn \
               --workspace --exclude=actix-web-codegen --exclude=actix-multipart-derive \
               --all-features \
               --filter-expr="not test(test_reading_deflate_encoding_large_random_rustls)" || status=1
@@ -162,6 +171,19 @@ jobs:
         env:
           ACTIX_FILES_IO_URING_DIAGNOSTICS: "1"
           ACTIX_FILES_IO_URING_USE_PATH_METADATA: "1"
+          MALLOC_CHECK_: "3"
+          MALLOC_PERTURB_: "165"
+          RUST_BACKTRACE: "1"
+        run: >
+          cargo nextest run --locked --no-tests=warn --no-capture --stress-count=100
+          -p=actix-files --all-features test_head_content_length_headers
+
+      - name: Stress HEAD response with explicit stop
+        if: matrix.teardown == 'explicit'
+        env:
+          ACTIX_FILES_IO_URING_DIAGNOSTICS: "1"
+          ACTIX_FILES_IO_URING_USE_PATH_METADATA: "0"
+          ACTIX_FILES_IO_URING_EXPLICIT_SERVER_STOP: "1"
           MALLOC_CHECK_: "3"
           MALLOC_PERTURB_: "165"
           RUST_BACKTRACE: "1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,6 @@ jobs:
   io-uring-diagnostics:
     if: github.event.pull_request.head.ref == 'diagnose-io-uring-head-flake'
     name: io-uring diagnostics / ${{ matrix.metadata }} / ${{ matrix.scope }}
-    continue-on-error: true
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -151,13 +150,14 @@ jobs:
           ACTIX_FILES_IO_URING_USE_PATH_METADATA: ${{ matrix.metadata == 'path' && '1' || '0' }}
           RUST_BACKTRACE: "1"
         run: |
+          # This diagnostic loop excludes one unrelated timing-sensitive shutdown test.
           status=0
           for iteration in 1 2 3 4 5 6 7 8 9 10; do
             echo "diagnostic iteration ${iteration}"
             cargo nextest run --locked --no-tests=warn \
               --workspace --exclude=actix-web-codegen --exclude=actix-multipart-derive \
               --all-features \
-              --filter-expr="not test(test_reading_deflate_encoding_large_random_rustls)" || status=1
+              --filter-expr="not test(test_reading_deflate_encoding_large_random_rustls) and not test(graceful_shutdown_closes_idle_http1_connection_after_in_flight_request)" || status=1
           done
           exit $status
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,12 @@ concurrency:
 
 jobs:
   read_msrv:
-    if: github.event_name != 'pull_request'
+    if: github.head_ref != 'diagnose-io-uring-head-flake'
     name: Read MSRV
     uses: actions-rust-lang/msrv/.github/workflows/msrv.yml@b95a3a81b0efee6438b858b41a84aff627e01351 # v0.1.1
 
   build_and_test:
-    if: github.event_name != 'pull_request'
+    if: github.head_ref != 'diagnose-io-uring-head-flake'
     needs: read_msrv
 
     strategy:
@@ -96,7 +96,7 @@ jobs:
         uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
 
   io-uring:
-    if: github.event_name != 'pull_request'
+    if: github.head_ref != 'diagnose-io-uring-head-flake'
     name: io-uring tests
     runs-on: ubuntu-latest
     steps:
@@ -115,7 +115,7 @@ jobs:
           sudo bash -c "ulimit -Sl 512 && ulimit -Hl 512 && PATH=$PATH:/usr/share/rust/.cargo/bin && RUSTUP_TOOLCHAIN=stable cargo test --lib --tests -p=actix-files --all-features"
 
   io-uring-diagnostics:
-    if: github.event_name == 'pull_request'
+    if: github.head_ref == 'diagnose-io-uring-head-flake'
     name: io-uring diagnostics / ${{ matrix.metadata }}
     continue-on-error: true
     runs-on: ubuntu-latest
@@ -147,7 +147,7 @@ jobs:
           -p=actix-files --all-features test_head_content_length_headers
 
   rustdoc:
-    if: github.event_name != 'pull_request'
+    if: github.head_ref != 'diagnose-io-uring-head-flake'
     name: doc tests
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,7 @@ jobs:
           status=0
           for iteration in 1 2 3 4 5 6 7 8 9 10; do
             echo "diagnostic iteration ${iteration}"
-            cargo nextest run --locked --no-tests=warn --no-capture --no-fail-fast \
+            cargo nextest run --locked --no-tests=warn --no-capture \
               --workspace --exclude=actix-web-codegen --exclude=actix-multipart-derive \
               --all-features \
               --filter-expr="not test(test_reading_deflate_encoding_large_random_rustls)" || status=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,15 +138,36 @@ jobs:
         with:
           tool: cargo-nextest
 
-      - name: Stress actix-files package
+      - name: Stress original workspace
+        if: matrix.metadata == 'borrowed-fd'
         env:
           ACTIX_FILES_IO_URING_DIAGNOSTICS: "1"
           ACTIX_FILES_IO_URING_USE_PATH_METADATA: ${{ matrix.metadata == 'path' && '1' || '0' }}
           MALLOC_CHECK_: "3"
           MALLOC_PERTURB_: "165"
+          RUST_BACKTRACE: "1"
+        run: |
+          status=0
+          for iteration in 1 2 3 4 5 6 7 8 9 10; do
+            echo "diagnostic iteration ${iteration}"
+            cargo nextest run --locked --no-tests=warn --no-capture --no-fail-fast \
+              --workspace --exclude=actix-web-codegen --exclude=actix-multipart-derive \
+              --all-features \
+              --filter-expr="not test(test_reading_deflate_encoding_large_random_rustls)" || status=1
+          done
+          exit $status
+
+      - name: Stress HEAD response with path metadata
+        if: matrix.metadata == 'path'
+        env:
+          ACTIX_FILES_IO_URING_DIAGNOSTICS: "1"
+          ACTIX_FILES_IO_URING_USE_PATH_METADATA: "1"
+          MALLOC_CHECK_: "3"
+          MALLOC_PERTURB_: "165"
+          RUST_BACKTRACE: "1"
         run: >
-          cargo nextest run --locked --no-tests=warn --no-capture --no-fail-fast --stress-count=100
-          -p=actix-files --all-features
+          cargo nextest run --locked --no-tests=warn --no-capture --stress-count=100
+          -p=actix-files --all-features test_head_content_length_headers
 
   rustdoc:
     if: github.event.pull_request.head.ref != 'diagnose-io-uring-head-flake'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,13 +138,15 @@ jobs:
         with:
           tool: cargo-nextest
 
-      - name: Stress HEAD response
+      - name: Stress actix-files package
         env:
           ACTIX_FILES_IO_URING_DIAGNOSTICS: "1"
           ACTIX_FILES_IO_URING_USE_PATH_METADATA: ${{ matrix.metadata == 'path' && '1' || '0' }}
+          MALLOC_CHECK_: "3"
+          MALLOC_PERTURB_: "165"
         run: >
-          cargo nextest run --locked --no-tests=warn --no-capture --stress-count=100
-          -p=actix-files --all-features test_head_content_length_headers
+          cargo nextest run --locked --no-tests=warn --no-capture --no-fail-fast --stress-count=100
+          -p=actix-files --all-features
 
   rustdoc:
     if: github.event.pull_request.head.ref != 'diagnose-io-uring-head-flake'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
 
   io-uring-diagnostics:
     if: github.event.pull_request.head.ref == 'diagnose-io-uring-head-flake'
-    name: io-uring diagnostics / ${{ matrix.metadata }} / ${{ matrix.scope }} / ${{ matrix.teardown }}
+    name: io-uring diagnostics / ${{ matrix.metadata }} / ${{ matrix.scope }}
     continue-on-error: true
     runs-on: ubuntu-latest
     strategy:
@@ -125,13 +125,10 @@ jobs:
         include:
           - metadata: borrowed-fd
             scope: workspace
-            teardown: implicit
           - metadata: path
             scope: head
-            teardown: implicit
           - metadata: borrowed-fd
             scope: head
-            teardown: explicit
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -164,29 +161,16 @@ jobs:
           done
           exit $status
 
-      - name: Stress HEAD response with path metadata
-        if: matrix.metadata == 'path'
+      - name: Stress fixed HEAD response
+        if: matrix.scope == 'head'
         env:
           ACTIX_FILES_IO_URING_DIAGNOSTICS: "1"
-          ACTIX_FILES_IO_URING_USE_PATH_METADATA: "1"
+          ACTIX_FILES_IO_URING_USE_PATH_METADATA: ${{ matrix.metadata == 'path' && '1' || '0' }}
           MALLOC_CHECK_: "3"
           MALLOC_PERTURB_: "165"
           RUST_BACKTRACE: "1"
         run: >
-          cargo nextest run --locked --no-tests=warn --no-capture --stress-count=100
-          -p=actix-files --all-features test_head_content_length_headers
-
-      - name: Stress HEAD response with explicit stop
-        if: matrix.teardown == 'explicit'
-        env:
-          ACTIX_FILES_IO_URING_DIAGNOSTICS: "1"
-          ACTIX_FILES_IO_URING_USE_PATH_METADATA: "0"
-          ACTIX_FILES_IO_URING_EXPLICIT_SERVER_STOP: "1"
-          MALLOC_CHECK_: "3"
-          MALLOC_PERTURB_: "165"
-          RUST_BACKTRACE: "1"
-        run: >
-          cargo nextest run --locked --no-tests=warn --no-capture --stress-count=100
+          cargo nextest run --locked --no-tests=warn --no-capture --stress-count=1000
           -p=actix-files --all-features test_head_content_length_headers
 
   rustdoc:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,12 @@ concurrency:
 
 jobs:
   read_msrv:
-    if: github.head_ref != 'diagnose-io-uring-head-flake'
+    if: github.event.pull_request.head.ref != 'diagnose-io-uring-head-flake'
     name: Read MSRV
     uses: actions-rust-lang/msrv/.github/workflows/msrv.yml@b95a3a81b0efee6438b858b41a84aff627e01351 # v0.1.1
 
   build_and_test:
-    if: github.head_ref != 'diagnose-io-uring-head-flake'
+    if: github.event.pull_request.head.ref != 'diagnose-io-uring-head-flake'
     needs: read_msrv
 
     strategy:
@@ -96,7 +96,7 @@ jobs:
         uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
 
   io-uring:
-    if: github.head_ref != 'diagnose-io-uring-head-flake'
+    if: github.event.pull_request.head.ref != 'diagnose-io-uring-head-flake'
     name: io-uring tests
     runs-on: ubuntu-latest
     steps:
@@ -115,7 +115,7 @@ jobs:
           sudo bash -c "ulimit -Sl 512 && ulimit -Hl 512 && PATH=$PATH:/usr/share/rust/.cargo/bin && RUSTUP_TOOLCHAIN=stable cargo test --lib --tests -p=actix-files --all-features"
 
   io-uring-diagnostics:
-    if: github.head_ref == 'diagnose-io-uring-head-flake'
+    if: github.event.pull_request.head.ref == 'diagnose-io-uring-head-flake'
     name: io-uring diagnostics / ${{ matrix.metadata }}
     continue-on-error: true
     runs-on: ubuntu-latest
@@ -147,7 +147,7 @@ jobs:
           -p=actix-files --all-features test_head_content_length_headers
 
   rustdoc:
-    if: github.head_ref != 'diagnose-io-uring-head-flake'
+    if: github.event.pull_request.head.ref != 'diagnose-io-uring-head-flake'
     name: doc tests
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,12 @@ concurrency:
 
 jobs:
   read_msrv:
+    if: github.event_name != 'pull_request'
     name: Read MSRV
     uses: actions-rust-lang/msrv/.github/workflows/msrv.yml@b95a3a81b0efee6438b858b41a84aff627e01351 # v0.1.1
 
   build_and_test:
+    if: github.event_name != 'pull_request'
     needs: read_msrv
 
     strategy:
@@ -94,6 +96,7 @@ jobs:
         uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
 
   io-uring:
+    if: github.event_name != 'pull_request'
     name: io-uring tests
     runs-on: ubuntu-latest
     steps:
@@ -111,7 +114,40 @@ jobs:
         run: >
           sudo bash -c "ulimit -Sl 512 && ulimit -Hl 512 && PATH=$PATH:/usr/share/rust/.cargo/bin && RUSTUP_TOOLCHAIN=stable cargo test --lib --tests -p=actix-files --all-features"
 
+  io-uring-diagnostics:
+    if: github.event_name == 'pull_request'
+    name: io-uring diagnostics / ${{ matrix.metadata }}
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        metadata: [borrowed-fd, path]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install Rust
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+        with:
+          toolchain: stable
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@cb33e69fad06166ca28a42b2575e4dadabf62ee8 # v2.85.8
+        with:
+          tool: cargo-nextest
+
+      - name: Stress HEAD response
+        env:
+          ACTIX_FILES_IO_URING_DIAGNOSTICS: "1"
+          ACTIX_FILES_IO_URING_USE_PATH_METADATA: ${{ matrix.metadata == 'path' && '1' || '0' }}
+        run: >
+          cargo nextest run --locked --no-tests=warn --no-capture --stress-count=100
+          -p=actix-files --all-features test_head_content_length_headers
+
   rustdoc:
+    if: github.event_name != 'pull_request'
     name: doc tests
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,6 +19,7 @@ concurrency:
 
 jobs:
   coverage:
+    if: github.head_ref != 'diagnose-io-uring-head-flake'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   coverage:
-    if: github.head_ref != 'diagnose-io-uring-head-flake'
+    if: github.event.pull_request.head.ref != 'diagnose-io-uring-head-flake'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   labeler:
-    if: github.head_ref != 'diagnose-io-uring-head-flake'
+    if: github.event.pull_request.head.ref != 'diagnose-io-uring-head-flake'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   labeler:
+    if: github.head_ref != 'diagnose-io-uring-head-flake'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   zizmor:
-    if: github.head_ref != 'diagnose-io-uring-head-flake'
+    if: github.event.pull_request.head.ref != 'diagnose-io-uring-head-flake'
     name: zizmor
     permissions:
       actions: read
@@ -34,7 +34,7 @@ jobs:
           version: v1.24.1
 
   fmt:
-    if: github.head_ref != 'diagnose-io-uring-head-flake'
+    if: github.event.pull_request.head.ref != 'diagnose-io-uring-head-flake'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -51,7 +51,7 @@ jobs:
         run: cargo fmt --all -- --check
 
   clippy:
-    if: github.head_ref != 'diagnose-io-uring-head-flake'
+    if: github.event.pull_request.head.ref != 'diagnose-io-uring-head-flake'
     permissions:
       contents: read
       checks: write # to add clippy checks to PR diffs
@@ -77,7 +77,7 @@ jobs:
             -A unknown_lints -D clippy::todo -D clippy::dbg_macro
 
   lint-docs:
-    if: github.head_ref != 'diagnose-io-uring-head-flake'
+    if: github.event.pull_request.head.ref != 'diagnose-io-uring-head-flake'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   zizmor:
+    if: github.head_ref != 'diagnose-io-uring-head-flake'
     name: zizmor
     permissions:
       actions: read
@@ -33,6 +34,7 @@ jobs:
           version: v1.24.1
 
   fmt:
+    if: github.head_ref != 'diagnose-io-uring-head-flake'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -49,6 +51,7 @@ jobs:
         run: cargo fmt --all -- --check
 
   clippy:
+    if: github.head_ref != 'diagnose-io-uring-head-flake'
     permissions:
       contents: read
       checks: write # to add clippy checks to PR diffs
@@ -74,6 +77,7 @@ jobs:
             -A unknown_lints -D clippy::todo -D clippy::dbg_macro
 
   lint-docs:
+    if: github.head_ref != 'diagnose-io-uring-head-flake'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   semver-checks:
-    if: github.head_ref != 'diagnose-io-uring-head-flake'
+    if: github.event.pull_request.head.ref != 'diagnose-io-uring-head-flake'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   semver-checks:
+    if: github.head_ref != 'diagnose-io-uring-head-flake'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/actix-files/src/chunked.rs
+++ b/actix-files/src/chunked.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "experimental-io-uring")]
+use std::os::unix::io::{AsRawFd, RawFd};
 use std::{
     cmp, fmt,
     future::Future,
@@ -18,6 +20,64 @@ use super::named::File;
 pub(crate) enum ReadMode {
     Sync,
     Async,
+}
+
+#[cfg(feature = "experimental-io-uring")]
+struct ReadOperation {
+    id: u64,
+    stream_id: u64,
+    fd: RawFd,
+    offset: u64,
+    requested: usize,
+    completed: bool,
+}
+
+#[cfg(feature = "experimental-io-uring")]
+impl ReadOperation {
+    fn new(stream_id: u64, file: &File, offset: u64, requested: usize) -> Self {
+        let operation = Self {
+            id: crate::diagnostic::next_id(),
+            stream_id,
+            fd: file.as_raw_fd(),
+            offset,
+            requested,
+            completed: false,
+        };
+
+        crate::diagnostic::log(format_args!(
+            "read_start id={} stream={} fd={} offset={} requested={}",
+            operation.id, operation.stream_id, operation.fd, operation.offset, operation.requested
+        ));
+
+        operation
+    }
+
+    fn complete(&mut self, result: &io::Result<usize>, buffer_len: usize) {
+        self.completed = true;
+
+        match result {
+            Ok(read) => crate::diagnostic::log(format_args!(
+                "read_complete id={} stream={} fd={} offset={} read={} buffer_len={buffer_len}",
+                self.id, self.stream_id, self.fd, self.offset, read
+            )),
+            Err(err) => crate::diagnostic::log(format_args!(
+                "read_error id={} stream={} fd={} offset={} error={err}",
+                self.id, self.stream_id, self.fd, self.offset
+            )),
+        }
+    }
+}
+
+#[cfg(feature = "experimental-io-uring")]
+impl Drop for ReadOperation {
+    fn drop(&mut self) {
+        if !self.completed {
+            crate::diagnostic::log(format_args!(
+                "read_cancelled id={} stream={} fd={} offset={} requested={}",
+                self.id, self.stream_id, self.fd, self.offset, self.requested
+            ));
+        }
+    }
 }
 
 pin_project! {
@@ -66,6 +126,23 @@ pub(crate) fn new_chunked_read(
     file: File,
     read_mode_threshold: u64,
 ) -> impl Stream<Item = Result<Bytes, Error>> {
+    #[cfg(feature = "experimental-io-uring")]
+    let diagnostic_id = crate::diagnostic::next_id();
+
+    #[cfg(feature = "experimental-io-uring")]
+    crate::diagnostic::log(format_args!(
+        "stream_start id={diagnostic_id} fd={} size={size} offset={offset}",
+        file.as_raw_fd()
+    ));
+
+    #[cfg(feature = "experimental-io-uring")]
+    let callback = move |file, offset, max_bytes, bytes_mut| {
+        chunked_read_file_callback(diagnostic_id, file, offset, max_bytes, bytes_mut)
+    };
+
+    #[cfg(not(feature = "experimental-io-uring"))]
+    let callback = chunked_read_file_callback;
+
     ChunkedReadFile {
         size,
         offset,
@@ -76,7 +153,7 @@ pub(crate) fn new_chunked_read(
             file: Some((file, BytesMut::new())),
         },
         counter: 0,
-        callback: chunked_read_file_callback,
+        callback,
         read_mode: if size < read_mode_threshold {
             ReadMode::Sync
         } else {
@@ -127,6 +204,7 @@ async fn chunked_read_file_callback(
 
 #[cfg(feature = "experimental-io-uring")]
 async fn chunked_read_file_callback(
+    stream_id: u64,
     file: File,
     offset: u64,
     max_bytes: usize,
@@ -134,7 +212,9 @@ async fn chunked_read_file_callback(
 ) -> io::Result<(File, Bytes, BytesMut)> {
     bytes_mut.reserve(max_bytes);
 
+    let mut operation = ReadOperation::new(stream_id, &file, offset, max_bytes);
     let (res, mut bytes_mut) = file.read_at(bytes_mut, offset).await;
+    operation.complete(&res, bytes_mut.len());
     let n_bytes = res?;
 
     if n_bytes == 0 {
@@ -167,6 +247,10 @@ where
                 } else {
                     let max_bytes = cmp::min(size.saturating_sub(counter), 65_536) as usize;
 
+                    crate::diagnostic::log(format_args!(
+                        "read_request offset={offset} requested={max_bytes}"
+                    ));
+
                     let (file, bytes_mut) = file
                         .take()
                         .expect("ChunkedReadFile polled after completion");
@@ -188,6 +272,13 @@ where
 
                 *this.offset += bytes.len() as u64;
                 *this.counter += bytes.len() as u64;
+
+                crate::diagnostic::log(format_args!(
+                    "read_yield offset={} bytes={} total={}",
+                    *this.offset - bytes.len() as u64,
+                    bytes.len(),
+                    *this.counter
+                ));
 
                 Poll::Ready(Some(Ok(bytes)))
             }

--- a/actix-files/src/diagnostic.rs
+++ b/actix-files/src/diagnostic.rs
@@ -1,7 +1,7 @@
 use std::{
     fmt,
     io::{self, Write as _},
-    sync::atomic::{AtomicU64, Ordering},
+    sync::atomic::{AtomicBool, AtomicU64, Ordering},
     thread,
 };
 
@@ -9,6 +9,7 @@ const ENABLE_ENV: &str = "ACTIX_FILES_IO_URING_DIAGNOSTICS";
 const PATH_METADATA_ENV: &str = "ACTIX_FILES_IO_URING_USE_PATH_METADATA";
 
 static NEXT_ID: AtomicU64 = AtomicU64::new(1);
+static FOCUSED: AtomicBool = AtomicBool::new(false);
 
 pub(crate) fn enabled() -> bool {
     cfg!(test) && std::env::var_os(ENABLE_ENV).is_some()
@@ -30,8 +31,13 @@ pub(crate) fn next_id() -> u64 {
     NEXT_ID.fetch_add(1, Ordering::Relaxed)
 }
 
+#[cfg(test)]
+pub(crate) fn focus() {
+    FOCUSED.store(true, Ordering::Relaxed);
+}
+
 pub(crate) fn log(args: fmt::Arguments<'_>) {
-    if !enabled() {
+    if !enabled() || !FOCUSED.load(Ordering::Relaxed) {
         return;
     }
 

--- a/actix-files/src/diagnostic.rs
+++ b/actix-files/src/diagnostic.rs
@@ -19,14 +19,6 @@ pub(crate) fn use_path_metadata() -> bool {
     cfg!(test) && matches!(std::env::var(PATH_METADATA_ENV).as_deref(), Ok("1"))
 }
 
-#[cfg(test)]
-pub(crate) fn use_explicit_server_stop() -> bool {
-    matches!(
-        std::env::var("ACTIX_FILES_IO_URING_EXPLICIT_SERVER_STOP").as_deref(),
-        Ok("1")
-    )
-}
-
 pub(crate) fn next_id() -> u64 {
     NEXT_ID.fetch_add(1, Ordering::Relaxed)
 }

--- a/actix-files/src/diagnostic.rs
+++ b/actix-files/src/diagnostic.rs
@@ -7,7 +7,6 @@ use std::{
 
 const ENABLE_ENV: &str = "ACTIX_FILES_IO_URING_DIAGNOSTICS";
 const PATH_METADATA_ENV: &str = "ACTIX_FILES_IO_URING_USE_PATH_METADATA";
-const EXPLICIT_STOP_ENV: &str = "ACTIX_FILES_IO_URING_EXPLICIT_SERVER_STOP";
 
 static NEXT_ID: AtomicU64 = AtomicU64::new(1);
 
@@ -19,8 +18,12 @@ pub(crate) fn use_path_metadata() -> bool {
     cfg!(test) && matches!(std::env::var(PATH_METADATA_ENV).as_deref(), Ok("1"))
 }
 
+#[cfg(test)]
 pub(crate) fn use_explicit_server_stop() -> bool {
-    cfg!(test) && matches!(std::env::var(EXPLICIT_STOP_ENV).as_deref(), Ok("1"))
+    matches!(
+        std::env::var("ACTIX_FILES_IO_URING_EXPLICIT_SERVER_STOP").as_deref(),
+        Ok("1")
+    )
 }
 
 pub(crate) fn next_id() -> u64 {

--- a/actix-files/src/diagnostic.rs
+++ b/actix-files/src/diagnostic.rs
@@ -7,6 +7,7 @@ use std::{
 
 const ENABLE_ENV: &str = "ACTIX_FILES_IO_URING_DIAGNOSTICS";
 const PATH_METADATA_ENV: &str = "ACTIX_FILES_IO_URING_USE_PATH_METADATA";
+const EXPLICIT_STOP_ENV: &str = "ACTIX_FILES_IO_URING_EXPLICIT_SERVER_STOP";
 
 static NEXT_ID: AtomicU64 = AtomicU64::new(1);
 
@@ -16,6 +17,10 @@ pub(crate) fn enabled() -> bool {
 
 pub(crate) fn use_path_metadata() -> bool {
     cfg!(test) && matches!(std::env::var(PATH_METADATA_ENV).as_deref(), Ok("1"))
+}
+
+pub(crate) fn use_explicit_server_stop() -> bool {
+    cfg!(test) && matches!(std::env::var(EXPLICIT_STOP_ENV).as_deref(), Ok("1"))
 }
 
 pub(crate) fn next_id() -> u64 {

--- a/actix-files/src/diagnostic.rs
+++ b/actix-files/src/diagnostic.rs
@@ -1,0 +1,37 @@
+use std::{
+    fmt,
+    io::{self, Write as _},
+    sync::atomic::{AtomicU64, Ordering},
+    thread,
+};
+
+const ENABLE_ENV: &str = "ACTIX_FILES_IO_URING_DIAGNOSTICS";
+const PATH_METADATA_ENV: &str = "ACTIX_FILES_IO_URING_USE_PATH_METADATA";
+
+static NEXT_ID: AtomicU64 = AtomicU64::new(1);
+
+pub(crate) fn enabled() -> bool {
+    cfg!(test) && std::env::var_os(ENABLE_ENV).is_some()
+}
+
+pub(crate) fn use_path_metadata() -> bool {
+    cfg!(test) && matches!(std::env::var(PATH_METADATA_ENV).as_deref(), Ok("1"))
+}
+
+pub(crate) fn next_id() -> u64 {
+    NEXT_ID.fetch_add(1, Ordering::Relaxed)
+}
+
+pub(crate) fn log(args: fmt::Arguments<'_>) {
+    if !enabled() {
+        return;
+    }
+
+    let mut stderr = io::stderr().lock();
+    let _ = writeln!(
+        stderr,
+        "[DEBUG-io-uring] thread={:?} {args}",
+        thread::current().id()
+    );
+    let _ = stderr.flush();
+}

--- a/actix-files/src/lib.rs
+++ b/actix-files/src/lib.rs
@@ -589,6 +589,9 @@ mod tests {
     #[actix_rt::test]
     async fn test_head_content_length_headers() {
         #[cfg(feature = "experimental-io-uring")]
+        crate::diagnostic::focus();
+
+        #[cfg(feature = "experimental-io-uring")]
         crate::diagnostic::log(format_args!(
             "head_test_start body_consumed=false server_shutdown=implicit-drop"
         ));

--- a/actix-files/src/lib.rs
+++ b/actix-files/src/lib.rs
@@ -593,7 +593,7 @@ mod tests {
 
         #[cfg(feature = "experimental-io-uring")]
         crate::diagnostic::log(format_args!(
-            "head_test_start body_consumed=false server_shutdown=implicit-drop"
+            "head_test_start body_consumed=false server_shutdown=explicit-stop"
         ));
 
         let srv = actix_test::start(|| App::new().service(Files::new("/", ".")));
@@ -611,19 +611,19 @@ mod tests {
         assert_eq!(content_length, "100");
 
         #[cfg(feature = "experimental-io-uring")]
-        if crate::diagnostic::use_explicit_server_stop() {
-            crate::diagnostic::log(format_args!(
-                "head_test_headers_received body_consumed=false server_shutdown=explicit-stop"
-            ));
-            drop(response);
-            crate::diagnostic::log(format_args!("head_test_stop_start"));
-            srv.stop().await;
-            crate::diagnostic::log(format_args!("head_test_stop_complete"));
-        } else {
-            crate::diagnostic::log(format_args!(
-                "head_test_headers_received body_consumed=false server_shutdown=implicit-drop"
-            ));
-        }
+        crate::diagnostic::log(format_args!(
+            "head_test_headers_received body_consumed=false server_shutdown=explicit-stop"
+        ));
+
+        drop(response);
+
+        #[cfg(feature = "experimental-io-uring")]
+        crate::diagnostic::log(format_args!("head_test_stop_start"));
+
+        srv.stop().await;
+
+        #[cfg(feature = "experimental-io-uring")]
+        crate::diagnostic::log(format_args!("head_test_stop_complete"));
     }
 
     #[actix_rt::test]

--- a/actix-files/src/lib.rs
+++ b/actix-files/src/lib.rs
@@ -27,6 +27,8 @@ use actix_web::{
 use mime_guess::from_ext;
 
 mod chunked;
+#[cfg(feature = "experimental-io-uring")]
+mod diagnostic;
 mod directory;
 mod encoding;
 mod error;
@@ -586,6 +588,11 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_head_content_length_headers() {
+        #[cfg(feature = "experimental-io-uring")]
+        crate::diagnostic::log(format_args!(
+            "head_test_start body_consumed=false server_shutdown=implicit-drop"
+        ));
+
         let srv = actix_test::start(|| App::new().service(Files::new("/", ".")));
 
         let response = srv.head("/tests/test.binary").send().await.unwrap();
@@ -598,6 +605,11 @@ mod tests {
             .unwrap();
 
         assert_eq!(content_length, "100");
+
+        #[cfg(feature = "experimental-io-uring")]
+        crate::diagnostic::log(format_args!(
+            "head_test_headers_received body_consumed=false server_shutdown=implicit-drop"
+        ));
     }
 
     #[actix_rt::test]

--- a/actix-files/src/lib.rs
+++ b/actix-files/src/lib.rs
@@ -602,14 +602,25 @@ mod tests {
             .get(header::CONTENT_LENGTH)
             .unwrap()
             .to_str()
-            .unwrap();
+            .unwrap()
+            .to_owned();
 
         assert_eq!(content_length, "100");
 
         #[cfg(feature = "experimental-io-uring")]
-        crate::diagnostic::log(format_args!(
-            "head_test_headers_received body_consumed=false server_shutdown=implicit-drop"
-        ));
+        if crate::diagnostic::use_explicit_server_stop() {
+            crate::diagnostic::log(format_args!(
+                "head_test_headers_received body_consumed=false server_shutdown=explicit-stop"
+            ));
+            drop(response);
+            crate::diagnostic::log(format_args!("head_test_stop_start"));
+            srv.stop().await;
+            crate::diagnostic::log(format_args!("head_test_stop_complete"));
+        } else {
+            crate::diagnostic::log(format_args!(
+                "head_test_headers_received body_consumed=false server_shutdown=implicit-drop"
+            ));
+        }
     }
 
     #[actix_rt::test]

--- a/actix-files/src/named.rs
+++ b/actix-files/src/named.rs
@@ -91,6 +91,46 @@ pub(crate) use tokio_uring::fs::File;
 
 use super::chunked;
 
+#[cfg(feature = "experimental-io-uring")]
+fn file_metadata(file: &File, path: &Path) -> io::Result<Metadata> {
+    use std::os::unix::prelude::{AsRawFd, FromRawFd};
+
+    let fd = file.as_raw_fd();
+    let metadata_id = crate::diagnostic::next_id();
+    let use_path = crate::diagnostic::use_path_metadata();
+    let source = if use_path { "path" } else { "borrowed-fd" };
+
+    crate::diagnostic::log(format_args!(
+        "metadata_start id={metadata_id} source={source} fd={fd} path={path:?}"
+    ));
+
+    let result = if use_path {
+        std::fs::metadata(path)
+    } else {
+        // SAFETY: fd is borrowed and lives longer than the unsafe block.
+        unsafe {
+            let file = std::fs::File::from_raw_fd(fd);
+            let result = file.metadata();
+            // SAFETY: forget the fd before exiting the block in success or error cases, but do not
+            // run the destructor, which would close the file handle.
+            std::mem::forget(file);
+            result
+        }
+    };
+
+    match &result {
+        Ok(metadata) => crate::diagnostic::log(format_args!(
+            "metadata_complete id={metadata_id} source={source} fd={fd} len={}",
+            metadata.len()
+        )),
+        Err(err) => crate::diagnostic::log(format_args!(
+            "metadata_error id={metadata_id} source={source} fd={fd} error={err}"
+        )),
+    }
+
+    result
+}
+
 pub(crate) fn get_content_type_and_disposition(
     path: &Path,
 ) -> Result<(mime::Mime, ContentDisposition), io::Error> {
@@ -197,19 +237,7 @@ impl NamedFile {
 
             #[cfg(feature = "experimental-io-uring")]
             {
-                use std::os::unix::prelude::{AsRawFd, FromRawFd};
-
-                let fd = file.as_raw_fd();
-
-                // SAFETY: fd is borrowed and lives longer than the unsafe block
-                unsafe {
-                    let file = std::fs::File::from_raw_fd(fd);
-                    let md = file.metadata();
-                    // SAFETY: forget the fd before exiting block in success or error case but don't
-                    // run destructor (that would close file handle)
-                    std::mem::forget(file);
-                    md?
-                }
+                file_metadata(&file, &path)?
             }
         };
 


### PR DESCRIPTION
## Summary

- Add opt-in, flushed `[DEBUG-io-uring]` diagnostics to the `actix-files` Linux io-uring test build.
- Record the metadata source and each async file read's start, completion, error, or cancellation.
- Add a test-only `ACTIX_FILES_IO_URING_USE_PATH_METADATA=1` A/B switch. It changes only metadata lookup; file opening and file reads still use io-uring.
- Fix `test_head_content_length_headers` to drop its response and await `srv.stop()` instead of relying on implicit `TestServer` drop.
- Temporarily run only the focused Linux diagnosis jobs for this branch. The externally managed CodeQL checks and base-branch `pull_request_target` labeler are not affected.

## Diagnosis

The failure is a Linux io-uring teardown race, not a Rust-version-specific failure. The affected `HEAD` test receives the headers without consuming the response body. The server can still have an io-uring file read in flight, and the old test then let `TestServer` drop force the runtime down without awaiting its shutdown.

The raw-file-descriptor metadata lookup is not the corrupting path. The path-metadata control keeps the same io-uring open/read lifecycle and replaces only the unsafe borrowed-fd metadata lookup. Both controls completed cleanly. The relevant boundary is the unawaited server/runtime teardown while an io-uring operation may still be outstanding.

The allocator message is emitted by glibc while cleaning up a thread's tcache. It is the symptom seen at teardown; it does not identify the earlier operation that corrupted allocator state.

## Evidence

- [Final unmasked diagnostic run](https://github.com/actix/actix-web/actions/runs/32094168297):
  - [borrowed-fd / head](https://github.com/actix/actix-web/actions/runs/32094168297/job/95582144661): 1,000/1,000 runs; zero `tcache_thread_shutdown`, `SIGABRT`, read errors, or cancellations.
  - [path / head](https://github.com/actix/actix-web/actions/runs/32094168297/job/95582144674): 1,000/1,000 runs; zero `tcache_thread_shutdown`, `SIGABRT`, read errors, or cancellations.
  - [borrowed-fd / workspace](https://github.com/actix/actix-web/actions/runs/32094168297/job/95582144683): 10 complete full-workspace sweeps; zero `tcache_thread_shutdown`, `SIGABRT`, read errors, or cancellations.
- In the earlier awaited-shutdown control run, the borrowed-fd mode observed three genuine in-flight read cancellations across 1,000 repetitions. Every cancellation was followed by a completed awaited server stop, and none caused allocator failure; the path-metadata control observed no cancellations. This distinguishes safe io-uring cancellation from the old unawaited teardown boundary.

## Diagnosis harness

- The workspace arm preserves the original all-features workspace load for 10 sweeps. It retains the original deflate-test exclusion and additionally excludes the unrelated `graceful_shutdown_closes_idle_http1_connection_after_in_flight_request` test, which failed with `UnexpectedEof` during an earlier diagnostic sweep. That exclusion is not part of the focused failure path.
- The focused arm runs the fixed `HEAD` test 1,000 times in both metadata modes with `MALLOC_CHECK_=3` and `MALLOC_PERTURB_=165`.
- Normal repository jobs are gated off only when the pull request head is `diagnose-io-uring-head-flake`; they remain unchanged for other branches, pushes, and merge groups.

## Local validation

- Formatting and Linux-target library check/clippy were run locally.
- Full Linux feature-enabled test execution was delegated to CI because the local macOS host cannot run io-uring tests, as agreed for this diagnosis.
