### PR TITLE
refactor(web): remove experimental io-uring feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,7 +125,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "slab",
- "socket2 0.6.5",
+ "socket2",
  "tokio",
 ]
 
@@ -222,7 +222,6 @@ dependencies = [
  "actix-macros",
  "futures-core",
  "tokio",
- "tokio-uring",
 ]
 
 [[package]]
@@ -237,9 +236,8 @@ dependencies = [
  "futures-core",
  "futures-util",
  "mio",
- "socket2 0.6.5",
+ "socket2",
  "tokio",
- "tokio-uring",
  "tracing",
 ]
 
@@ -369,7 +367,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "smallvec",
- "socket2 0.6.5",
+ "socket2",
  "static_assertions",
  "time",
  "tokio",
@@ -1902,22 +1900,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-uring"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595a0399f411a508feb2ec1e970a4a30c249351e30208960d58298de8660b0e5"
-dependencies = [
- "bitflags 1.3.2",
- "libc",
-]
-
-[[package]]
 name = "ipconfig"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
 dependencies = [
- "socket2 0.6.5",
+ "socket2",
  "widestring",
  "windows-registry",
  "windows-result",
@@ -3067,16 +3055,6 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "socket2"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
@@ -3336,7 +3314,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.5",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -3425,20 +3403,6 @@ dependencies = [
  "futures-core",
  "tokio",
  "tokio-stream",
-]
-
-[[package]]
-name = "tokio-uring"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "748482e3e13584a34664a710168ad5068e8cb1d968aa4ffa887e83ca6dd27967"
-dependencies = [
- "futures-util",
- "io-uring",
- "libc",
- "slab",
- "socket2 0.4.10",
- "tokio",
 ]
 
 [[package]]

--- a/actix-web/CHANGES.md
+++ b/actix-web/CHANGES.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add `Error::add_response_mapper()` to allow middleware to modify error-generated responses before they are sent. [#2979]
+- Remove the experimental `experimental-io-uring` crate feature.
 
 [#2979]: https://github.com/actix/actix-web/pull/2979
 

--- a/actix-web/Cargo.toml
+++ b/actix-web/Cargo.toml
@@ -116,9 +116,6 @@ __compress = []
 # Don't rely on these whatsoever. They may disappear at anytime.
 __tls = []
 
-# io-uring feature only available for Linux OSes.
-experimental-io-uring = ["actix-server/io-uring"]
-
 # Feature group which, when disabled, helps migrate code to v5.0.
 compat = ["compat-routing-macros-force-pub"]
 

--- a/justfile
+++ b/justfile
@@ -24,7 +24,7 @@ non_linux_all_features_list := ```
     cargo metadata --format-version=1 \
     | jq '.packages[] | select(.source == null) | .features | keys' \
     | jq -r --slurp \
-        --arg exclusions "__tls,__compress,tokio-uring,io-uring,experimental-io-uring" \
+        --arg exclusions "__tls,__compress" \
         'add | unique | . - ($exclusions | split(",")) | join(",")'
 ```
 all_crate_features := if os() == "linux" { "--all-features" } else { "--features='" + non_linux_all_features_list + "'" }
@@ -109,7 +109,7 @@ update-readmes: && fmt
     cd ./actix-multipart && cargo rdme --force
     cd ./actix-test && cargo rdme --force
 
-feature_combo_skip_list := if os() == "linux" { "__tls,__compress" } else { "__tls,__compress,experimental-io-uring" }
+feature_combo_skip_list := "__tls,__compress"
 
 # Checks compatibility of feature combinations.
 check-feature-combinations:


### PR DESCRIPTION
Summary:
- Remove actix-web's experimental-io-uring feature.
- Remove stale feature-matrix exclusions and io-uring lockfile dependencies.
- Document the semver-exempt feature removal.

Tests:
- just test
- cargo check --workspace --all-targets
- just check (Clippy passed; Prettier is blocked by pre-existing actix-web/README.md formatting.)