### PR TITLE
chore: migrate internal pin macros to std

### DIFF
--- a/actix-http/src/body/body_stream.rs
+++ b/actix-http/src/body/body_stream.rs
@@ -68,12 +68,9 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::{convert::Infallible, time::Duration};
+    use std::{convert::Infallible, pin::pin, time::Duration};
 
-    use actix_rt::{
-        pin,
-        time::{sleep, Sleep},
-    };
+    use actix_rt::time::{sleep, Sleep};
     use actix_utils::future::poll_fn;
     use derive_more::{Display, Error};
     use futures_core::ready;
@@ -102,7 +99,7 @@ mod tests {
                 .iter()
                 .map(|&v| Ok::<_, Infallible>(Bytes::from(v))),
         ));
-        pin!(body);
+        let mut body = pin!(body);
 
         assert_eq!(
             poll_fn(|cx| body.as_mut().poll_next(cx))

--- a/actix-http/src/body/message_body.rs
+++ b/actix-http/src/body/message_body.rs
@@ -533,7 +533,8 @@ where
 
 #[cfg(test)]
 mod tests {
-    use actix_rt::pin;
+    use std::pin::pin;
+
     use actix_utils::future::poll_fn;
     use futures_util::stream;
 
@@ -566,7 +567,7 @@ mod tests {
         assert_eq!(().size(), Box::pin(()).size());
 
         let pl = Box::new(());
-        pin!(pl);
+        let mut pl = pin!(pl);
         assert_poll_next_none!(pl);
 
         let mut pl = Box::pin(());
@@ -579,11 +580,11 @@ mod tests {
         assert_eq!(().size(), (&(&mut ())).size());
 
         let pl = &mut ();
-        pin!(pl);
+        let mut pl = pin!(pl);
         assert_poll_next_none!(pl);
 
         let pl = &mut Box::new(());
-        pin!(pl);
+        let mut pl = pin!(pl);
         assert_poll_next_none!(pl);
 
         let mut body = body::SizedStream::new(
@@ -595,7 +596,7 @@ mod tests {
         );
         let body = &mut body;
         assert_eq!(body.size(), BodySize::Sized(8));
-        pin!(body);
+        let mut body = pin!(body);
         assert_poll_next!(body, Bytes::from_static(b"1234"));
         assert_poll_next!(body, Bytes::from_static(b"5678"));
         assert_poll_next_none!(body);
@@ -606,7 +607,7 @@ mod tests {
     async fn test_unit() {
         let pl = ();
         assert_eq!(pl.size(), BodySize::Sized(0));
-        pin!(pl);
+        let mut pl = pin!(pl);
         assert_poll_next_none!(pl);
     }
 
@@ -616,7 +617,7 @@ mod tests {
         assert_eq!("test".size(), BodySize::Sized(4));
 
         let pl = "test";
-        pin!(pl);
+        let mut pl = pin!(pl);
         assert_poll_next!(pl, Bytes::from("test"));
     }
 
@@ -626,7 +627,7 @@ mod tests {
         assert_eq!(b"test".as_ref().size(), BodySize::Sized(4));
 
         let pl = b"test".as_ref();
-        pin!(pl);
+        let mut pl = pin!(pl);
         assert_poll_next!(pl, Bytes::from("test"));
     }
 
@@ -636,7 +637,7 @@ mod tests {
         assert_eq!(Vec::from("test").size(), BodySize::Sized(4));
 
         let pl = Vec::from("test");
-        pin!(pl);
+        let mut pl = pin!(pl);
         assert_poll_next!(pl, Bytes::from("test"));
     }
 
@@ -646,7 +647,7 @@ mod tests {
         assert_eq!(Bytes::from_static(b"test").size(), BodySize::Sized(4));
 
         let pl = Bytes::from_static(b"test");
-        pin!(pl);
+        let mut pl = pin!(pl);
         assert_poll_next!(pl, Bytes::from("test"));
     }
 
@@ -656,7 +657,7 @@ mod tests {
         assert_eq!(BytesMut::from(b"test".as_ref()).size(), BodySize::Sized(4));
 
         let pl = BytesMut::from("test");
-        pin!(pl);
+        let mut pl = pin!(pl);
         assert_poll_next!(pl, Bytes::from("test"));
     }
 
@@ -666,7 +667,7 @@ mod tests {
         assert_eq!("test".to_owned().size(), BodySize::Sized(4));
 
         let pl = "test".to_owned();
-        pin!(pl);
+        let mut pl = pin!(pl);
         assert_poll_next!(pl, Bytes::from("test"));
     }
 
@@ -674,7 +675,7 @@ mod tests {
     async fn test_byte_string() {
         let pl = bytestring::ByteString::from_static("test");
         assert_eq!(pl.size(), BodySize::Sized(4));
-        pin!(pl);
+        let mut pl = pin!(pl);
         assert_poll_next!(pl, Bytes::from_static(b"test"));
         assert_poll_next_none!(pl);
     }

--- a/actix-http/src/body/sized_stream.rs
+++ b/actix-http/src/body/sized_stream.rs
@@ -71,9 +71,8 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::convert::Infallible;
+    use std::{convert::Infallible, pin::pin};
 
-    use actix_rt::pin;
     use actix_utils::future::poll_fn;
     use futures_util::stream;
     use static_assertions::{assert_impl_all, assert_not_impl_any};
@@ -103,7 +102,7 @@ mod tests {
             ),
         );
 
-        pin!(body);
+        let mut body = pin!(body);
 
         assert_eq!(
             poll_fn(|cx| body.as_mut().poll_next(cx))

--- a/actix-http/src/body/utils.rs
+++ b/actix-http/src/body/utils.rs
@@ -1,6 +1,5 @@
-use std::task::Poll;
+use std::{pin::pin, task::Poll};
 
-use actix_rt::pin;
 use actix_utils::future::poll_fn;
 use bytes::{Bytes, BytesMut};
 use derive_more::{Display, Error};
@@ -85,7 +84,7 @@ pub async fn to_bytes_limited<B: MessageBody>(
     let mut exceeded_limit = false;
     let mut buf = BytesMut::with_capacity(cap);
 
-    pin!(body);
+    let mut body = pin!(body);
 
     match poll_fn(|cx| loop {
         let body = body.as_mut();

--- a/actix-http/src/h1/dispatcher_tests.rs
+++ b/actix-http/src/h1/dispatcher_tests.rs
@@ -1,7 +1,7 @@
 use std::{
     cell::Cell,
     future::Future,
-    pin::Pin,
+    pin::{pin, Pin},
     rc::Rc,
     str,
     task::{Context, Poll},
@@ -9,10 +9,7 @@ use std::{
 };
 
 use actix_codec::Framed;
-use actix_rt::{
-    pin,
-    time::{sleep, timeout},
-};
+use actix_rt::time::{sleep, timeout};
 use actix_service::{fn_service, Service};
 use actix_utils::future::{ready, Ready};
 use bytes::BytesMut;
@@ -88,7 +85,7 @@ async fn late_request() {
         None,
         OnConnectData::default(),
     );
-    pin!(h1);
+    let mut h1 = pin!(h1);
 
     lazy(|cx| {
         assert!(matches!(&h1.inner, DispatcherState::Normal { .. }));
@@ -155,7 +152,7 @@ async fn oneshot_connection() {
         None,
         OnConnectData::default(),
     );
-    pin!(h1);
+    let mut h1 = pin!(h1);
 
     lazy(|cx| {
         assert!(matches!(&h1.inner, DispatcherState::Normal { .. }));
@@ -216,7 +213,7 @@ async fn keep_alive_timeout() {
         None,
         OnConnectData::default(),
     );
-    pin!(h1);
+    let mut h1 = pin!(h1);
 
     lazy(|cx| {
         assert!(matches!(&h1.inner, DispatcherState::Normal { .. }));
@@ -295,7 +292,7 @@ async fn keep_alive_follow_up_req() {
         None,
         OnConnectData::default(),
     );
-    pin!(h1);
+    let mut h1 = pin!(h1);
 
     lazy(|cx| {
         assert!(matches!(&h1.inner, DispatcherState::Normal { .. }));
@@ -425,7 +422,7 @@ async fn graceful_shutdown_does_not_start_buffered_request() {
         None,
         OnConnectData::default(),
     );
-    pin!(dispatcher);
+    let mut dispatcher = pin!(dispatcher);
 
     // The shutdown notification and request data are ready in the same dispatcher poll.
     let mut cx = Context::from_waker(futures_util::task::noop_waker_ref());
@@ -456,7 +453,7 @@ async fn req_parse_err() {
             OnConnectData::default(),
         );
 
-        pin!(h1);
+        let mut h1 = pin!(h1);
 
         match h1.as_mut().poll(cx) {
             Poll::Pending => panic!(),
@@ -502,7 +499,7 @@ async fn pipelining_ok_then_ok() {
             OnConnectData::default(),
         );
 
-        pin!(h1);
+        let mut h1 = pin!(h1);
 
         assert!(matches!(&h1.inner, DispatcherState::Normal { .. }));
 
@@ -572,7 +569,7 @@ async fn early_response_with_payload_lingers_before_closing() {
             OnConnectData::default(),
         );
 
-        pin!(h1);
+        let mut h1 = pin!(h1);
 
         assert!(matches!(&h1.inner, DispatcherState::Normal { .. }));
 
@@ -644,7 +641,7 @@ async fn buffered_upload_ignored_by_handler_should_not_shutdown_immediately() {
             OnConnectData::default(),
         );
 
-        pin!(h1);
+        let mut h1 = pin!(h1);
 
         assert!(matches!(&h1.inner, DispatcherState::Normal { .. }));
 
@@ -771,7 +768,7 @@ async fn pipelining_ok_then_bad() {
             OnConnectData::default(),
         );
 
-        pin!(h1);
+        let mut h1 = pin!(h1);
 
         assert!(matches!(&h1.inner, DispatcherState::Normal { .. }));
 
@@ -843,7 +840,7 @@ async fn expect_handling() {
                 ",
         );
 
-        pin!(h1);
+        let mut h1 = pin!(h1);
 
         assert!(h1.as_mut().poll(cx).is_pending());
         assert!(matches!(&h1.inner, DispatcherState::Normal { .. }));
@@ -920,7 +917,7 @@ async fn expect_eager() {
                 ",
         );
 
-        pin!(h1);
+        let mut h1 = pin!(h1);
 
         assert!(h1.as_mut().poll(cx).is_ready());
         assert!(matches!(&h1.inner, DispatcherState::Normal { .. }));
@@ -1003,7 +1000,7 @@ async fn upgrade_handling() {
                 ",
         );
 
-        pin!(h1);
+        let mut h1 = pin!(h1);
 
         assert!(h1.as_mut().poll(cx).is_ready());
         assert!(matches!(&h1.inner, DispatcherState::Upgrade { .. }));
@@ -1040,7 +1037,7 @@ async fn upgrade_response_does_not_close_unfinished_payload() {
         None,
         OnConnectData::default(),
     );
-    pin!(h1);
+    let mut h1 = pin!(h1);
 
     lazy(|cx| {
         assert!(h1.as_mut().poll(cx).is_pending());
@@ -1101,7 +1098,7 @@ async fn handler_drop_payload() {
         None,
         OnConnectData::default(),
     );
-    pin!(h1);
+    let mut h1 = pin!(h1);
 
     lazy(|cx| {
         assert!(h1.as_mut().poll(cx).is_pending());
@@ -1245,7 +1242,7 @@ async fn handler_drop_payload_drains_body() {
         None,
         OnConnectData::default(),
     );
-    pin!(h1);
+    let mut h1 = pin!(h1);
 
     lazy(|cx| {
         assert!(h1.as_mut().poll(cx).is_pending());
@@ -1352,7 +1349,7 @@ async fn allow_half_closed() {
         None,
         OnConnectData::default(),
     );
-    pin!(disptacher);
+    let mut disptacher = pin!(disptacher);
 
     assert!(disptacher.as_mut().poll(&mut cx).is_pending());
     assert_eq!(disptacher.poll_count, 1);
@@ -1405,7 +1402,7 @@ async fn disallow_half_closed() {
         None,
         OnConnectData::default(),
     );
-    pin!(disptacher);
+    let mut disptacher = pin!(disptacher);
 
     assert!(disptacher.as_mut().poll(&mut cx).is_pending());
     assert_eq!(disptacher.poll_count, 1);
@@ -1441,7 +1438,7 @@ async fn h1_write_buffer_size_limits_buffering() {
         None,
         OnConnectData::default(),
     );
-    pin!(default_dispatcher);
+    let mut default_dispatcher = pin!(default_dispatcher);
 
     let mut cx = Context::from_waker(futures_util::task::noop_waker_ref());
     assert!(default_dispatcher.as_mut().poll(&mut cx).is_pending());
@@ -1463,7 +1460,7 @@ async fn h1_write_buffer_size_limits_buffering() {
         None,
         OnConnectData::default(),
     );
-    pin!(custom_dispatcher);
+    let mut custom_dispatcher = pin!(custom_dispatcher);
 
     assert!(custom_dispatcher.as_mut().poll(&mut cx).is_pending());
     assert_eq!(custom_polls.get(), 1);

--- a/actix-http/tests/test_rustls.rs
+++ b/actix-http/tests/test_rustls.rs
@@ -7,6 +7,7 @@ use std::{
     convert::Infallible,
     io::{self, Write},
     net::{SocketAddr, TcpStream as StdTcpStream},
+    pin::pin,
     sync::Arc,
     task::Poll,
     time::Duration,
@@ -19,7 +20,7 @@ use actix_http::{
     Error, HttpService, Method, Request, Response, StatusCode, TlsAcceptorConfig, Version,
 };
 use actix_http_test::test_server;
-use actix_rt::{net::TcpStream as RtTcpStream, pin};
+use actix_rt::net::TcpStream as RtTcpStream;
 use actix_service::{fn_factory_with_config, fn_service};
 use actix_tls::{accept::rustls_0_23::TlsStream, connect::rustls_0_23::webpki_roots_cert_store};
 use actix_utils::future::{err, ok, poll_fn};
@@ -37,7 +38,7 @@ where
 {
     let mut buf = BytesMut::new();
 
-    pin!(stream);
+    let mut stream = pin!(stream);
 
     poll_fn(|cx| loop {
         let body = stream.as_mut();

--- a/awc/src/client/h1proto.rs
+++ b/awc/src/client/h1proto.rs
@@ -1,6 +1,6 @@
 use std::{
     io::Write,
-    pin::Pin,
+    pin::{pin, Pin},
     task::{Context, Poll},
 };
 
@@ -34,7 +34,7 @@ where
     B: MessageBody,
     B::Error: Into<BoxError>,
 {
-    actix_rt::pin!(body);
+    let mut body = pin!(body);
 
     let orig_length = body.size();
     let mut length = orig_length;

--- a/awc/src/client/h2proto.rs
+++ b/awc/src/client/h2proto.rs
@@ -1,4 +1,4 @@
-use std::future::Future;
+use std::{future::Future, pin::pin};
 
 use actix_http::{
     body::{BodySize, MessageBody},
@@ -142,7 +142,7 @@ where
 {
     let mut buf = None;
 
-    actix_rt::pin!(body);
+    let mut body = pin!(body);
 
     loop {
         if buf.is_none() {


### PR DESCRIPTION
## Summary

- migrate internal `actix_rt::pin!` uses to `std::pin::pin!`
- update bindings for the standard macro expression form
- keep the public `actix_web::rt::pin` re-export unchanged for backwards compatibility

## Testing

- `just clippy -p actix-http -p awc -p actix-web`
- `just test`
- `just test-msrv`
- `cargo +nightly fmt --all -- --check`