### PR TITLE
test: document awc Tokio runtime requirement

### DIFF
--- a/awc/Cargo.toml
+++ b/awc/Cargo.toml
@@ -121,7 +121,7 @@ rand = "0.10.1"
 serde = "1.0"
 serde_json = "1.0"
 serde_urlencoded = "0.7"
-tokio = { version = "1.38.2", features = ["sync"] }
+tokio = { version = "1.51", features = ["sync"] }
 
 cookie = { version = "0.16", features = ["percent-encode"], optional = true }
 
@@ -150,7 +150,7 @@ futures-util = { version = "0.3.17", default-features = false }
 static_assertions = "1.1"
 rcgen = "0.14"
 rustls-pki-types = "1.13.1"
-tokio = { version = "1.38.2", features = ["rt-multi-thread", "macros"] }
+tokio = { version = "1.51", features = ["rt-multi-thread", "macros"] }
 zstd = "0.13"
 tls-rustls-0_23 = { package = "rustls", version = "0.23" } # add rustls 0.23 with default features to make aws_lc_rs work in tests
 

--- a/awc/tests/test_client.rs
+++ b/awc/tests/test_client.rs
@@ -54,6 +54,30 @@ async fn simple() {
     assert!(response.status().is_success());
 }
 
+// this test should be altered/removed if spawn_local is no longer used in awc
+#[should_panic(expected = "called from outside of a `task::LocalSet`")]
+#[tokio::test(flavor = "current_thread")]
+async fn tokio_runtime_without_local_set() {
+    let srv = actix_test::start(|| App::new());
+
+    let _ = awc::Client::default()
+        .get(srv.url("/"))
+        .send()
+        .await
+        .unwrap();
+}
+
+#[tokio::test(flavor = "local")]
+async fn tokio_local_runtime() {
+    let srv = actix_test::start(|| App::new());
+
+    let _ = awc::Client::default()
+        .get(srv.url("/"))
+        .send()
+        .await
+        .unwrap();
+}
+
 #[actix_rt::test]
 async fn json() {
     let srv = actix_test::start(|| {


### PR DESCRIPTION
## Summary

- add an integration test that uses `awc` from a plain `#[tokio::test]`
- document the expected `spawn_local` panic when no `LocalSet` is present
