### PR TITLE
fix(files): avoid file reads for HEAD responses

### DIFF
--- a/actix-files/src/lib.rs
+++ b/actix-files/src/lib.rs
@@ -598,6 +598,9 @@ mod tests {
             .unwrap();
 
         assert_eq!(content_length, "100");
+
+        drop(response);
+        srv.stop().await;
     }
 
     #[actix_rt::test]

--- a/actix-files/src/named.rs
+++ b/actix-files/src/named.rs
@@ -1,12 +1,15 @@
 use std::{
+    convert::Infallible,
     fs::Metadata,
     io,
     path::{Path, PathBuf},
+    pin::Pin,
+    task::{Context, Poll},
     time::{SystemTime, UNIX_EPOCH},
 };
 
 use actix_web::{
-    body::{self, BoxBody, SizedStream},
+    body::{self, BodySize, BoxBody, MessageBody, SizedStream},
     dev::{
         self, AppService, HttpServiceFactory, ResourceDef, Service, ServiceFactory, ServiceRequest,
         ServiceResponse,
@@ -16,11 +19,12 @@ use actix_web::{
             self, Charset, ContentDisposition, ContentEncoding, DispositionParam, DispositionType,
             ExtendedValue,
         },
-        StatusCode,
+        Method, StatusCode,
     },
     Error, HttpMessage, HttpRequest, HttpResponse, Responder,
 };
 use bitflags::bitflags;
+use bytes::Bytes;
 use derive_more::{Deref, DerefMut};
 use futures_core::future::LocalBoxFuture;
 use mime::Mime;
@@ -40,6 +44,24 @@ bitflags! {
 impl Default for Flags {
     fn default() -> Self {
         Flags::from_bits_truncate(0b0000_1111)
+    }
+}
+
+/// Empty response body that reports the representation length of a HEAD request.
+struct HeadBody(u64);
+
+impl MessageBody for HeadBody {
+    type Error = Infallible;
+
+    fn size(&self) -> BodySize {
+        BodySize::Sized(self.0)
+    }
+
+    fn poll_next(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Bytes, Self::Error>>> {
+        Poll::Ready(None)
     }
 }
 
@@ -514,6 +536,10 @@ impl NamedFile {
                 res.insert_header((header::CONTENT_ENCODING, current_encoding.as_str()));
             }
 
+            if req.method() == Method::HEAD {
+                return res.body(HeadBody(self.md.len()));
+            }
+
             let reader =
                 chunked::new_chunked_read(self.md.len(), 0, self.file, self.read_mode_threshold);
 
@@ -636,11 +662,15 @@ impl NamedFile {
                 .map_into_boxed_body();
         }
 
-        let reader = chunked::new_chunked_read(length, offset, self.file, self.read_mode_threshold);
-
         if ranged_req {
             res.status(StatusCode::PARTIAL_CONTENT);
         }
+
+        if req.method() == Method::HEAD {
+            return res.body(HeadBody(length));
+        }
+
+        let reader = chunked::new_chunked_read(length, offset, self.file, self.read_mode_threshold);
 
         res.body(SizedStream::new(length, reader))
     }


### PR DESCRIPTION
## Summary

- Return HEAD responses with the same status and representation length without constructing a streaming file reader.
- Drop the test response and await `TestServer::stop` so test teardown is explicit.
- Add no executor or runtime dependency.

## Root cause

The focused diagnosis in #4195 showed that this HEAD request can finish at the client while its Linux io-uring file read is pending. Actix Files constructed the same streaming body as for GET. The HTTP dispatcher then suppressed and dropped that body to implement HEAD semantics, which could cancel an active io-uring read. glibc later detected allocator damage during server-thread tcache cleanup.

Awaiting the existing forced `TestServer::stop` alone did not fix the failure: Linux stable reproduced the same SIGABRT in run 32096821992. The cancellation can occur when the dispatcher drops the unused HEAD body, before test shutdown begins.

The corrected response path uses an empty body that reports the representation length. The encoder therefore emits the correct `Content-Length`, but no file reader exists to poll or cancel. The test also uses the existing async shutdown API and awaits full server teardown.

## Validation

- `cargo +nightly fmt --check`
- `git diff --check`
- io-uring tests: https://github.com/actix/actix-web/actions/runs/32097616137/job/95591976444
- Linux stable: https://github.com/actix/actix-web/actions/runs/32097616137/job/95592028422
- Linux MSRV: https://github.com/actix/actix-web/actions/runs/32097616137/job/95592028548
