### PR TITLE
fix: validate WebSocket close frames

### DIFF
--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Reject invalid WebSocket close-frame status codes, malformed payloads, and invalid UTF-8 close reasons.
+- Deprecate the `Parser::parse_close_payload()` method in favor of `Parser::try_parse_close_payload()`.
+
 ## 3.13.4
 
 - Reject WebSocket frames with reserved bits.

--- a/actix-http/src/ws/codec.rs
+++ b/actix-http/src/ws/codec.rs
@@ -278,7 +278,7 @@ impl Decoder for Codec {
             OpCode::Bad => Err(ProtocolError::BadOpCode),
             OpCode::Close => {
                 if let Some(ref pl) = payload {
-                    let close_reason = Parser::parse_close_payload(pl);
+                    let close_reason = Parser::try_parse_close_payload(pl)?;
                     Ok(Some(Frame::Close(close_reason)))
                 } else {
                     Ok(Some(Frame::Close(None)))

--- a/actix-http/src/ws/frame.rs
+++ b/actix-http/src/ws/frame.rs
@@ -1,4 +1,4 @@
-use std::{cmp::min, io};
+use std::{cmp::min, io, str};
 
 use bytes::{Buf, BufMut, BytesMut};
 use tracing::debug;
@@ -160,6 +160,14 @@ impl Parser {
     }
 
     /// Parse the payload of a close frame.
+    ///
+    /// This method preserves the historical behavior of accepting unknown status codes and
+    /// replacing invalid UTF-8 in the reason. Use [`Parser::try_parse_close_payload`] when the
+    /// payload must be validated.
+    #[deprecated(
+        since = "3.13.5",
+        note = "Use `Parser::try_parse_close_payload` instead."
+    )]
     pub fn parse_close_payload(payload: &[u8]) -> Option<CloseReason> {
         if payload.len() >= 2 {
             let raw_code = u16::from_be_bytes(TryFrom::try_from(&payload[..2]).unwrap());
@@ -173,6 +181,54 @@ impl Parser {
         } else {
             None
         }
+    }
+
+    /// Parse and validate the payload of a close frame.
+    ///
+    /// # Validation
+    ///
+    /// A close payload is either empty or contains a two-byte status code followed by an optional
+    /// UTF-8 reason. This follows [RFC 6455 §5.5.1], with status code rules from [RFC 6455 §7.4]
+    /// and UTF-8 error handling from [RFC 6455 §8.1].
+    ///
+    /// [RFC 6455 §5.5.1]: https://datatracker.ietf.org/doc/html/rfc6455#section-5.5.1
+    /// [RFC 6455 §7.4]: https://datatracker.ietf.org/doc/html/rfc6455#section-7.4
+    /// [RFC 6455 §8.1]: https://datatracker.ietf.org/doc/html/rfc6455#section-8.1
+    pub fn try_parse_close_payload(payload: &[u8]) -> Result<Option<CloseReason>, ProtocolError> {
+        // RFC 6455 §5.5.1 requires a two-byte status code when a close payload is not empty.
+        if payload.len() == 1 {
+            return Err(ProtocolError::InvalidLength(payload.len()));
+        }
+
+        if payload.len() >= 2 {
+            let raw_code = u16::from_be_bytes(
+                payload[..2]
+                    .try_into()
+                    .expect("Payload length should be checked before parsing"),
+            );
+
+            // RFC 6455 §7.4 reserves 1000-2999 for protocol-defined codes. Reject reserved and
+            // undefined values while allowing registered codes (3000-3999) and private-use codes
+            // (4000-4999).
+            if !matches!(raw_code, 1000..=1003 | 1007..=1014 | 3000..=4999) {
+                // TODO(semver-major): use this instead
+                // return Err(ProtocolError::InvalidCloseCode(raw_code));
+                return Err(ProtocolError::BadOpCode);
+            }
+
+            if payload.len() > 2 {
+                // RFC 6455 §5.5.1 defines the remaining bytes as a UTF-8 reason. RFC 6455 §8.1
+                // requires the connection to fail when data interpreted as UTF-8 is invalid.
+                str::from_utf8(&payload[2..]).map_err(|_| {
+                    // TODO(semver-major): use this instead
+                    // ProtocolError::InvalidCloseReason
+                    ProtocolError::BadOpCode
+                })?;
+            }
+        }
+
+        #[expect(deprecated)]
+        Ok(Self::parse_close_payload(payload))
     }
 
     /// Generate binary representation
@@ -441,6 +497,18 @@ mod tests {
         let mut buf = BytesMut::new();
         Parser::write_close(&mut buf, None, false);
         assert_eq!(&buf[..], &vec![0x88, 0x00][..]);
+    }
+
+    #[test]
+    fn try_parse_close_payload_validates_payload() {
+        assert!(matches!(
+            Parser::try_parse_close_payload(&[0x03, 0xe8, 0xff]).unwrap_err(),
+            ProtocolError::BadOpCode
+        ));
+        assert!(matches!(
+            Parser::try_parse_close_payload(&[0, 0]).unwrap_err(),
+            ProtocolError::BadOpCode
+        ));
     }
 
     #[test]

--- a/actix-http/src/ws/mod.rs
+++ b/actix-http/src/ws/mod.rs
@@ -27,44 +27,54 @@ pub use self::{
 #[derive(Debug, Display, Error, From)]
 pub enum ProtocolError {
     /// Received an unmasked frame from client.
-    #[display("received an unmasked frame from client")]
+    #[display("Received an unmasked frame from client")]
     UnmaskedFrame,
 
     /// Received a masked frame from server.
-    #[display("received a masked frame from server")]
+    #[display("Received a masked frame from server")]
     MaskedFrame,
 
     /// Encountered invalid opcode.
-    #[display("invalid opcode ({})", _0)]
+    #[display("Invalid opcode ({})", _0)]
     InvalidOpcode(#[error(not(source))] u8),
 
     // TODO(semver-major):
     // /// Received a frame with non-zero reserved bits.
-    // #[display("received a frame with non-zero reserved bits")]
+    // #[display("Received a frame with non-zero reserved bits")]
     // InvalidReservedBits,
     //
     /// Invalid control frame length
-    #[display("invalid control frame length ({})", _0)]
+    #[display("Invalid control frame length ({})", _0)]
     InvalidLength(#[error(not(source))] usize),
 
+    // TODO(semver-major): use in Parser::try_parse_close_payload
+    //
+    // /// Invalid close status code.
+    // #[display("Invalid close status code ({})", _0)]
+    // InvalidCloseCode(#[error(not(source))] u16),
+    //
+    // /// Invalid UTF-8 close reason.
+    // #[display("Invalid UTF-8 close reason")]
+    // InvalidCloseReason,
+    //
     /// Bad opcode.
-    #[display("bad opcode")]
+    #[display("Bad opcode")]
     BadOpCode,
 
     /// A payload reached size limit.
-    #[display("payload reached size limit")]
+    #[display("Payload reached size limit")]
     Overflow,
 
     /// Continuation has not started.
-    #[display("continuation has not started")]
+    #[display("Continuation has not started")]
     ContinuationNotStarted,
 
     /// Received new continuation but it is already started.
-    #[display("received new continuation but it has already started")]
+    #[display("Received new continuation but it has already started")]
     ContinuationStarted,
 
     /// Unknown continuation fragment.
-    #[display("unknown continuation fragment: {}", _0)]
+    #[display("Unknown continuation fragment: {}", _0)]
     ContinuationFragment(#[error(not(source))] OpCode),
 
     /// I/O error.

--- a/actix-http/tests/test_ws.rs
+++ b/actix-http/tests/test_ws.rs
@@ -109,6 +109,101 @@ async fn service(msg: Frame) -> Result<Message, Error> {
     Ok(msg)
 }
 
+fn masked_close(payload: &[u8]) -> BytesMut {
+    let mask = [1, 2, 3, 4];
+    let mut frame = BytesMut::with_capacity(6 + payload.len());
+    frame.extend_from_slice(&[0x88, 0x80 | payload.len() as u8]);
+    frame.extend_from_slice(&mask);
+
+    for (idx, byte) in payload.iter().enumerate() {
+        frame.extend_from_slice(&[byte ^ mask[idx % mask.len()]]);
+    }
+
+    frame
+}
+
+#[test]
+fn rejects_invalid_close_codes() {
+    for code in [0_u16, 999, 1004, 1005, 1006, 1015, 1016, 1100, 2000, 2999] {
+        let mut codec = ws::Codec::new();
+        let mut frame = masked_close(&code.to_be_bytes());
+
+        assert!(matches!(
+            codec.decode(&mut frame).unwrap_err(),
+            ws::ProtocolError::BadOpCode
+        ));
+    }
+}
+
+#[test]
+fn rejects_invalid_close_reason() {
+    let mut codec = ws::Codec::new();
+    let mut frame = masked_close(&[0x03, 0xe8, 0xff]);
+
+    assert!(matches!(
+        codec.decode(&mut frame).unwrap_err(),
+        ws::ProtocolError::BadOpCode
+    ));
+}
+
+#[test]
+fn accepts_valid_close_codes() {
+    for code in [
+        1000_u16, 1001, 1002, 1003, 1007, 1008, 1009, 1010, 1011, 1012, 1013, 1014, 3000, 3999,
+        4999,
+    ] {
+        let mut codec = ws::Codec::new();
+        let mut frame = masked_close(&code.to_be_bytes());
+
+        let Some(Frame::Close(Some(reason))) = codec.decode(&mut frame).unwrap() else {
+            panic!("expected close reason for status code {code}");
+        };
+        assert_eq!(u16::from(reason.code), code);
+        assert_eq!(reason.description, None);
+    }
+}
+
+#[test]
+fn rejects_close_payload_without_status_code() {
+    let mut codec = ws::Codec::new();
+    let mut frame = masked_close(&[0]);
+
+    assert!(matches!(
+        codec.decode(&mut frame).unwrap_err(),
+        ws::ProtocolError::InvalidLength(1)
+    ));
+}
+
+#[test]
+fn accepts_close_payload_without_status_code() {
+    let mut codec = ws::Codec::new();
+    let mut frame = masked_close(&[]);
+
+    assert_eq!(codec.decode(&mut frame).unwrap(), Some(Frame::Close(None)));
+}
+
+#[test]
+fn decodes_valid_close_reason() {
+    let mut codec = ws::Codec::new();
+    let mut frame = masked_close(&[0x03, 0xe8, b'f', b'o', b'o']);
+
+    let Some(Frame::Close(Some(reason))) = codec.decode(&mut frame).unwrap() else {
+        panic!("expected close reason");
+    };
+    assert_eq!(reason.code, CloseCode::Normal);
+    assert_eq!(reason.description.as_deref(), Some("foo"));
+}
+
+#[expect(deprecated)]
+#[test]
+fn legacy_close_payload_parser_wrongly_allows_non_utf8() {
+    assert!(ws::Parser::parse_close_payload(&[0]).is_none());
+
+    let reason = ws::Parser::parse_close_payload(&[0, 0, 0xff]).expect("expected close reason");
+    assert_eq!(u16::from(reason.code), 0);
+    assert_eq!(reason.description.as_deref(), Some("\u{fffd}"));
+}
+
 #[actix_rt::test]
 async fn simple() {
     let mut srv = test_server(|| {

--- a/awc/tests/test_client.rs
+++ b/awc/tests/test_client.rs
@@ -58,7 +58,7 @@ async fn simple() {
 #[should_panic(expected = "called from outside of a `task::LocalSet`")]
 #[tokio::test(flavor = "current_thread")]
 async fn tokio_runtime_without_local_set() {
-    let srv = actix_test::start(|| App::new());
+    let srv = actix_test::start(App::new);
 
     let _ = awc::Client::default()
         .get(srv.url("/"))
@@ -69,7 +69,7 @@ async fn tokio_runtime_without_local_set() {
 
 #[tokio::test(flavor = "local")]
 async fn tokio_local_runtime() {
-    let srv = actix_test::start(|| App::new());
+    let srv = actix_test::start(App::new);
 
     let _ = awc::Client::default()
         .get(srv.url("/"))


### PR DESCRIPTION
Fixes #4216

## Summary

- make WebSocket close-frame payload parsing fallible
- reject reserved and unassigned close codes
- reject malformed one-byte close payloads
- reject invalid UTF-8 close reasons instead of replacing bytes
- propagate typed protocol errors from `ws::Codec`

## Validation

- `cargo test -p actix-http --features ws --tests`
- `just test`
- `just clippy -p actix-http --features ws`
- `cargo fmt --all -- --check`
- Autobahn 25.10.1: affected cases `7.5.1` and `7.9.1`-`7.9.9` passed (10/10)
