### PR TITLE
ci: move cargo deny checks to lint workflow

### DIFF
--- a/.github/workflows/actions.lock
+++ b/.github/workflows/actions.lock
@@ -14,7 +14,6 @@ workflows:
     '.github/workflows/ci.yml':
         - 'actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659'
         - 'actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1'
-        - 'embarkstudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25'
         - 'ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b'
         - 'rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444'
         - 'taiki-e/install-action@cb33e69fad06166ca28a42b2575e4dadabf62ee8'
@@ -29,6 +28,7 @@ workflows:
     '.github/workflows/lint.yml':
         - 'actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659'
         - 'actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1'
+        - 'embarkstudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25'
         - 'giraffate/clippy-action@13b9d32482f25d29ead141b79e7e04e7900281e0'
         - 'taiki-e/cache-cargo-install-action@9ee83daaa7b96a6fab930949ecf1122bba04a389'
         - 'taiki-e/install-action@cb33e69fad06166ca28a42b2575e4dadabf62ee8'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,10 +89,6 @@ jobs:
       - name: CI cache clean
         run: cargo-ci-cache-clean
 
-      - name: deny check
-        if: matrix.version.name == 'stable' && matrix.target.os == 'ubuntu-latest'
-        uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
-
   rustdoc:
     name: doc tests
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,6 +32,18 @@ jobs:
           annotations: true
           version: v1.24.1
 
+  deny:
+    name: deny
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: deny check
+        uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
+
   fmt:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

- move the cargo-deny check from the CI test matrix to a dedicated lint job
- update the generated actions lock mapping

## Validation

- Ruby YAML parsing
- Prettier workflow check