### PR TITLE
fix(encoding): correct 8 KiB buffer size typo for Brotli decoder

### DIFF
--- a/actix-http/CHANGES.md
+++ b/actix-http/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Fix 8 KiB buffer size typo in Brotli decompressor. [#4226]
+
+[#4226]: https://github.com/actix/actix-web/issues/4226
+
 ## 3.13.3
 
 - Close idle HTTP/1 keep-alive connections during graceful server shutdown and close active connections after their current request finishes.

--- a/actix-http/src/encoding/decoder.rs
+++ b/actix-http/src/encoding/decoder.rs
@@ -43,7 +43,7 @@ where
         let decoder = match encoding {
             #[cfg(feature = "compress-brotli")]
             ContentEncoding::Brotli => Some(ContentDecoder::Brotli(Box::new(
-                brotli::DecompressorWriter::new(Writer::new(), 8_096),
+                brotli::DecompressorWriter::new(Writer::new(), 8_192),
             ))),
 
             #[cfg(feature = "compress-gzip")]

--- a/actix-web/tests/utils.rs
+++ b/actix-web/tests/utils.rs
@@ -49,7 +49,7 @@ pub mod brotli {
     pub fn encode(bytes: impl AsRef<[u8]>) -> Vec<u8> {
         let mut encoder = BrotliEncoder::new(
             Vec::new(),
-            8 * 1024, // 32 KiB buffer
+            8 * 1024, // 8 KiB buffer
             3,        // BROTLI_PARAM_QUALITY
             22,       // BROTLI_PARAM_LGWIN
         );
@@ -59,7 +59,7 @@ pub mod brotli {
     }
 
     pub fn decode(bytes: impl AsRef<[u8]>) -> Vec<u8> {
-        let mut decoder = BrotliDecoder::new(bytes.as_ref(), 8_096);
+        let mut decoder = BrotliDecoder::new(bytes.as_ref(), 8_192);
         let mut buf = Vec::new();
         decoder.read_to_end(&mut buf).unwrap();
         buf

--- a/awc/tests/utils.rs
+++ b/awc/tests/utils.rs
@@ -49,7 +49,7 @@ pub mod brotli {
     pub fn encode(bytes: impl AsRef<[u8]>) -> Vec<u8> {
         let mut encoder = BrotliEncoder::new(
             Vec::new(),
-            8 * 1024, // 32 KiB buffer
+            8 * 1024, // 8 KiB buffer
             3,        // BROTLI_PARAM_QUALITY
             22,       // BROTLI_PARAM_LGWIN
         );
@@ -59,7 +59,7 @@ pub mod brotli {
     }
 
     pub fn decode(bytes: impl AsRef<[u8]>) -> Vec<u8> {
-        let mut decoder = BrotliDecoder::new(bytes.as_ref(), 8_096);
+        let mut decoder = BrotliDecoder::new(bytes.as_ref(), 8_192);
         let mut buf = Vec::new();
         decoder.read_to_end(&mut buf).unwrap();
         buf


### PR DESCRIPTION
## PR Type

Bug Fix / Code Style

## PR Checklist

- [x] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt.
- [ ] (Team) Label with affected crates and semver status.

## Overview

In `actix-http/src/encoding/decoder.rs:46`, `brotli::DecompressorWriter::new(Writer::new(), 8_096)` used `8_096` instead of `8_192` (8 KiB). This was a typo for the standard 8 KiB buffer size, matching the 8 KiB capacity of `Writer` and standard power-of-two buffer sizing.

This change:
- Corrects `8_096` to `8_192` in `actix-http/src/encoding/decoder.rs`.
- Corrects `8_096` to `8_192` and updates the comment in `actix-web/tests/utils.rs` and `awc/tests/utils.rs`.
- Adds an unreleased changelog entry for `actix-http`.

Partially addresses #4226.