### PR TITLE
fix: reject data frames during WebSocket continuations

### DIFF
--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject new WebSocket text or binary frames during a continuation.
+
 ## 3.13.3
 
 - Close idle HTTP/1 keep-alive connections during graceful server shutdown and close active connections after their current request finishes.

--- a/actix-http/src/ws/codec.rs
+++ b/actix-http/src/ws/codec.rs
@@ -2,7 +2,6 @@ use bitflags::bitflags;
 use bytes::{Bytes, BytesMut};
 use bytestring::ByteString;
 use tokio_util::codec::{Decoder, Encoder};
-use tracing::error;
 
 use super::{
     frame::Parser,
@@ -220,83 +219,95 @@ impl Decoder for Codec {
     type Error = ProtocolError;
 
     fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
-        match Parser::parse(src, self.flags.contains(Flags::SERVER), self.max_size) {
-            Ok(Some((finished, opcode, payload))) => {
-                // continuation is not supported
-                if !finished {
-                    return match opcode {
-                        OpCode::Continue => {
-                            if self.flags.contains(Flags::CONTINUATION) {
-                                Ok(Some(Frame::Continuation(Item::Continue(
-                                    payload.map(|pl| pl.freeze()).unwrap_or_else(Bytes::new),
-                                ))))
-                            } else {
-                                Err(ProtocolError::ContinuationNotStarted)
-                            }
-                        }
-                        OpCode::Binary => {
-                            if !self.flags.contains(Flags::CONTINUATION) {
-                                self.flags.insert(Flags::CONTINUATION);
-                                Ok(Some(Frame::Continuation(Item::FirstBinary(
-                                    payload.map(|pl| pl.freeze()).unwrap_or_else(Bytes::new),
-                                ))))
-                            } else {
-                                Err(ProtocolError::ContinuationStarted)
-                            }
-                        }
-                        OpCode::Text => {
-                            if !self.flags.contains(Flags::CONTINUATION) {
-                                self.flags.insert(Flags::CONTINUATION);
-                                Ok(Some(Frame::Continuation(Item::FirstText(
-                                    payload.map(|pl| pl.freeze()).unwrap_or_else(Bytes::new),
-                                ))))
-                            } else {
-                                Err(ProtocolError::ContinuationStarted)
-                            }
-                        }
-                        _ => {
-                            error!("Unfinished fragment {:?}", opcode);
-                            Err(ProtocolError::ContinuationFragment(opcode))
-                        }
-                    };
-                }
+        let Some((finished, opcode, payload)) =
+            Parser::parse(src, self.flags.contains(Flags::SERVER), self.max_size)?
+        else {
+            return Ok(None);
+        };
 
-                match opcode {
-                    OpCode::Continue => {
-                        if self.flags.contains(Flags::CONTINUATION) {
-                            self.flags.remove(Flags::CONTINUATION);
-                            Ok(Some(Frame::Continuation(Item::Last(
-                                payload.map(|pl| pl.freeze()).unwrap_or_else(Bytes::new),
-                            ))))
-                        } else {
-                            Err(ProtocolError::ContinuationNotStarted)
-                        }
+        if !finished {
+            return match opcode {
+                // Continuation frames are exposed individually; aggregation is handled downstream.
+                OpCode::Continue => {
+                    if self.flags.contains(Flags::CONTINUATION) {
+                        Ok(Some(Frame::Continuation(Item::Continue(
+                            payload.map(|pl| pl.freeze()).unwrap_or_else(Bytes::new),
+                        ))))
+                    } else {
+                        Err(ProtocolError::ContinuationNotStarted)
                     }
-                    OpCode::Bad => Err(ProtocolError::BadOpCode),
-                    OpCode::Close => {
-                        if let Some(ref pl) = payload {
-                            let close_reason = Parser::parse_close_payload(pl);
-                            Ok(Some(Frame::Close(close_reason)))
-                        } else {
-                            Ok(Some(Frame::Close(None)))
-                        }
+                }
+                OpCode::Binary => {
+                    if !self.flags.contains(Flags::CONTINUATION) {
+                        self.flags.insert(Flags::CONTINUATION);
+                        Ok(Some(Frame::Continuation(Item::FirstBinary(
+                            payload.map(|pl| pl.freeze()).unwrap_or_else(Bytes::new),
+                        ))))
+                    } else {
+                        Err(ProtocolError::ContinuationStarted)
                     }
-                    OpCode::Ping => Ok(Some(Frame::Ping(
+                }
+                OpCode::Text => {
+                    if !self.flags.contains(Flags::CONTINUATION) {
+                        self.flags.insert(Flags::CONTINUATION);
+                        Ok(Some(Frame::Continuation(Item::FirstText(
+                            payload.map(|pl| pl.freeze()).unwrap_or_else(Bytes::new),
+                        ))))
+                    } else {
+                        Err(ProtocolError::ContinuationStarted)
+                    }
+                }
+                _ => {
+                    tracing::error!("Unfinished fragment {opcode:?}");
+                    Err(ProtocolError::ContinuationFragment(opcode))
+                }
+            };
+        }
+
+        match opcode {
+            OpCode::Continue => {
+                if self.flags.contains(Flags::CONTINUATION) {
+                    self.flags.remove(Flags::CONTINUATION);
+                    Ok(Some(Frame::Continuation(Item::Last(
                         payload.map(|pl| pl.freeze()).unwrap_or_else(Bytes::new),
-                    ))),
-                    OpCode::Pong => Ok(Some(Frame::Pong(
-                        payload.map(|pl| pl.freeze()).unwrap_or_else(Bytes::new),
-                    ))),
-                    OpCode::Binary => Ok(Some(Frame::Binary(
-                        payload.map(|pl| pl.freeze()).unwrap_or_else(Bytes::new),
-                    ))),
-                    OpCode::Text => Ok(Some(Frame::Text(
-                        payload.map(|pl| pl.freeze()).unwrap_or_else(Bytes::new),
-                    ))),
+                    ))))
+                } else {
+                    Err(ProtocolError::ContinuationNotStarted)
                 }
             }
-            Ok(None) => Ok(None),
-            Err(err) => Err(err),
+            OpCode::Bad => Err(ProtocolError::BadOpCode),
+            OpCode::Close => {
+                if let Some(ref pl) = payload {
+                    let close_reason = Parser::parse_close_payload(pl);
+                    Ok(Some(Frame::Close(close_reason)))
+                } else {
+                    Ok(Some(Frame::Close(None)))
+                }
+            }
+            OpCode::Ping => Ok(Some(Frame::Ping(
+                payload.map(|pl| pl.freeze()).unwrap_or_else(Bytes::new),
+            ))),
+            OpCode::Pong => Ok(Some(Frame::Pong(
+                payload.map(|pl| pl.freeze()).unwrap_or_else(Bytes::new),
+            ))),
+            OpCode::Binary => {
+                if self.flags.contains(Flags::CONTINUATION) {
+                    Err(ProtocolError::ContinuationStarted)
+                } else {
+                    Ok(Some(Frame::Binary(
+                        payload.map(|pl| pl.freeze()).unwrap_or_else(Bytes::new),
+                    )))
+                }
+            }
+            OpCode::Text => {
+                if self.flags.contains(Flags::CONTINUATION) {
+                    Err(ProtocolError::ContinuationStarted)
+                } else {
+                    Ok(Some(Frame::Text(
+                        payload.map(|pl| pl.freeze()).unwrap_or_else(Bytes::new),
+                    )))
+                }
+            }
         }
     }
 }

--- a/actix-http/src/ws/frame.rs
+++ b/actix-http/src/ws/frame.rs
@@ -175,10 +175,10 @@ impl Parser {
         mask: bool,
     ) {
         let payload = pl.as_ref();
-        let one: u8 = if fin {
-            0x80 | Into::<u8>::into(op)
+        let one = if fin {
+            0x80 | u8::from(op)
         } else {
-            op.into()
+            u8::from(op)
         };
         let payload_len = payload.len();
         let (two, p_len) = if mask {

--- a/actix-http/src/ws/proto.rs
+++ b/actix-http/src/ws/proto.rs
@@ -1,7 +1,6 @@
 use std::fmt;
 
 use base64::prelude::*;
-use tracing::error;
 
 /// Operation codes defined in [RFC 6455 §11.8].
 ///
@@ -34,15 +33,15 @@ impl fmt::Display for OpCode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use OpCode::*;
 
-        match self {
-            Continue => write!(f, "CONTINUE"),
-            Text => write!(f, "TEXT"),
-            Binary => write!(f, "BINARY"),
-            Close => write!(f, "CLOSE"),
-            Ping => write!(f, "PING"),
-            Pong => write!(f, "PONG"),
-            Bad => write!(f, "BAD"),
-        }
+        f.write_str(match self {
+            Continue => "CONTINUE",
+            Text => "TEXT",
+            Binary => "BINARY",
+            Close => "CLOSE",
+            Ping => "PING",
+            Pong => "PONG",
+            Bad => "BAD",
+        })
     }
 }
 
@@ -58,7 +57,7 @@ impl From<OpCode> for u8 {
             Ping => 9,
             Pong => 10,
             Bad => {
-                error!("Attempted to convert invalid opcode to u8. This is a bug.");
+                tracing::error!("Attempted to convert invalid opcode to u8. This is a bug.");
                 8 // if this somehow happens, a close frame will help us tear down quickly
             }
         }

--- a/actix-http/tests/test_ws.rs
+++ b/actix-http/tests/test_ws.rs
@@ -13,10 +13,11 @@ use actix_http::{
 };
 use actix_http_test::test_server;
 use actix_service::{fn_factory, Service};
-use bytes::Bytes;
+use bytes::{Bytes, BytesMut};
 use derive_more::{Display, Error, From};
 use futures_core::future::LocalBoxFuture;
 use futures_util::{SinkExt as _, StreamExt as _};
+use tokio_util::codec::Decoder as _;
 
 #[derive(Clone)]
 struct WsService(Cell<bool>);
@@ -192,4 +193,52 @@ async fn simple() {
 
     let item = framed.next().await.unwrap().unwrap();
     assert_eq!(item, Frame::Close(Some(CloseCode::Normal.into())));
+}
+
+#[test]
+fn rejects_new_data_frame_during_continuation() {
+    let mut codec = ws::Codec::new();
+    let mut buf = BytesMut::new();
+
+    ws::Parser::write_message(&mut buf, b"fragment1", ws::OpCode::Text, false, true);
+    ws::Parser::write_message(&mut buf, b"fragment2", ws::OpCode::Text, true, true);
+
+    assert_eq!(
+        codec.decode(&mut buf).unwrap(),
+        Some(Frame::Continuation(Item::FirstText(Bytes::from_static(
+            b"fragment1",
+        )))),
+        "the first text fragment should be returned as a continuation"
+    );
+    assert!(
+        matches!(
+            codec.decode(&mut buf),
+            Err(ws::ProtocolError::ContinuationStarted)
+        ),
+        "a final text frame should be rejected during a continuation"
+    );
+}
+
+#[test]
+fn rejects_new_binary_frame_during_continuation() {
+    let mut codec = ws::Codec::new();
+    let mut buf = BytesMut::new();
+
+    ws::Parser::write_message(&mut buf, b"fragment1", ws::OpCode::Binary, false, true);
+    ws::Parser::write_message(&mut buf, b"fragment2", ws::OpCode::Binary, true, true);
+
+    assert_eq!(
+        codec.decode(&mut buf).unwrap(),
+        Some(Frame::Continuation(Item::FirstBinary(Bytes::from_static(
+            b"fragment1",
+        )))),
+        "the first binary fragment should be returned as a continuation"
+    );
+    assert!(
+        matches!(
+            codec.decode(&mut buf),
+            Err(ws::ProtocolError::ContinuationStarted)
+        ),
+        "a final binary frame should be rejected during a continuation"
+    );
 }


### PR DESCRIPTION
Fixes #4215

## Summary

- reject final Text and Binary frames while a fragmented message is active
- return the existing `ContinuationStarted` protocol error before delivering the frame
- add public `Codec::decode` regressions for both data opcodes

## Validation

- `cargo test -p actix-http --features ws --tests`
- `just test`
- `just clippy -p actix-http --features ws`
- `cargo fmt --all -- --check`
- Autobahn 25.10.1 case `5.18`: `behavior: OK`, `behaviorClose: OK`
