### PR TITLE
test(router): increase actix-router test coverage

### DIFF
--- a/actix-router/src/de.rs
+++ b/actix-router/src/de.rs
@@ -635,6 +635,20 @@ mod tests {
     #[derive(Debug, Deserialize, PartialEq)]
     struct TestTupleStruct(String, String, String);
 
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct UnitPath;
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct NewtypePath(String);
+
+    #[allow(dead_code)]
+    #[derive(Debug, Deserialize)]
+    enum NonUnitEnum {
+        Newtype(String),
+        Tuple(String, String),
+        Struct { value: String },
+    }
+
     #[test]
     fn test_request_extract() {
         let mut router = Router::<()>::build();
@@ -687,6 +701,17 @@ mod tests {
         assert!(router.recognize(&mut path).is_some());
         let i: i8 = de::Deserialize::deserialize(PathDeserializer::new(&path)).unwrap();
         assert_eq!(i, 32);
+
+        let unit: () = de::Deserialize::deserialize(PathDeserializer::new(&path)).unwrap();
+        assert_eq!(unit, ());
+
+        let unit_struct: UnitPath =
+            de::Deserialize::deserialize(PathDeserializer::new(&path)).unwrap();
+        assert_eq!(unit_struct, UnitPath);
+
+        let newtype: NewtypePath =
+            de::Deserialize::deserialize(PathDeserializer::new(&path)).unwrap();
+        assert_eq!(newtype, NewtypePath("32".to_owned()));
     }
 
     #[test]
@@ -709,6 +734,35 @@ mod tests {
         let i: (TestEnum, TestEnum) =
             de::Deserialize::deserialize(PathDeserializer::new(&path)).unwrap();
         assert_eq!(i, (TestEnum::Val1, TestEnum::Val2));
+
+        let path = Path::new("/static");
+        let result: Result<TestEnum, de::value::Error> =
+            de::Deserialize::deserialize(PathDeserializer::new(&path));
+
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("expected at least one parameters"));
+
+        let resource = ResourceDef::new("/{variant}");
+
+        let mut path = Path::new("/Newtype");
+        assert!(resource.capture_match_info(&mut path));
+        let newtype: Result<NonUnitEnum, de::value::Error> =
+            de::Deserialize::deserialize(PathDeserializer::new(&path));
+        assert!(newtype.unwrap_err().to_string().contains("not supported"));
+
+        let mut path = Path::new("/Tuple");
+        assert!(resource.capture_match_info(&mut path));
+        let tuple: Result<NonUnitEnum, de::value::Error> =
+            de::Deserialize::deserialize(PathDeserializer::new(&path));
+        assert!(tuple.unwrap_err().to_string().contains("not supported"));
+
+        let mut path = Path::new("/Struct");
+        assert!(resource.capture_match_info(&mut path));
+        let structure: Result<NonUnitEnum, de::value::Error> =
+            de::Deserialize::deserialize(PathDeserializer::new(&path));
+        assert!(structure.unwrap_err().to_string().contains("not supported"));
     }
 
     #[test]
@@ -726,8 +780,7 @@ mod tests {
         assert!(router.recognize(&mut path).is_some());
         let i: Result<Test3, de::value::Error> =
             de::Deserialize::deserialize(PathDeserializer::new(&path));
-        assert!(i.is_err());
-        assert!(format!("{:?}", i).contains("unknown variant"));
+        assert!(i.unwrap_err().to_string().contains("unknown variant"));
     }
 
     #[test]
@@ -740,37 +793,149 @@ mod tests {
         assert!(router.recognize(&mut path).is_some());
 
         let i: (String,) = de::Deserialize::deserialize(PathDeserializer::new(&path)).unwrap();
-        assert_eq!(i.0, String::from("tail/with/slash/es"));
+        assert_eq!(i.0, "tail/with/slash/es".to_owned());
 
         let i: TestSeq1 = de::Deserialize::deserialize(PathDeserializer::new(&path)).unwrap();
         assert_eq!(
             i.tail,
-            vec![
-                String::from("tail"),
-                String::from("with"),
-                String::from("slash/es")
-            ]
+            vec!["tail".to_owned(), "with".to_owned(), "slash/es".to_owned()]
         );
 
         let i: TestSeq2 = de::Deserialize::deserialize(PathDeserializer::new(&path)).unwrap();
         assert_eq!(
             i.tail,
-            (
-                String::from("tail"),
-                String::from("with"),
-                String::from("slash/es")
-            )
+            ("tail".to_owned(), "with".to_owned(), "slash/es".to_owned())
         );
 
         let i: TestSeq3 = de::Deserialize::deserialize(PathDeserializer::new(&path)).unwrap();
         assert_eq!(
             i.tail,
-            TestTupleStruct(
-                String::from("tail"),
-                String::from("with"),
-                String::from("slash/es")
-            )
+            TestTupleStruct("tail".to_owned(), "with".to_owned(), "slash/es".to_owned())
         );
+
+        let optional: Vec<Option<String>> =
+            de::Deserialize::deserialize(PathDeserializer::new(&path)).unwrap();
+        assert_eq!(optional, vec![Some("tail/with/slash/es".to_owned())]);
+
+        let ignored: Vec<de::IgnoredAny> =
+            de::Deserialize::deserialize(PathDeserializer::new(&path)).unwrap();
+        assert_eq!(ignored.len(), 1);
+
+        let units: Vec<()> = de::Deserialize::deserialize(PathDeserializer::new(&path)).unwrap();
+        assert_eq!(units, vec![()]);
+
+        let unit_structs: Vec<UnitPath> =
+            de::Deserialize::deserialize(PathDeserializer::new(&path)).unwrap();
+        assert_eq!(unit_structs, vec![UnitPath]);
+
+        let newtypes: Vec<NewtypePath> =
+            de::Deserialize::deserialize(PathDeserializer::new(&path)).unwrap();
+        assert_eq!(newtypes, vec![NewtypePath("tail/with/slash/es".to_owned())]);
+
+        let mut path = Path::new("/path/to/one//two/");
+        assert!(router.recognize(&mut path).is_some());
+        let i: TestSeq1 = de::Deserialize::deserialize(PathDeserializer::new(&path)).unwrap();
+        assert_eq!(i.tail, vec!["one".to_owned(), "two".to_owned()]);
+    }
+
+    #[test]
+    fn captured_bytes_are_percent_decoded() {
+        #[derive(Debug, PartialEq)]
+        struct Bytes(Vec<u8>);
+
+        impl<'de> Deserialize<'de> for Bytes {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct BytesVisitor;
+
+                impl<'de> Visitor<'de> for BytesVisitor {
+                    type Value = Bytes;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        formatter.write_str("bytes")
+                    }
+
+                    fn visit_borrowed_bytes<E>(self, value: &'de [u8]) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Ok(Bytes(value.to_vec()))
+                    }
+
+                    fn visit_byte_buf<E>(self, value: Vec<u8>) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Ok(Bytes(value))
+                    }
+                }
+
+                deserializer.deserialize_byte_buf(BytesVisitor)
+            }
+        }
+
+        let resource = ResourceDef::new("/{value}");
+        let mut path = Path::new("/bytes");
+        assert!(resource.capture_match_info(&mut path));
+
+        let bytes: Bytes = de::Deserialize::deserialize(PathDeserializer::new(&path)).unwrap();
+        assert_eq!(bytes, Bytes(b"bytes".to_vec()));
+
+        let mut path = Path::new("/%62ytes");
+        assert!(resource.capture_match_info(&mut path));
+        let bytes: Bytes = de::Deserialize::deserialize(PathDeserializer::new(&path)).unwrap();
+        assert_eq!(bytes, Bytes(b"bytes".to_vec()));
+    }
+
+    #[test]
+    fn captured_tuples_require_matching_lengths() {
+        #[allow(dead_code)]
+        #[derive(Debug, Deserialize)]
+        struct TupleValues {
+            tail: (String, String),
+        }
+
+        let resource = ResourceDef::new("/path/{tail}*");
+        let mut path = Path::new("/path/one/two/three");
+        assert!(resource.capture_match_info(&mut path));
+
+        let tuple: Result<TupleValues, de::value::Error> =
+            de::Deserialize::deserialize(PathDeserializer::new(&path));
+        assert!(tuple
+            .unwrap_err()
+            .to_string()
+            .contains("path and tuple lengths don't match"));
+    }
+
+    #[test]
+    fn captured_values_reject_nested_structs() {
+        #[allow(dead_code)]
+        #[derive(Debug, Deserialize)]
+        struct Nested {
+            value: String,
+        }
+
+        #[allow(dead_code)]
+        #[derive(Debug, Deserialize)]
+        struct StructValues {
+            tail: Nested,
+        }
+
+        let resource = ResourceDef::new("/path/{tail}*");
+        let mut path = Path::new("/path/one/two/three");
+        assert!(resource.capture_match_info(&mut path));
+
+        let nested: Result<StructValues, de::value::Error> =
+            de::Deserialize::deserialize(PathDeserializer::new(&path));
+        assert!(nested
+            .unwrap_err()
+            .to_string()
+            .contains("unsupported type: struct"));
     }
 
     #[test]
@@ -797,23 +962,65 @@ mod tests {
 
         let s: Result<Test1, de::value::Error> =
             de::Deserialize::deserialize(PathDeserializer::new(&path));
-        assert!(s.is_err());
-        assert!(format!("{:?}", s).contains("wrong number of parameters"));
+        assert!(s
+            .unwrap_err()
+            .to_string()
+            .contains("wrong number of parameters"));
 
         let s: Result<Test2, de::value::Error> =
             de::Deserialize::deserialize(PathDeserializer::new(&path));
-        assert!(s.is_err());
-        assert!(format!("{:?}", s).contains("can not parse"));
+        assert!(s.unwrap_err().to_string().contains("can not parse"));
 
         let s: Result<(String, String), de::value::Error> =
             de::Deserialize::deserialize(PathDeserializer::new(&path));
-        assert!(s.is_err());
-        assert!(format!("{:?}", s).contains("wrong number of parameters"));
+        assert!(s
+            .unwrap_err()
+            .to_string()
+            .contains("wrong number of parameters"));
 
         let s: Result<u32, de::value::Error> =
             de::Deserialize::deserialize(PathDeserializer::new(&path));
-        assert!(s.is_err());
-        assert!(format!("{:?}", s).contains("can not parse"));
+        assert!(s.unwrap_err().to_string().contains("can not parse"));
+
+        let option: Result<Option<String>, de::value::Error> =
+            de::Deserialize::deserialize(PathDeserializer::new(&path));
+        assert!(option
+            .unwrap_err()
+            .to_string()
+            .contains("unsupported type: Option<T>"));
+
+        let ignored: Result<de::IgnoredAny, de::value::Error> =
+            de::Deserialize::deserialize(PathDeserializer::new(&path));
+        assert!(ignored
+            .unwrap_err()
+            .to_string()
+            .contains("unsupported type: ignored_any"));
+
+        struct IdentifierVisitor;
+
+        impl<'de> Visitor<'de> for IdentifierVisitor {
+            type Value = ();
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("an identifier")
+            }
+
+            fn visit_str<E>(self, _: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(())
+            }
+        }
+
+        let identifier = serde::Deserializer::deserialize_identifier(
+            PathDeserializer::new(&path),
+            IdentifierVisitor,
+        );
+        assert!(identifier
+            .unwrap_err()
+            .to_string()
+            .contains("unsupported type: identifier"));
     }
 
     #[test]
@@ -847,6 +1054,27 @@ mod tests {
 
     #[test]
     fn deserialize_path_decode_map() {
+        use std::collections::HashMap;
+
+        use serde::de::{MapAccess, Visitor};
+
+        struct ValueBeforeKey;
+
+        impl<'de> Visitor<'de> for ValueBeforeKey {
+            type Value = ();
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("a map")
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                map.next_value::<String>().map(|_| ())
+            }
+        }
+
         #[derive(Deserialize)]
         struct Vals {
             key: String,
@@ -861,6 +1089,14 @@ mod tests {
         let vals: Vals = serde::Deserialize::deserialize(de).unwrap();
         assert_eq!(vals.key, "%");
         assert_eq!(vals.value, "/");
+
+        let vals: Result<HashMap<String, String>, de::value::Error> =
+            de::Deserialize::deserialize(PathDeserializer::new(&path));
+        assert!(vals.unwrap_err().to_string().contains("Unexpected"));
+
+        let vals =
+            serde::Deserializer::deserialize_map(PathDeserializer::new(&path), ValueBeforeKey);
+        assert!(vals.unwrap_err().to_string().contains("unexpected item"));
     }
 
     #[test]
@@ -974,6 +1210,42 @@ mod tests {
         let vals: Vals = serde::Deserialize::deserialize(de).unwrap();
         assert_eq!(vals.key, AnyEnumCustom::Int(123));
         assert_eq!(vals.value, AnyEnumDerive::String("/".to_string()));
+
+        let rdef = ResourceDef::new("/{key}");
+
+        let mut path = Path::new("/4294967296");
+        rdef.capture_match_info(&mut path);
+        let segment: AnyEnumCustom =
+            serde::Deserialize::deserialize(PathDeserializer::new(&path)).unwrap();
+        assert_eq!(
+            segment,
+            AnyEnumCustom::String("some str: 4294967296".to_string())
+        );
+
+        let mut path = Path::new("/-123");
+        rdef.capture_match_info(&mut path);
+        let segment: AnyEnumCustom =
+            serde::Deserialize::deserialize(PathDeserializer::new(&path)).unwrap();
+        assert_eq!(segment, AnyEnumCustom::String("some str: -123".to_string()));
+
+        let mut path = Path::new("/-2147483649");
+        rdef.capture_match_info(&mut path);
+        let segment: AnyEnumCustom =
+            serde::Deserialize::deserialize(PathDeserializer::new(&path)).unwrap();
+        assert_eq!(
+            segment,
+            AnyEnumCustom::String("some str: -2147483649".to_string())
+        );
+
+        let mut path = Path::new("/one/two");
+        let rdef = ResourceDef::new("/{key}/{value}");
+        rdef.capture_match_info(&mut path);
+        let result: Result<AnyEnumCustom, de::value::Error> =
+            serde::Deserialize::deserialize(PathDeserializer::new(&path));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("wrong number of parameters"));
     }
 
     #[test]

--- a/actix-router/src/path.rs
+++ b/actix-router/src/path.rs
@@ -299,6 +299,7 @@ mod tests {
     use std::cell::RefCell;
 
     use super::*;
+    use crate::ResourceDef;
 
     #[allow(clippy::needless_borrow)]
     #[test]
@@ -308,5 +309,99 @@ mod tests {
 
         let foo = RefCell::new(foo);
         let _ = foo.borrow_mut().resource_path();
+    }
+
+    #[test]
+    #[expect(deprecated)]
+    fn path_accessors_reflect_processed_state() {
+        let mut path = Path::new("/user/alice".to_owned());
+
+        assert_eq!(path.get_ref(), "/user/alice");
+        assert_eq!(path.as_str(), "/user/alice");
+        assert_eq!(path.unprocessed(), "/user/alice");
+
+        path.skip(6);
+        assert_eq!(path.unprocessed(), "alice");
+        assert_eq!(path.path(), "alice");
+
+        path.get_mut().push_str("/profile");
+        assert_eq!(path.as_str(), "/user/alice/profile");
+        assert_eq!(path.unprocessed(), "alice/profile");
+    }
+
+    #[test]
+    fn captured_static_segments_are_queryable() {
+        let mut path = Path::new("/user/alice");
+
+        path.add_static("kind", "user");
+        assert!(!path.is_empty());
+        assert_eq!(path.segment_count(), 1);
+        assert_eq!(path.get("kind"), Some("user"));
+        assert_eq!(path.query("kind"), "user");
+        assert_eq!(path.query("missing"), "");
+        assert_eq!(&path["kind"], "user");
+        assert_eq!(&path[0], "user");
+        assert_eq!(path.iter().collect::<Vec<_>>(), vec![("kind", "user")]);
+        assert!(path.iter().nth(1).is_none());
+    }
+
+    #[test]
+    fn set_replaces_path_state() {
+        let mut path = Path::new("/user/alice".to_owned());
+        path.skip(6);
+        path.add_static("kind", "user");
+
+        path.set("/new".to_owned());
+        assert_eq!(path.as_str(), "/new");
+        assert_eq!(path.unprocessed(), "/new");
+        assert!(path.is_empty());
+        assert_eq!(path.segment_count(), 0);
+    }
+
+    #[test]
+    fn reset_clears_captured_state() {
+        let mut path = Path::new("/new");
+        path.skip(1);
+        path.add_static("kind", "new");
+
+        path.reset();
+        assert!(path.is_empty());
+        assert_eq!(path.unprocessed(), "/new");
+    }
+
+    #[test]
+    #[expect(deprecated)]
+    fn deprecated_path_clamps_oversized_skip() {
+        let mut path = Path::new("/new");
+        path.skip(100);
+        assert_eq!(path.path(), "");
+    }
+
+    #[test]
+    fn remapping_preserves_valid_utf8_boundaries() {
+        let resource = ResourceDef::new("/{id}/{kind}");
+        let mut path = Path::new("/abc/def".to_owned());
+        assert!(resource.capture_match_info(&mut path));
+
+        path.update_with_reindex("/é".to_owned(), |index| match index {
+            1 => 3,
+            4 => 2,
+            5 => 1,
+            index => index,
+        });
+
+        assert_eq!(path.unprocessed(), "");
+        assert_eq!(path.get("id"), Some(""));
+        assert_eq!(path.get("kind"), Some("é"));
+    }
+
+    #[test]
+    fn path_load_deserializes_captured_values() {
+        let resource = ResourceDef::new("/{id}");
+        let mut path = Path::new("/123");
+        assert!(resource.capture_match_info(&mut path));
+
+        let id: u32 = path.load().unwrap();
+        assert_eq!(id, 123);
     }
 }

--- a/actix-router/src/pattern.rs
+++ b/actix-router/src/pattern.rs
@@ -90,3 +90,66 @@ array_patterns_multiple!(&str, |&v| v.to_owned(), 2 3 4 5 6 7 8 9 10 11 12 13 14
 
 array_patterns_single!(String);
 array_patterns_multiple!(String, |v| v.clone(), 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16);
+
+#[cfg(test)]
+mod tests {
+    use bytestring::ByteString;
+
+    use super::*;
+
+    #[test]
+    fn empty_patterns_are_distinguished_from_single_patterns() {
+        assert!(!Patterns::Single("/one".to_owned()).is_empty());
+        assert!(Patterns::List(Vec::new()).is_empty());
+        assert!(!Patterns::List(vec!["/one".to_owned()]).is_empty());
+    }
+
+    #[test]
+    fn supported_inputs_convert_to_patterns() {
+        let owned = "/owned".to_owned();
+        assert_eq!(owned.patterns(), Patterns::Single("/owned".to_owned()));
+        let owned_ref = &owned;
+        assert_eq!(owned_ref.patterns(), Patterns::Single("/owned".to_owned()));
+
+        let str_value: &str = "/str";
+        assert_eq!(
+            <str as IntoPatterns>::patterns(str_value),
+            Patterns::Single("/str".to_owned())
+        );
+        let ref_value: &str = "/ref";
+        assert_eq!(
+            <&str as IntoPatterns>::patterns(&ref_value),
+            Patterns::Single("/ref".to_owned())
+        );
+
+        let bytes = ByteString::from("/bytes");
+        assert_eq!(bytes.patterns(), Patterns::Single("/bytes".to_owned()));
+
+        let original = Patterns::List(vec!["/first".to_owned(), "/second".to_owned()]);
+        assert_eq!(original.patterns(), original);
+
+        assert_eq!(vec!["/one"].patterns(), Patterns::Single("/one".to_owned()));
+        assert_eq!(
+            vec!["/one", "/two"].patterns(),
+            Patterns::List(vec!["/one".to_owned(), "/two".to_owned()])
+        );
+        assert_eq!(
+            vec!["/one".to_owned()].patterns(),
+            Patterns::Single("/one".to_owned())
+        );
+
+        assert_eq!(["/one"].patterns(), Patterns::Single("/one".to_owned()));
+        assert_eq!(
+            ["/one", "/two"].patterns(),
+            Patterns::List(vec!["/one".to_owned(), "/two".to_owned()])
+        );
+        assert_eq!(
+            ["/one".to_owned()].patterns(),
+            Patterns::Single("/one".to_owned())
+        );
+        assert_eq!(
+            ["/one".to_owned(), "/two".to_owned()].patterns(),
+            Patterns::List(vec!["/one".to_owned(), "/two".to_owned()])
+        );
+    }
+}

--- a/actix-router/src/resource.rs
+++ b/actix-router/src/resource.rs
@@ -1142,10 +1142,85 @@ mod tests {
 
         assert_eq!(ResourceDef::new("/"), ResourceDef::new(["/"]));
         assert_eq!(ResourceDef::new("/"), ResourceDef::new(vec!["/"]));
+        assert_eq!(
+            ResourceDef::from("/from-str"),
+            ResourceDef::new("/from-str")
+        );
+        assert_eq!(
+            ResourceDef::from("/from-string".to_owned()),
+            ResourceDef::new("/from-string")
+        );
 
         assert_ne!(ResourceDef::new(""), ResourceDef::prefix(""));
         assert_ne!(ResourceDef::new("/"), ResourceDef::prefix("/"));
         assert_ne!(ResourceDef::new("/{id}"), ResourceDef::prefix("/{id}"));
+    }
+
+    #[test]
+    fn metadata_accessors_update_resource_identity() {
+        let mut resource = ResourceDef::new("/root");
+        assert_eq!(resource.id(), 0);
+        resource.set_id(42);
+        assert_eq!(resource.id(), 42);
+        assert!(!resource.is_prefix());
+
+        assert!(resource.name().is_none());
+        resource.set_name("root");
+        assert_eq!(resource.name(), Some("root"));
+    }
+
+    #[test]
+    fn pattern_iterators_report_registered_patterns() {
+        let resource = ResourceDef::new("/root");
+        assert_eq!(resource.pattern(), Some("/root"));
+        let mut patterns = resource.pattern_iter();
+        assert_eq!(patterns.size_hint(), (1, Some(1)));
+        assert_eq!(patterns.next(), Some("/root"));
+        assert_eq!(patterns.next(), None);
+
+        let resource = ResourceDef::new(["/first", "/second"]);
+        assert_eq!(resource.pattern(), Some("/first"));
+        let mut patterns = resource.pattern_iter();
+        assert_eq!(patterns.size_hint(), (2, Some(2)));
+        assert_eq!(patterns.next(), Some("/first"));
+        assert_eq!(patterns.next(), Some("/second"));
+        assert_eq!(patterns.next(), None);
+        assert_eq!(patterns.next(), None);
+    }
+
+    #[test]
+    fn empty_pattern_sets_never_match() {
+        let empty = ResourceDef::new(Vec::<&str>::new());
+        assert_eq!(empty.pattern(), None);
+        assert_eq!(empty.pattern_iter().next(), None);
+        assert!(!empty.is_match("/root"));
+        assert_eq!(empty.find_match("/root"), None);
+    }
+
+    #[test]
+    fn equal_resources_have_equal_hashes() {
+        fn hash(resource: &ResourceDef) -> u64 {
+            let mut hasher = std::collections::hash_map::DefaultHasher::new();
+            resource.hash(&mut hasher);
+            hasher.finish()
+        }
+
+        let mut first = ResourceDef::new("/root");
+        first.set_id(1);
+        first.set_name("first");
+
+        let mut second = ResourceDef::new("/root");
+        second.set_id(2);
+        second.set_name("second");
+
+        assert_eq!(first, second);
+        assert_eq!(hash(&first), hash(&second));
+    }
+
+    #[test]
+    #[should_panic(expected = "resource name should not be empty")]
+    fn empty_resource_names_are_rejected() {
+        ResourceDef::new("/root").set_name("");
     }
 
     #[test]
@@ -1368,6 +1443,26 @@ mod tests {
         assert_eq!(path.get("id").unwrap(), "2345");
         assert_eq!(path.get("tail").unwrap(), "sdg");
         assert_eq!(path.unprocessed(), "");
+    }
+
+    #[test]
+    fn capture_check_can_reject_a_match_without_mutating_path() {
+        let resource = ResourceDef::prefix("/user/{id}");
+        let mut path = Path::new("/user/admin/stars");
+
+        assert!(
+            !resource.capture_match_info_fn(&mut path, |path| { !path.as_str().contains("admin") })
+        );
+        assert_eq!(path.unprocessed(), "/user/admin/stars");
+        assert!(path.is_empty());
+    }
+
+    #[test]
+    fn dynamic_set_capture_rejects_unmatched_paths() {
+        let resource = ResourceDef::new(["/user/{id}", r"/number/{id:\d+}"]);
+        let mut path = Path::new("/");
+        assert!(!resource.capture_match_info(&mut path));
+        assert_eq!(path.unprocessed(), "/");
     }
 
     #[allow(clippy::literal_string_with_formatting_args)]

--- a/actix-router/src/resource_path.rs
+++ b/actix-router/src/resource_path.rs
@@ -42,3 +42,30 @@ impl ResourcePath for http::Uri {
         self.path()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use bytestring::ByteString;
+
+    use super::*;
+
+    #[test]
+    fn resource_path_implementations_expose_their_path() {
+        let owned = "/owned".to_owned();
+        assert_eq!(<String as ResourcePath>::path(&owned), "/owned");
+
+        let borrowed = "/borrowed";
+        assert_eq!(<&str as ResourcePath>::path(&borrowed), "/borrowed");
+
+        let bytes = ByteString::from("/bytes");
+        assert_eq!(<ByteString as ResourcePath>::path(&bytes), "/bytes");
+    }
+
+    #[cfg(feature = "http")]
+    #[test]
+    fn uri_resource_path_ignores_queries() {
+        let uri = http::Uri::from_static("/resource?query=value");
+
+        assert_eq!(<http::Uri as ResourcePath>::path(&uri), "/resource");
+    }
+}

--- a/actix-router/src/router.rs
+++ b/actix-router/src/router.rs
@@ -142,6 +142,7 @@ mod tests {
     use crate::{
         path::Path,
         router::{ResourceId, Router},
+        ResourceDef,
     };
 
     #[allow(clippy::cognitive_complexity)]
@@ -279,5 +280,76 @@ mod tests {
         let (h, _) = router.recognize_mut(&mut path).unwrap();
         assert_eq!(*h, 11);
         assert_eq!(&path["val"], "ttt");
+    }
+
+    #[test]
+    fn builder_methods_expose_mutable_registration_parts() {
+        let mut builder = Router::<u8, bool>::build();
+        let (resource, value, context) = builder.prefix("/prefix", 1);
+        resource.set_id(7);
+        *value = 2;
+        *context = true;
+
+        let (resource, value, context) = builder.rdef(ResourceDef::new("/exact"), 3);
+        resource.set_id(8);
+        *value = 4;
+        assert!(!*context);
+
+        let router = builder.finish();
+
+        let mut path = Path::new("/prefix/child");
+        let (value, id) = router.recognize(&mut path).unwrap();
+        assert_eq!(*value, 2);
+        assert_eq!(id, ResourceId(7));
+        assert_eq!(path.unprocessed(), "/child");
+
+        let mut path = Path::new("/exact");
+        let (value, id) = router.recognize(&mut path).unwrap();
+        assert_eq!(*value, 4);
+        assert_eq!(id, ResourceId(8));
+    }
+
+    #[test]
+    fn recognize_fn_filters_matches_using_context() {
+        let mut builder = Router::<u8, bool>::build();
+        *builder.prefix("/prefix", 2).2 = true;
+        builder.path("/exact", 4);
+        let router = builder.finish();
+
+        let mut path = Path::new("/prefix/child");
+        let (value, _) = router
+            .recognize_fn(&mut path, |resource, allowed| {
+                resource.as_str().starts_with("/prefix") && *allowed
+            })
+            .unwrap();
+        assert_eq!(*value, 2);
+        assert_eq!(path.unprocessed(), "/child");
+
+        let mut path = Path::new("/exact");
+        assert!(router
+            .recognize_fn(&mut path, |_, allowed| *allowed)
+            .is_none());
+        assert_eq!(path.unprocessed(), "/exact");
+    }
+
+    #[test]
+    fn recognize_mut_fn_returns_mutable_values() {
+        let mut builder = Router::<u8, bool>::build();
+        let (resource, _, context) = builder.prefix("/prefix", 2);
+        resource.set_id(7);
+        *context = true;
+        let mut router = builder.finish();
+
+        let mut path = Path::new("/prefix/child");
+        let (value, id) = router
+            .recognize_mut_fn(&mut path, |_, allowed| *allowed)
+            .unwrap();
+        *value = 9;
+        assert_eq!(id, ResourceId(7));
+        assert_eq!(path.unprocessed(), "/child");
+
+        let mut path = Path::new("/prefix/child");
+        let (value, _) = router.recognize(&mut path).unwrap();
+        assert_eq!(*value, 9);
     }
 }

--- a/actix-router/src/url.rs
+++ b/actix-router/src/url.rs
@@ -140,4 +140,39 @@ mod tests {
         // We should always get a valid utf8 string
         assert!(String::from_utf8(path.as_str().as_bytes().to_owned()).is_ok());
     }
+
+    #[test]
+    fn url_updates_replace_uri() {
+        let initial = Uri::from_static("/initial%20path");
+        let mut url = Url::new(initial.clone());
+
+        assert_eq!(url.uri(), &initial);
+        assert_eq!(url.path(), "/initial path");
+        assert_eq!(<Url as ResourcePath>::path(&url), "/initial path");
+
+        let updated = Uri::from_static("/updated%20path");
+        url.update(&updated);
+        assert_eq!(url.uri(), &updated);
+        assert_eq!(url.path(), "/updated path");
+    }
+
+    #[test]
+    fn custom_quoter_preserves_protected_bytes() {
+        let custom_quoter = Quoter::new(b"", b"-");
+        let initial = Uri::from_static("/initial%2Dpath");
+        let mut url = Url::new_with_quoter(initial, &custom_quoter);
+        assert_eq!(url.path(), "/initial%2Dpath");
+
+        let updated = Uri::from_static("/updated%2Dpath");
+        url.update_with_quoter(&updated, &custom_quoter);
+        assert_eq!(url.uri(), &updated);
+        assert_eq!(url.path(), "/updated%2Dpath");
+    }
+
+    #[test]
+    fn default_url_uses_root_path() {
+        let default = Url::default();
+        assert_eq!(default.uri(), &Uri::default());
+        assert_eq!(default.path(), "/");
+    }
 }


### PR DESCRIPTION
## Summary

- Add semantic tests for actix-router path state, pattern conversions, resource paths, URLs, resource metadata, router recognition, and deserialization behavior.
- Raise all-features line coverage from 84.46% to 98.38%.
- Keep production behavior unchanged.

## Validation

- 74 all-features tests passed.
- 66 no-default-feature tests passed.
- 25 doctests passed.
- Nightly llvm-cov report: 98.38% lines, 98.94% regions, 98.08% functions.
- Formatting and targeted Clippy passed; Clippy reports only existing redundant-borrow warnings.
