### PR TITLE
refactor(files)!: remove experimental io-uring support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,24 +93,6 @@ jobs:
         if: matrix.version.name == 'stable' && matrix.target.os == 'ubuntu-latest'
         uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
 
-  io-uring:
-    name: io-uring tests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - name: Install Rust
-        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
-        with:
-          toolchain: nightly
-
-      - name: tests (io-uring)
-        timeout-minutes: 30
-        run: >
-          sudo bash -c "ulimit -Sl 512 && ulimit -Hl 512 && PATH=$PATH:/usr/share/rust/.cargo/bin && RUSTUP_TOOLCHAIN=stable cargo test --lib --tests -p=actix-files --all-features"
-
   rustdoc:
     name: doc tests
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,6 @@ version = "0.6.10"
 dependencies = [
  "actix-http",
  "actix-rt",
- "actix-server",
  "actix-service",
  "actix-test",
  "actix-utils",
@@ -43,7 +42,6 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "tempfile",
- "tokio-uring",
  "v_htmlescape",
 ]
 
@@ -3434,7 +3432,6 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "748482e3e13584a34664a710168ad5068e8cb1d968aa4ffa887e83ca6dd27967"
 dependencies = [
- "bytes",
  "futures-util",
  "io-uring",
  "libc",

--- a/actix-files/CHANGES.md
+++ b/actix-files/CHANGES.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Remove the experimental `experimental-io-uring` crate feature and its implementation.
+- Remove the `NamedFile::open_async` method. Use `NamedFile::open` instead. This breaking API change requires the next major Actix Files release (`0.7`).
 - Add support for passing multiple root directories to `Files::new`. [#3402]
 - Add `Files::try_compressed()` to support serving pre-compressed static files [#2615]
 - Fix handling of `bytes=0-`

--- a/actix-files/CHANGES.md
+++ b/actix-files/CHANGES.md
@@ -2,8 +2,7 @@
 
 ## Unreleased
 
-- Remove the experimental `experimental-io-uring` crate feature and its implementation.
-- Remove the `NamedFile::open_async` method. Use `NamedFile::open` instead. This breaking API change requires the next major Actix Files release (`0.7`).
+- Remove the experimental `experimental-io-uring` crate feature and its implementation, including the `NamedFile::open_async()` method.
 - Add support for passing multiple root directories to `Files::new`. [#3402]
 - Add `Files::try_compressed()` to support serving pre-compressed static files [#2615]
 - Fix handling of `bytes=0-`

--- a/actix-files/CHANGES.md
+++ b/actix-files/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Remove the experimental `experimental-io-uring` crate feature and its implementation.
 - Add support for passing multiple root directories to `Files::new`. [#3402]
 - Add `Files::try_compressed()` to support serving pre-compressed static files [#2615]
 - Fix handling of `bytes=0-`

--- a/actix-files/Cargo.toml
+++ b/actix-files/Cargo.toml
@@ -13,9 +13,6 @@ edition = "2021"
 [package.metadata.cargo_check_external_types]
 allowed_external_types = ["actix_http::*", "actix_service::*", "actix_web::*", "http::*", "mime::*"]
 
-[features]
-experimental-io-uring = ["actix-web/experimental-io-uring", "tokio-uring"]
-
 [dependencies]
 actix-http = "3"
 actix-service = "2"
@@ -33,11 +30,6 @@ mime_guess = "2.0.1"
 percent-encoding = "2.1"
 pin-project-lite = "0.2.7"
 v_htmlescape = "0.17"
-
-# experimental-io-uring
-[target.'cfg(target_os = "linux")'.dependencies]
-tokio-uring = { version = "0.5", optional = true, features = ["bytes"] }
-actix-server = { version = "2.4", optional = true } # ensure matching tokio-uring versions
 
 [dev-dependencies]
 actix-rt = "2.7"

--- a/actix-files/src/chunked.rs
+++ b/actix-files/src/chunked.rs
@@ -7,8 +7,6 @@ use std::{
 };
 
 use actix_web::{error::Error, web::Bytes};
-#[cfg(feature = "experimental-io-uring")]
-use bytes::BytesMut;
 use futures_core::{ready, Stream};
 use pin_project_lite::pin_project;
 
@@ -34,22 +32,11 @@ pin_project! {
     }
 }
 
-#[cfg(not(feature = "experimental-io-uring"))]
 pin_project! {
     #[project = ChunkedReadFileStateProj]
     #[project_replace = ChunkedReadFileStateProjReplace]
     enum ChunkedReadFileState<Fut> {
         File { file: Option<File>, },
-        Future { #[pin] fut: Fut },
-    }
-}
-
-#[cfg(feature = "experimental-io-uring")]
-pin_project! {
-    #[project = ChunkedReadFileStateProj]
-    #[project_replace = ChunkedReadFileStateProjReplace]
-    enum ChunkedReadFileState<Fut> {
-        File { file: Option<(File, BytesMut)> },
         Future { #[pin] fut: Fut },
     }
 }
@@ -69,12 +56,7 @@ pub(crate) fn new_chunked_read(
     ChunkedReadFile {
         size,
         offset,
-        #[cfg(not(feature = "experimental-io-uring"))]
         state: ChunkedReadFileState::File { file: Some(file) },
-        #[cfg(feature = "experimental-io-uring")]
-        state: ChunkedReadFileState::File {
-            file: Some((file, BytesMut::new())),
-        },
         counter: 0,
         callback: chunked_read_file_callback,
         read_mode: if size < read_mode_threshold {
@@ -85,7 +67,6 @@ pub(crate) fn new_chunked_read(
     }
 }
 
-#[cfg(not(feature = "experimental-io-uring"))]
 fn chunked_read_file_callback_sync(
     mut file: File,
     offset: u64,
@@ -106,7 +87,6 @@ fn chunked_read_file_callback_sync(
     }
 }
 
-#[cfg(not(feature = "experimental-io-uring"))]
 #[inline]
 async fn chunked_read_file_callback(
     file: File,
@@ -125,77 +105,6 @@ async fn chunked_read_file_callback(
     Ok(res)
 }
 
-#[cfg(feature = "experimental-io-uring")]
-async fn chunked_read_file_callback(
-    file: File,
-    offset: u64,
-    max_bytes: usize,
-    mut bytes_mut: BytesMut,
-) -> io::Result<(File, Bytes, BytesMut)> {
-    bytes_mut.reserve(max_bytes);
-
-    let (res, mut bytes_mut) = file.read_at(bytes_mut, offset).await;
-    let n_bytes = res?;
-
-    if n_bytes == 0 {
-        return Err(io::ErrorKind::UnexpectedEof.into());
-    }
-
-    let bytes = bytes_mut.split_to(n_bytes).freeze();
-
-    Ok((file, bytes, bytes_mut))
-}
-
-#[cfg(feature = "experimental-io-uring")]
-impl<F, Fut> Stream for ChunkedReadFile<F, Fut>
-where
-    F: Fn(File, u64, usize, BytesMut) -> Fut,
-    Fut: Future<Output = io::Result<(File, Bytes, BytesMut)>>,
-{
-    type Item = Result<Bytes, Error>;
-
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        let mut this = self.as_mut().project();
-        match this.state.as_mut().project() {
-            ChunkedReadFileStateProj::File { file } => {
-                let size = *this.size;
-                let offset = *this.offset;
-                let counter = *this.counter;
-
-                if size == counter {
-                    Poll::Ready(None)
-                } else {
-                    let max_bytes = cmp::min(size.saturating_sub(counter), 65_536) as usize;
-
-                    let (file, bytes_mut) = file
-                        .take()
-                        .expect("ChunkedReadFile polled after completion");
-
-                    let fut = (this.callback)(file, offset, max_bytes, bytes_mut);
-
-                    this.state
-                        .project_replace(ChunkedReadFileState::Future { fut });
-
-                    self.poll_next(cx)
-                }
-            }
-            ChunkedReadFileStateProj::Future { fut } => {
-                let (file, bytes, bytes_mut) = ready!(fut.poll(cx))?;
-
-                this.state.project_replace(ChunkedReadFileState::File {
-                    file: Some((file, bytes_mut)),
-                });
-
-                *this.offset += bytes.len() as u64;
-                *this.counter += bytes.len() as u64;
-
-                Poll::Ready(Some(Ok(bytes)))
-            }
-        }
-    }
-}
-
-#[cfg(not(feature = "experimental-io-uring"))]
 impl<F, Fut> Stream for ChunkedReadFile<F, Fut>
 where
     F: Fn(File, u64, usize, ReadMode) -> Fut,

--- a/actix-files/src/files.rs
+++ b/actix-files/src/files.rs
@@ -368,8 +368,6 @@ impl Files {
     /// Tweaking this value according to your expected usage may lead to significant performance
     /// gains (or losses in other handlers, if `size` is too high).
     ///
-    /// When the `experimental-io-uring` crate feature is enabled, file reads are always async.
-    ///
     /// Default is 0, meaning all files are read asynchronously.
     pub fn read_mode_threshold(mut self, size: u64) -> Self {
         self.read_mode_threshold = size;

--- a/actix-files/src/files.rs
+++ b/actix-files/src/files.rs
@@ -460,7 +460,7 @@ impl Files {
     ///     .index_file("index.html")
     ///     .default_handler(fn_service(|req: ServiceRequest| async {
     ///         let (req, _) = req.into_parts();
-    ///         let file = NamedFile::open_async("./static/404.html").await?;
+    ///         let file = NamedFile::open("./static/404.html")?;
     ///         let res = file.into_response(&req);
     ///         Ok(ServiceResponse::new(req, res))
     ///     }));

--- a/actix-files/src/lib.rs
+++ b/actix-files/src/lib.rs
@@ -110,7 +110,7 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_if_modified_since_without_if_none_match() {
-        let file = NamedFile::open_async("Cargo.toml").await.unwrap();
+        let file = NamedFile::open("Cargo.toml").unwrap();
         let since = header::HttpDate::from(SystemTime::now().add(Duration::from_secs(60)));
 
         let req = TestRequest::default()
@@ -122,7 +122,7 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_if_modified_since_without_if_none_match_same() {
-        let file = NamedFile::open_async("Cargo.toml").await.unwrap();
+        let file = NamedFile::open("Cargo.toml").unwrap();
         let since = file.last_modified().unwrap();
 
         let req = TestRequest::default()
@@ -134,7 +134,7 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_if_modified_since_with_if_none_match() {
-        let file = NamedFile::open_async("Cargo.toml").await.unwrap();
+        let file = NamedFile::open("Cargo.toml").unwrap();
         let since = header::HttpDate::from(SystemTime::now().add(Duration::from_secs(60)));
 
         let req = TestRequest::default()
@@ -147,7 +147,7 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_if_unmodified_since() {
-        let file = NamedFile::open_async("Cargo.toml").await.unwrap();
+        let file = NamedFile::open("Cargo.toml").unwrap();
         let since = file.last_modified().unwrap();
 
         let req = TestRequest::default()
@@ -159,7 +159,7 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_if_unmodified_since_failed() {
-        let file = NamedFile::open_async("Cargo.toml").await.unwrap();
+        let file = NamedFile::open("Cargo.toml").unwrap();
         let since = header::HttpDate::from(SystemTime::UNIX_EPOCH);
 
         let req = TestRequest::default()
@@ -171,8 +171,8 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_named_file_text() {
-        assert!(NamedFile::open_async("test--").await.is_err());
-        let mut file = NamedFile::open_async("Cargo.toml").await.unwrap();
+        assert!(NamedFile::open("test--").is_err());
+        let mut file = NamedFile::open("Cargo.toml").unwrap();
         {
             file.file();
             let _f: &File = &file;
@@ -195,8 +195,8 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_named_file_content_disposition() {
-        assert!(NamedFile::open_async("test--").await.is_err());
-        let mut file = NamedFile::open_async("Cargo.toml").await.unwrap();
+        assert!(NamedFile::open("test--").is_err());
+        let mut file = NamedFile::open("Cargo.toml").unwrap();
         {
             file.file();
             let _f: &File = &file;
@@ -212,8 +212,7 @@ mod tests {
             "inline; filename=\"Cargo.toml\""
         );
 
-        let file = NamedFile::open_async("Cargo.toml")
-            .await
+        let file = NamedFile::open("Cargo.toml")
             .unwrap()
             .disable_content_disposition();
         let req = TestRequest::default().to_http_request();
@@ -248,8 +247,7 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_named_file_set_content_type() {
-        let mut file = NamedFile::open_async("Cargo.toml")
-            .await
+        let mut file = NamedFile::open("Cargo.toml")
             .unwrap()
             .set_content_type(mime::TEXT_XML);
         {
@@ -274,7 +272,7 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_named_file_image() {
-        let mut file = NamedFile::open_async("tests/test.png").await.unwrap();
+        let mut file = NamedFile::open("tests/test.png").unwrap();
         {
             file.file();
             let _f: &File = &file;
@@ -297,7 +295,7 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_named_file_javascript() {
-        let file = NamedFile::open_async("tests/test.js").await.unwrap();
+        let file = NamedFile::open("tests/test.js").unwrap();
 
         let req = TestRequest::default().to_http_request();
         let resp = file.respond_to(&req);
@@ -317,8 +315,7 @@ mod tests {
             disposition: DispositionType::Attachment,
             parameters: vec![DispositionParam::Filename(String::from("test.png"))],
         };
-        let mut file = NamedFile::open_async("tests/test.png")
-            .await
+        let mut file = NamedFile::open("tests/test.png")
             .unwrap()
             .set_content_disposition(cd);
         {
@@ -343,7 +340,7 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_named_file_binary() {
-        let mut file = NamedFile::open_async("tests/test.binary").await.unwrap();
+        let mut file = NamedFile::open("tests/test.binary").unwrap();
         {
             file.file();
             let _f: &File = &file;
@@ -367,13 +364,11 @@ mod tests {
     #[allow(deprecated)]
     #[actix_rt::test]
     async fn status_code_customize_same_output() {
-        let file1 = NamedFile::open_async("Cargo.toml")
-            .await
+        let file1 = NamedFile::open("Cargo.toml")
             .unwrap()
             .set_status_code(StatusCode::NOT_FOUND);
 
-        let file2 = NamedFile::open_async("Cargo.toml")
-            .await
+        let file2 = NamedFile::open("Cargo.toml")
             .unwrap()
             .customize()
             .with_status(StatusCode::NOT_FOUND);
@@ -388,7 +383,7 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_named_file_status_code_text() {
-        let mut file = NamedFile::open_async("Cargo.toml").await.unwrap();
+        let mut file = NamedFile::open("Cargo.toml").unwrap();
 
         {
             file.file();
@@ -671,8 +666,7 @@ mod tests {
     async fn test_named_file_content_encoding() {
         let srv = test::init_service(App::new().wrap(Compress::default()).service(
             web::resource("/").to(|| async {
-                NamedFile::open_async("Cargo.toml")
-                    .await
+                NamedFile::open("Cargo.toml")
                     .unwrap()
                     .set_content_encoding(header::ContentEncoding::Identity)
             }),
@@ -693,8 +687,7 @@ mod tests {
     async fn test_named_file_content_encoding_gzip() {
         let srv = test::init_service(App::new().wrap(Compress::default()).service(
             web::resource("/").to(|| async {
-                NamedFile::open_async("Cargo.toml")
-                    .await
+                NamedFile::open("Cargo.toml")
                     .unwrap()
                     .set_content_encoding(header::ContentEncoding::Gzip)
             }),
@@ -720,7 +713,7 @@ mod tests {
     #[actix_rt::test]
     async fn test_named_file_allowed_method() {
         let req = TestRequest::default().method(Method::GET).to_http_request();
-        let file = NamedFile::open_async("Cargo.toml").await.unwrap();
+        let file = NamedFile::open("Cargo.toml").unwrap();
         let resp = file.respond_to(&req);
         assert_eq!(resp.status(), StatusCode::OK);
     }
@@ -1203,7 +1196,7 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_serve_named_file() {
-        let factory = NamedFile::open_async("Cargo.toml").await.unwrap();
+        let factory = NamedFile::open("Cargo.toml").unwrap();
         let srv = test::init_service(App::new().service(factory)).await;
 
         let req = TestRequest::get().uri("/Cargo.toml").to_request();
@@ -1221,7 +1214,7 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_serve_named_file_prefix() {
-        let factory = NamedFile::open_async("Cargo.toml").await.unwrap();
+        let factory = NamedFile::open("Cargo.toml").unwrap();
         let srv =
             test::init_service(App::new().service(web::scope("/test").service(factory))).await;
 
@@ -1240,7 +1233,7 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_named_file_default_service() {
-        let factory = NamedFile::open_async("Cargo.toml").await.unwrap();
+        let factory = NamedFile::open("Cargo.toml").unwrap();
         let srv = test::init_service(App::new().default_service(factory)).await;
 
         for route in ["/foobar", "/baz", "/"].iter() {
@@ -1256,7 +1249,7 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_default_handler_named_file() {
-        let factory = NamedFile::open_async("Cargo.toml").await.unwrap();
+        let factory = NamedFile::open("Cargo.toml").unwrap();
         let st = Files::new("/", ".")
             .default_handler(factory)
             .new_service(())

--- a/actix-files/src/lib.rs
+++ b/actix-files/src/lib.rs
@@ -223,17 +223,7 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_named_file_non_ascii_file_name() {
-        let file = {
-            #[cfg(feature = "experimental-io-uring")]
-            {
-                crate::named::File::open("Cargo.toml").await.unwrap()
-            }
-
-            #[cfg(not(feature = "experimental-io-uring"))]
-            {
-                crate::named::File::open("Cargo.toml").unwrap()
-            }
-        };
+        let file = crate::named::File::open("Cargo.toml").unwrap();
 
         let mut file = NamedFile::from_file(file, "貨物.toml").unwrap();
         {

--- a/actix-files/src/named.rs
+++ b/actix-files/src/named.rs
@@ -83,11 +83,7 @@ pub struct NamedFile {
     pub(crate) read_mode_threshold: u64,
 }
 
-#[cfg(not(feature = "experimental-io-uring"))]
 pub(crate) use std::fs::File;
-
-#[cfg(feature = "experimental-io-uring")]
-pub(crate) use tokio_uring::fs::File;
 
 use super::chunked;
 
@@ -189,29 +185,7 @@ impl NamedFile {
         // and Content-Disposition values
         let (content_type, content_disposition) = get_content_type_and_disposition(&path)?;
 
-        let md = {
-            #[cfg(not(feature = "experimental-io-uring"))]
-            {
-                file.metadata()?
-            }
-
-            #[cfg(feature = "experimental-io-uring")]
-            {
-                use std::os::unix::prelude::{AsRawFd, FromRawFd};
-
-                let fd = file.as_raw_fd();
-
-                // SAFETY: fd is borrowed and lives longer than the unsafe block
-                unsafe {
-                    let file = std::fs::File::from_raw_fd(fd);
-                    let md = file.metadata();
-                    // SAFETY: forget the fd before exiting block in success or error case but don't
-                    // run destructor (that would close file handle)
-                    std::mem::forget(file);
-                    md?
-                }
-            }
-        };
+        let md = file.metadata()?;
 
         let modified = md.modified().ok();
         let encoding = None;
@@ -237,16 +211,14 @@ impl NamedFile {
     /// use actix_files::NamedFile;
     /// let file = NamedFile::open("foo.txt");
     /// ```
-    #[cfg(not(feature = "experimental-io-uring"))]
     pub fn open<P: AsRef<Path>>(path: P) -> io::Result<NamedFile> {
         let file = File::open(&path)?;
         Self::from_file(file, path)
     }
 
-    /// Attempts to open a file asynchronously in read-only mode.
+    /// Attempts to open a file in read-only mode.
     ///
-    /// When the `experimental-io-uring` crate feature is enabled, this will be async. Otherwise, it
-    /// will behave just like `open`.
+    /// This currently behaves like [`NamedFile::open`].
     ///
     /// # Examples
     /// ```
@@ -256,19 +228,7 @@ impl NamedFile {
     /// # }
     /// ```
     pub async fn open_async<P: AsRef<Path>>(path: P) -> io::Result<NamedFile> {
-        let file = {
-            #[cfg(not(feature = "experimental-io-uring"))]
-            {
-                File::open(&path)?
-            }
-
-            #[cfg(feature = "experimental-io-uring")]
-            {
-                File::open(&path).await?
-            }
-        };
-
-        Self::from_file(file, path)
+        Self::open(path)
     }
 
     /// Returns reference to the underlying file object.
@@ -388,8 +348,6 @@ impl NamedFile {
     ///
     /// Tweaking this value according to your expected usage may lead to significant performance
     /// gains (or losses in other handlers, if `size` is too high).
-    ///
-    /// When the `experimental-io-uring` crate feature is enabled, file reads are always async.
     ///
     /// Default is 0, meaning all files are read asynchronously.
     pub fn read_mode_threshold(mut self, size: u64) -> Self {

--- a/actix-files/src/named.rs
+++ b/actix-files/src/named.rs
@@ -50,8 +50,8 @@ impl Default for Flags {
 /// use actix_web::App;
 /// use actix_files::NamedFile;
 ///
-/// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-/// let file = NamedFile::open_async("./static/index.html").await?;
+/// # fn run() -> Result<(), Box<dyn std::error::Error>> {
+/// let file = NamedFile::open("./static/index.html")?;
 /// let app = App::new().service(file);
 /// # Ok(())
 /// # }
@@ -64,7 +64,7 @@ impl Default for Flags {
 ///
 /// #[get("/")]
 /// async fn index() -> impl Responder {
-///     NamedFile::open_async("./static/index.html").await
+///     NamedFile::open("./static/index.html")
 /// }
 /// ```
 #[derive(Debug, Deref, DerefMut)]
@@ -216,21 +216,6 @@ impl NamedFile {
         Self::from_file(file, path)
     }
 
-    /// Attempts to open a file in read-only mode.
-    ///
-    /// This currently behaves like [`NamedFile::open`].
-    ///
-    /// # Examples
-    /// ```
-    /// use actix_files::NamedFile;
-    /// # async fn open() {
-    /// let file = NamedFile::open_async("foo.txt").await.unwrap();
-    /// # }
-    /// ```
-    pub async fn open_async<P: AsRef<Path>>(path: P) -> io::Result<NamedFile> {
-        Self::open(path)
-    }
-
     /// Returns reference to the underlying file object.
     #[inline]
     pub fn file(&self) -> &File {
@@ -244,8 +229,8 @@ impl NamedFile {
     /// # use std::io;
     /// use actix_files::NamedFile;
     ///
-    /// # async fn path() -> io::Result<()> {
-    /// let file = NamedFile::open_async("test.txt").await?;
+    /// # fn path() -> io::Result<()> {
+    /// let file = NamedFile::open("test.txt")?;
     /// assert_eq!(file.path().as_os_str(), "foo.txt");
     /// # Ok(())
     /// # }
@@ -687,7 +672,7 @@ impl Service<ServiceRequest> for NamedFileService {
 
         let path = self.path.clone();
         Box::pin(async move {
-            let file = NamedFile::open_async(path).await?;
+            let file = NamedFile::open(path)?;
             let res = file.into_response(&req);
             Ok(ServiceResponse::new(req, res))
         })

--- a/actix-files/src/service.rs
+++ b/actix-files/src/service.rs
@@ -230,7 +230,7 @@ impl Service<ServiceRequest> for FilesService {
                                 }
                             }
                             // fallback to the uncompressed version
-                            match NamedFile::open_async(named_path).await {
+                            match NamedFile::open(named_path) {
                                 Ok(named_file) => return Ok(this.serve_named_file(req, named_file)),
                                 Err(err)
                                     if matches!(
@@ -260,7 +260,7 @@ impl Service<ServiceRequest> for FilesService {
                         None => found_unrenderable_dir = true,
                     }
                 } else {
-                    match NamedFile::open_async(&path).await {
+                    match NamedFile::open(&path) {
                         Ok(named_file) => return Ok(this.serve_named_file(req, named_file)),
                         Err(err)
                             if matches!(
@@ -360,7 +360,7 @@ async fn find_compressed(
         filename.push(extension);
         compressed_path.set_file_name(filename);
 
-        match NamedFile::open_async(&compressed_path).await {
+        match NamedFile::open(&compressed_path) {
             Ok(mut named_file) => {
                 named_file.content_type = content_type.take().unwrap();
                 named_file.content_disposition = content_disposition.take().unwrap();

--- a/actix-files/tests/encoding.rs
+++ b/actix-files/tests/encoding.rs
@@ -207,7 +207,7 @@ async fn test_compression_encodings_multiple_directories() {
 #[actix_web::test]
 async fn partial_range_response_encoding() {
     let srv = test::init_service(App::new().default_service(web::to(|| async {
-        NamedFile::open_async("./tests/test.binary").await.unwrap()
+        NamedFile::open("./tests/test.binary").unwrap()
     })))
     .await;
 

--- a/actix-files/tests/pre_epoch_mtime.rs
+++ b/actix-files/tests/pre_epoch_mtime.rs
@@ -28,7 +28,7 @@ async fn serves_file_with_pre_epoch_mtime() {
         let path = path.clone();
         test::init_service(App::new().default_service(web::to(move || {
             let path = path.clone();
-            async move { NamedFile::open_async(path).await.unwrap() }
+            async move { NamedFile::open(path).unwrap() }
         })))
         .await
     };

--- a/actix-web/src/middleware/compress.rs
+++ b/actix-web/src/middleware/compress.rs
@@ -61,7 +61,7 @@ use crate::{
 /// use actix_web::{middleware, http::header, web, App, HttpResponse, Responder};
 ///
 /// async fn index_handler() -> actix_web::Result<impl Responder> {
-///     Ok(actix_files::NamedFile::open_async("./assets/index.html.gz").await?
+///     Ok(actix_files::NamedFile::open("./assets/index.html.gz")?
 ///         .customize()
 ///         .insert_header(header::ContentEncoding::Gzip))
 /// }


### PR DESCRIPTION
## Summary

- Remove the semver-exempt `actix-files/experimental-io-uring` feature and its implementation.
- Remove `NamedFile::open_async`; callers must use `NamedFile::open` without `.await`.
- Remove the tokio-uring reader and unsafe raw-FD metadata bridge.
- Remove the direct tokio-uring and actix-server dependencies from `actix-files`.
- Remove the dedicated Actix Files io-uring CI job.
- Keep the separate Actix Web server-level io-uring feature unchanged.

## Breaking change

Removing `NamedFile::open_async` is a public API break. This PR is labeled `B-semver-major` and targets the next major Actix Files release (`0.7`).

## Rationale

The focused diagnosis in #4195 localized the Linux allocator failures to cancellation of the io-uring file-read path. This is an alternative to #4197: remove the experimental Actix Files integration and its async-open API instead of retaining the implementation and avoiding reads for HEAD requests.

The standard file implementation already opened files synchronously when the experimental feature was disabled. Internal callers now use that API directly. No futures executor is added.

## Validation

- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `cargo clippy --locked -p actix-files --all-targets --all-features` (passes with existing warnings in other crates)
- `cargo test --locked -p actix-files --all-features`
- `cargo +nightly test --locked --doc -p actix-web`
- `cargo package --locked --allow-dirty -p actix-files`

The previous head passed Linux stable and MSRV CI. The amended head will rerun those checks. `cargo-semver-checks` is expected to report the removed feature and method as a major change; that result matches the PR classification.
